### PR TITLE
fix: move mid-file import to top to resolve ruff E402 lint error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13"]
-        exclude:
-          - os: macos-latest
-            python-version: "3.11"
     steps:
       - uses: actions/checkout@v4
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ where = ["src"]
 [dependency-groups]
 dev = [
     "mypy>=1.19.1",
+    "pre-commit>=4.0",
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=5.0",

--- a/src/agentops/__main__.py
+++ b/src/agentops/__main__.py
@@ -1,4 +1,5 @@
 """Entrypoint for `python -m agentops`."""
+
 from agentops.cli.app import app
 
 if __name__ == "__main__":

--- a/src/agentops/backends/base.py
+++ b/src/agentops/backends/base.py
@@ -1,4 +1,5 @@
 """Backend protocol and shared execution models."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/agentops/backends/foundry_backend.py
+++ b/src/agentops/backends/foundry_backend.py
@@ -108,30 +108,38 @@ def _parse_agent_name_version(agent_id: str) -> tuple[str, str | None]:
     return agent_id.strip(), None
 
 
-_NLP_ONLY_EVALUATORS = frozenset({
-    "f1_score",
-    "bleu",
-    "rouge",
-    "meteor",
-    "gleu",
-})
+_NLP_ONLY_EVALUATORS = frozenset(
+    {
+        "f1_score",
+        "bleu",
+        "rouge",
+        "meteor",
+        "gleu",
+    }
+)
 
-_EVALUATORS_NEEDING_GROUND_TRUTH = frozenset({
-    "similarity",
-    "f1_score",
-    "bleu",
-    "rouge",
-    "meteor",
-    "gleu",
-})
+_EVALUATORS_NEEDING_GROUND_TRUTH = frozenset(
+    {
+        "similarity",
+        "f1_score",
+        "bleu",
+        "rouge",
+        "meteor",
+        "gleu",
+    }
+)
 
-_EVALUATORS_NEEDING_CONTEXT = frozenset({
-    "groundedness",
-})
+_EVALUATORS_NEEDING_CONTEXT = frozenset(
+    {
+        "groundedness",
+    }
+)
 
-_EVALUATORS_NEEDING_TOOL_CALLS = frozenset({
-    "tool_call_accuracy",
-})
+_EVALUATORS_NEEDING_TOOL_CALLS = frozenset(
+    {
+        "tool_call_accuracy",
+    }
+)
 
 
 def _cloud_evaluator_data_mapping(
@@ -1415,20 +1423,26 @@ class FoundryBackend:
             # Only emit local evaluator metrics if they are configured in the bundle.
             if "exact_match" in enabled_local_names:
                 passed = prediction.lower() == expected.lower() if expected else False
-                row_metric_entries.append({
-                    "name": "exact_match",
-                    "value": 1.0 if passed else 0.0,
-                })
+                row_metric_entries.append(
+                    {
+                        "name": "exact_match",
+                        "value": 1.0 if passed else 0.0,
+                    }
+                )
             if "latency_seconds" in enabled_local_names:
-                row_metric_entries.append({
-                    "name": "latency_seconds",
-                    "value": approx_latency_per_row,
-                })
+                row_metric_entries.append(
+                    {
+                        "name": "latency_seconds",
+                        "value": approx_latency_per_row,
+                    }
+                )
             if "avg_latency_seconds" in enabled_local_names:
-                row_metric_entries.append({
-                    "name": "avg_latency_seconds",
-                    "value": approx_latency_per_row,
-                })
+                row_metric_entries.append(
+                    {
+                        "name": "avg_latency_seconds",
+                        "value": approx_latency_per_row,
+                    }
+                )
 
             # Update aggregate values for local evaluator metrics.
             for entry in row_metric_entries:
@@ -1441,10 +1455,12 @@ class FoundryBackend:
             if isinstance(datasource_item_id, int) and datasource_item_id >= 0:
                 row_index = datasource_item_id + 1
 
-            row_metrics_payload.append({
-                "row_index": row_index,
-                "metrics": row_metric_entries,
-            })
+            row_metrics_payload.append(
+                {
+                    "row_index": row_index,
+                    "metrics": row_metric_entries,
+                }
+            )
             stdout_lines.append(
                 f"row={row_index} expected={expected!r} prediction={prediction!r}"
             )
@@ -1457,10 +1473,12 @@ class FoundryBackend:
         for name in enabled_evaluator_order:
             values = evaluator_aggregate_values.get(name, [])
             if values:
-                metrics_entries.append({
-                    "name": name,
-                    "value": sum(values) / len(values),
-                })
+                metrics_entries.append(
+                    {
+                        "name": name,
+                        "value": sum(values) / len(values),
+                    }
+                )
         metrics_entries.append({"name": "samples_evaluated", "value": float(total)})
 
         metrics_path.write_text(
@@ -1631,20 +1649,26 @@ class FoundryBackend:
             # Only emit local evaluator metrics that are configured in the bundle.
             if "exact_match" in enabled_local_names:
                 passed = prediction_normalized.lower() == expected_text.lower()
-                row_metric_entries.append({
-                    "name": "exact_match",
-                    "value": 1.0 if passed else 0.0,
-                })
+                row_metric_entries.append(
+                    {
+                        "name": "exact_match",
+                        "value": 1.0 if passed else 0.0,
+                    }
+                )
             if "latency_seconds" in enabled_local_names:
-                row_metric_entries.append({
-                    "name": "latency_seconds",
-                    "value": row_latency,
-                })
+                row_metric_entries.append(
+                    {
+                        "name": "latency_seconds",
+                        "value": row_latency,
+                    }
+                )
             if "avg_latency_seconds" in enabled_local_names:
-                row_metric_entries.append({
-                    "name": "avg_latency_seconds",
-                    "value": row_latency,
-                })
+                row_metric_entries.append(
+                    {
+                        "name": "avg_latency_seconds",
+                        "value": row_latency,
+                    }
+                )
 
             for metric_entry in row_metric_entries:
                 metric_name = metric_entry["name"]
@@ -1652,10 +1676,12 @@ class FoundryBackend:
                 if metric_name in evaluator_aggregate_values:
                     evaluator_aggregate_values[metric_name].append(metric_value)
 
-            row_metrics_payload.append({
-                "row_index": row_index,
-                "metrics": row_metric_entries,
-            })
+            row_metrics_payload.append(
+                {
+                    "row_index": row_index,
+                    "metrics": row_metric_entries,
+                }
+            )
 
             stdout_lines.append(
                 f"row={row_index} expected={expected_text!r} prediction={prediction_normalized!r}"
@@ -1776,10 +1802,12 @@ class FoundryBackend:
         for evaluator_name in enabled_evaluator_order:
             values = evaluator_aggregate_values.get(evaluator_name, [])
             if values:
-                metrics_entries.append({
-                    "name": evaluator_name,
-                    "value": sum(values) / len(values),
-                })
+                metrics_entries.append(
+                    {
+                        "name": evaluator_name,
+                        "value": sum(values) / len(values),
+                    }
+                )
 
         metrics_entries.append({"name": "samples_evaluated", "value": float(total)})
 

--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -59,6 +59,7 @@ def _planned_command(command_name: str) -> None:
 # Global callback — configures logging before any command runs
 # ---------------------------------------------------------------------------
 
+
 def _version_callback(value: bool) -> None:
     if value:
         from agentops import __version__
@@ -90,9 +91,12 @@ def _main(
 # agentops init
 # ---------------------------------------------------------------------------
 
+
 @app.command("init")
 def cmd_init(
-    force: bool = typer.Option(False, "--force", help="Overwrite starter files if they exist."),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite starter files if they exist."
+    ),
     directory: Path = typer.Option(
         Path("."),
         "--dir",
@@ -129,6 +133,7 @@ def cmd_init(
 # agentops eval run
 # ---------------------------------------------------------------------------
 
+
 @eval_app.command("run")
 def cmd_eval_run(
     config: Annotated[
@@ -139,7 +144,10 @@ def cmd_eval_run(
             help="Path to run.yaml (default: .agentops/run.yaml).",
         ),
     ] = None,
-    output: Annotated[Optional[Path], typer.Option("--output", "-o", help="Output directory for results.")] = None,
+    output: Annotated[
+        Optional[Path],
+        typer.Option("--output", "-o", help="Output directory for results."),
+    ] = None,
 ) -> None:
     """Run an evaluation defined in a run.yaml file."""
     log.debug("cmd_eval_run called config=%s output=%s", config, output)
@@ -176,6 +184,7 @@ def cmd_eval_compare(
 # agentops report
 # ---------------------------------------------------------------------------
 
+
 @report_app.callback(invoke_without_command=True)
 def cmd_report(
     ctx: typer.Context,
@@ -189,7 +198,9 @@ def cmd_report(
             ),
         ),
     ] = None,
-    report_out: Annotated[Optional[Path], typer.Option("--out", help="Output path for report.md.")] = None,
+    report_out: Annotated[
+        Optional[Path], typer.Option("--out", help="Output path for report.md.")
+    ] = None,
 ) -> None:
     """Regenerate report.md from a results.json file."""
     if ctx.invoked_subcommand is not None:
@@ -291,7 +302,9 @@ def cmd_config_show() -> None:
 
 @config_app.command("cicd")
 def cmd_config_cicd(
-    force: bool = typer.Option(False, "--force", help="Overwrite existing workflow file."),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite existing workflow file."
+    ),
     directory: Path = typer.Option(
         Path("."),
         "--dir",
@@ -318,9 +331,15 @@ def cmd_config_cicd(
     if result.created_files or result.overwritten_files:
         typer.echo("")
         typer.echo("Next steps:")
-        typer.echo("  1. Set GitHub repository variables: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID")
-        typer.echo("  2. Set GitHub repository secret: AZURE_AI_FOUNDRY_PROJECT_ENDPOINT")
-        typer.echo("  3. Configure Azure Workload Identity Federation (see docs/ci-github-actions.md)")
+        typer.echo(
+            "  1. Set GitHub repository variables: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID"
+        )
+        typer.echo(
+            "  2. Set GitHub repository secret: AZURE_AI_FOUNDRY_PROJECT_ENDPOINT"
+        )
+        typer.echo(
+            "  3. Configure Azure Workload Identity Federation (see docs/ci-github-actions.md)"
+        )
         typer.echo("  4. Commit and push the workflow file")
     elif result.skipped_files:
         typer.echo("No files written. Use --force to overwrite existing workflow.")

--- a/src/agentops/core/config_loader.py
+++ b/src/agentops/core/config_loader.py
@@ -1,4 +1,5 @@
 """YAML config loaders for AgentOps schemas."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/agentops/core/models.py
+++ b/src/agentops/core/models.py
@@ -1,4 +1,5 @@
 """Pydantic models for AgentOps schemas."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -186,9 +187,8 @@ class BackendConfig(BaseModel):
 
         normalized = value.strip()
         looks_like_placeholder = (
-            (normalized.startswith("<") and normalized.endswith(">"))
-            or "replace-with" in normalized.lower()
-        )
+            normalized.startswith("<") and normalized.endswith(">")
+        ) or "replace-with" in normalized.lower()
         if looks_like_placeholder:
             raise ValueError(
                 "backend.model must be replaced with a real Foundry model deployment name"
@@ -205,17 +205,24 @@ class BackendConfig(BaseModel):
         elif self.type == "foundry":
             target = (self.target or "agent").strip().lower()
             if target not in {"agent", "model"}:
-                raise ValueError("backend.target must be 'agent' or 'model' for foundry")
+                raise ValueError(
+                    "backend.target must be 'agent' or 'model' for foundry"
+                )
 
             self.target = target
             if target == "agent":
                 if not self.agent_id or not self.agent_id.strip():
-                    raise ValueError("backend.agent_id is required for foundry target=agent")
+                    raise ValueError(
+                        "backend.agent_id is required for foundry target=agent"
+                    )
             # target=model does not require agent_id
 
             if self.max_poll_attempts is not None and self.max_poll_attempts <= 0:
                 raise ValueError("backend.max_poll_attempts must be > 0")
-            if self.poll_interval_seconds is not None and self.poll_interval_seconds <= 0:
+            if (
+                self.poll_interval_seconds is not None
+                and self.poll_interval_seconds <= 0
+            ):
                 raise ValueError("backend.poll_interval_seconds must be > 0")
         else:
             raise ValueError(f"Unsupported backend type: {self.type}")

--- a/src/agentops/core/reporter.py
+++ b/src/agentops/core/reporter.py
@@ -1,4 +1,5 @@
 """Markdown report generation for AgentOps."""
+
 from __future__ import annotations
 
 from agentops.core.models import RunResult
@@ -52,7 +53,9 @@ def generate_report_markdown(result: RunResult) -> str:
     lines.append("## Item Verdicts")
     if result.item_evaluations:
         passed_items = sum(1 for item in result.item_evaluations if item.passed_all)
-        lines.append(f"- Items passed all thresholds: {passed_items}/{len(result.item_evaluations)}")
+        lines.append(
+            f"- Items passed all thresholds: {passed_items}/{len(result.item_evaluations)}"
+        )
         lines.append("")
         lines.append("| Row | Passed All | Passed Rules | Total Rules |")
         lines.append("|---:|---|---:|---:|")
@@ -72,7 +75,9 @@ def generate_report_markdown(result: RunResult) -> str:
         lines.append("|---|---|---:|---:|---|")
         for threshold in result.thresholds:
             mark = "PASS" if threshold.passed else "FAIL"
-            lines.append(f"| {threshold.evaluator} | {threshold.criteria} | {threshold.expected} | {threshold.actual} | {mark} |")
+            lines.append(
+                f"| {threshold.evaluator} | {threshold.criteria} | {threshold.expected} | {threshold.actual} | {mark} |"
+            )
     else:
         lines.append("- No thresholds configured")
 
@@ -84,7 +89,9 @@ def generate_report_markdown(result: RunResult) -> str:
         if result.artifacts.backend_stderr is not None:
             lines.append(f"- backend_stderr: {result.artifacts.backend_stderr}")
         if result.artifacts.foundry_eval_studio_url is not None:
-            lines.append(f"- foundry_eval_studio_url: {result.artifacts.foundry_eval_studio_url}")
+            lines.append(
+                f"- foundry_eval_studio_url: {result.artifacts.foundry_eval_studio_url}"
+            )
         if result.artifacts.foundry_eval_name is not None:
             lines.append(f"- foundry_eval_name: {result.artifacts.foundry_eval_name}")
     return "\n".join(lines).rstrip() + "\n"

--- a/src/agentops/core/thresholds.py
+++ b/src/agentops/core/thresholds.py
@@ -1,4 +1,5 @@
 """Threshold evaluation logic for AgentOps."""
+
 from __future__ import annotations
 
 from typing import Dict, List
@@ -14,7 +15,9 @@ def evaluate_thresholds(
 
     for rule in threshold_rules:
         if rule.evaluator not in metrics_by_name:
-            raise ValueError(f"Missing evaluator score required by threshold: {rule.evaluator}")
+            raise ValueError(
+                f"Missing evaluator score required by threshold: {rule.evaluator}"
+            )
 
         actual_value = metrics_by_name[rule.evaluator]
 
@@ -41,7 +44,9 @@ def evaluate_thresholds(
             continue
 
         if rule.value is None:
-            raise ValueError(f"Threshold for evaluator '{rule.evaluator}' requires a numeric value")
+            raise ValueError(
+                f"Threshold for evaluator '{rule.evaluator}' requires a numeric value"
+            )
 
         target_value = float(rule.value)
 

--- a/src/agentops/services/cicd.py
+++ b/src/agentops/services/cicd.py
@@ -1,4 +1,5 @@
 """CI/CD workflow generation service for `agentops config cicd`."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/agentops/services/initializer.py
+++ b/src/agentops/services/initializer.py
@@ -1,4 +1,5 @@
 """Workspace initialization service for `agentops init`."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/agentops/services/reporting.py
+++ b/src/agentops/services/reporting.py
@@ -1,4 +1,5 @@
 """Report orchestration service."""
+
 from __future__ import annotations
 
 import json
@@ -15,7 +16,9 @@ class ReportResult:
     output_report_path: Path
 
 
-def generate_report_from_results(results_path: Path, output_path: Path | None = None) -> ReportResult:
+def generate_report_from_results(
+    results_path: Path, output_path: Path | None = None
+) -> ReportResult:
     resolved_results_path = results_path.resolve()
     if not resolved_results_path.exists():
         raise FileNotFoundError(f"results.json not found: {resolved_results_path}")
@@ -23,7 +26,11 @@ def generate_report_from_results(results_path: Path, output_path: Path | None = 
     payload = json.loads(resolved_results_path.read_text(encoding="utf-8"))
     result = RunResult.model_validate(payload)
 
-    resolved_output_path = output_path.resolve() if output_path is not None else resolved_results_path.with_name("report.md")
+    resolved_output_path = (
+        output_path.resolve()
+        if output_path is not None
+        else resolved_results_path.with_name("report.md")
+    )
     resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
     resolved_output_path.write_text(generate_report_markdown(result), encoding="utf-8")
 

--- a/src/agentops/utils/logging.py
+++ b/src/agentops/utils/logging.py
@@ -3,6 +3,7 @@
 No side effects at import time — call setup_logging() explicitly from the
 CLI callback before any command runs.
 """
+
 from __future__ import annotations
 
 import logging
@@ -34,7 +35,9 @@ def setup_logging(verbose: bool = False) -> None:
         logging.getLogger("azure.identity").setLevel(logging.WARNING)
         logging.getLogger("azure.core").setLevel(logging.WARNING)
         logging.getLogger("azure.core.pipeline").setLevel(logging.WARNING)
-        logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
+        logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(
+            logging.WARNING
+        )
         logging.getLogger("azure.ai.evaluation").setLevel(logging.WARNING)
         logging.getLogger("httpx").setLevel(logging.WARNING)
         logging.getLogger("openai").setLevel(logging.WARNING)

--- a/src/agentops/utils/yaml.py
+++ b/src/agentops/utils/yaml.py
@@ -1,4 +1,5 @@
 """YAML load/save helpers using ruamel.yaml."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/integration/test_eval_run_integration.py
+++ b/tests/integration/test_eval_run_integration.py
@@ -39,7 +39,11 @@ def _write_project_files(tmp_path: Path, *, fail_thresholds: bool) -> Path:
                 {"name": "fluency", "source": "local", "enabled": True},
             ],
             "thresholds": [
-                {"evaluator": "groundedness", "criteria": ">=", "value": threshold_value},
+                {
+                    "evaluator": "groundedness",
+                    "criteria": ">=",
+                    "value": threshold_value,
+                },
                 {"evaluator": "relevance", "criteria": ">=", "value": threshold_value},
                 {"evaluator": "coherence", "criteria": ">=", "value": threshold_value},
                 {"evaluator": "fluency", "criteria": ">=", "value": threshold_value},
@@ -55,19 +59,23 @@ def _write_project_files(tmp_path: Path, *, fail_thresholds: bool) -> Path:
             "name": "smoke",
             "description": "Integration dataset",
             "source": {"type": "file", "path": "../data/smoke.jsonl"},
-            "format": {"type": "jsonl", "input_field": "input", "expected_field": "expected"},
+            "format": {
+                "type": "jsonl",
+                "input_field": "input",
+                "expected_field": "expected",
+            },
             "metadata": {"owner": "tests"},
         },
     )
 
     (data_dir / "smoke.jsonl").write_text(
-        '\n'.join(
+        "\n".join(
             [
                 '{"id":"1","input":"hello","expected":"hello"}',
                 '{"id":"2","input":"world","expected":"world"}',
             ]
         )
-        + '\n',
+        + "\n",
         encoding="utf-8",
     )
 
@@ -166,7 +174,9 @@ def test_eval_run_integration_threshold_fail(tmp_path: Path, monkeypatch) -> Non
     assert run_metrics["items_pass_rate"] == 0.0
 
 
-def test_eval_run_integration_uses_default_run_yaml_and_updates_latest(tmp_path: Path, monkeypatch) -> None:
+def test_eval_run_integration_uses_default_run_yaml_and_updates_latest(
+    tmp_path: Path, monkeypatch
+) -> None:
     _write_project_files(tmp_path, fail_thresholds=False)
 
     monkeypatch.chdir(tmp_path)
@@ -182,7 +192,9 @@ def test_eval_run_integration_uses_default_run_yaml_and_updates_latest(tmp_path:
     assert (latest_dir / "report.md").is_file()
 
     timestamp_dirs = [
-        path for path in results_root.iterdir() if path.is_dir() and path.name != "latest"
+        path
+        for path in results_root.iterdir()
+        if path.is_dir() and path.name != "latest"
     ]
     assert len(timestamp_dirs) == 1
     assert (timestamp_dirs[0] / "results.json").is_file()

--- a/tests/unit/test_foundry_backend.py
+++ b/tests/unit/test_foundry_backend.py
@@ -48,7 +48,11 @@ def _dataset_yaml(tmp_path: Path) -> Path:
             "version": 1,
             "name": "smoke",
             "source": {"type": "file", "path": str(dataset_file)},
-            "format": {"type": "jsonl", "input_field": "input", "expected_field": "expected"},
+            "format": {
+                "type": "jsonl",
+                "input_field": "input",
+                "expected_field": "expected",
+            },
         },
     )
     return config_path
@@ -65,8 +69,17 @@ def _bundle_yaml(tmp_path: Path, *, similarity_source: str | None = None) -> Pat
     ]
 
     if similarity_source is not None:
-        evaluators.insert(0, {"name": "SimilarityEvaluator", "source": similarity_source, "enabled": True})
-        thresholds.insert(0, {"evaluator": "SimilarityEvaluator", "criteria": ">=", "value": 3})
+        evaluators.insert(
+            0,
+            {
+                "name": "SimilarityEvaluator",
+                "source": similarity_source,
+                "enabled": True,
+            },
+        )
+        thresholds.insert(
+            0, {"evaluator": "SimilarityEvaluator", "criteria": ">=", "value": 3}
+        )
 
     bundle_path = tmp_path / "bundle.yaml"
     save_yaml(
@@ -100,7 +113,10 @@ def test_foundry_backend_uses_default_azure_credential(tmp_path: Path) -> None:
     )
 
     # When _acquire_token raises, the error should propagate clearly
-    with patch("agentops.backends.foundry_backend._acquire_token", side_effect=RuntimeError("azure-identity not installed")):
+    with patch(
+        "agentops.backends.foundry_backend._acquire_token",
+        side_effect=RuntimeError("azure-identity not installed"),
+    ):
         try:
             FoundryBackend().execute(context)
             assert False, "expected RuntimeError"
@@ -132,16 +148,26 @@ def test_foundry_backend_agent_service_target(tmp_path: Path) -> None:
         _FakeHttpResponse({"id": "msg_1"}),
         _FakeHttpResponse({"id": "run_1"}),
         _FakeHttpResponse({"status": "completed"}),
-        _FakeHttpResponse({"data": [{"role": "assistant", "content": [{"text": {"value": "4"}}]}]}),
+        _FakeHttpResponse(
+            {"data": [{"role": "assistant", "content": [{"text": {"value": "4"}}]}]}
+        ),
         _FakeHttpResponse({"id": "thread_2"}),
         _FakeHttpResponse({"id": "msg_2"}),
         _FakeHttpResponse({"id": "run_2"}),
         _FakeHttpResponse({"status": "completed"}),
-        _FakeHttpResponse({"data": [{"role": "assistant", "content": [{"text": {"value": "8"}}]}]}),
+        _FakeHttpResponse(
+            {"data": [{"role": "assistant", "content": [{"text": {"value": "8"}}]}]}
+        ),
     ]
 
-    with patch("agentops.backends.foundry_backend._acquire_token", return_value="fake-agent-token"):
-        with patch("agentops.backends.foundry_backend.urllib.request.urlopen", side_effect=responses):
+    with patch(
+        "agentops.backends.foundry_backend._acquire_token",
+        return_value="fake-agent-token",
+    ):
+        with patch(
+            "agentops.backends.foundry_backend.urllib.request.urlopen",
+            side_effect=responses,
+        ):
             result = FoundryBackend().execute(context)
 
     assert result.backend == "foundry"
@@ -157,12 +183,16 @@ def test_foundry_backend_agent_service_target(tmp_path: Path) -> None:
     assert "GroundednessEvaluator" not in metrics_by_name
     assert metrics_by_name["samples_evaluated"] == 2.0
     assert len(payload["row_metrics"]) == 2
-    first_row_metrics = {item["name"]: item["value"] for item in payload["row_metrics"][0]["metrics"]}
+    first_row_metrics = {
+        item["name"]: item["value"] for item in payload["row_metrics"][0]["metrics"]
+    }
     assert "GroundednessEvaluator" not in first_row_metrics
     assert first_row_metrics["exact_match"] == 1.0
 
 
-def test_foundry_backend_uses_similarity_evaluator_when_source_is_foundry(tmp_path: Path) -> None:
+def test_foundry_backend_uses_similarity_evaluator_when_source_is_foundry(
+    tmp_path: Path,
+) -> None:
     dataset_path = _dataset_yaml(tmp_path)
     bundle_path = _bundle_yaml(tmp_path, similarity_source="foundry")
     context = BackendRunContext(
@@ -186,12 +216,16 @@ def test_foundry_backend_uses_similarity_evaluator_when_source_is_foundry(tmp_pa
         _FakeHttpResponse({"id": "msg_1"}),
         _FakeHttpResponse({"id": "run_1"}),
         _FakeHttpResponse({"status": "completed"}),
-        _FakeHttpResponse({"data": [{"role": "assistant", "content": [{"text": {"value": "4"}}]}]}),
+        _FakeHttpResponse(
+            {"data": [{"role": "assistant", "content": [{"text": {"value": "4"}}]}]}
+        ),
         _FakeHttpResponse({"id": "thread_2"}),
         _FakeHttpResponse({"id": "msg_2"}),
         _FakeHttpResponse({"id": "run_2"}),
         _FakeHttpResponse({"status": "completed"}),
-        _FakeHttpResponse({"data": [{"role": "assistant", "content": [{"text": {"value": "8"}}]}]}),
+        _FakeHttpResponse(
+            {"data": [{"role": "assistant", "content": [{"text": {"value": "8"}}]}]}
+        ),
     ]
 
     class _FakeSimilarityEvaluator:
@@ -201,7 +235,10 @@ def test_foundry_backend_uses_similarity_evaluator_when_source_is_foundry(tmp_pa
             assert "ground_truth" in kwargs
             return {"similarity": 4.0}
 
-    with patch("agentops.backends.foundry_backend._acquire_token", return_value="fake-agent-token"):
+    with patch(
+        "agentops.backends.foundry_backend._acquire_token",
+        return_value="fake-agent-token",
+    ):
         with patch(
             "agentops.backends.foundry_backend._build_foundry_evaluator_runtimes",
             return_value=[
@@ -217,7 +254,10 @@ def test_foundry_backend_uses_similarity_evaluator_when_source_is_foundry(tmp_pa
                 )
             ],
         ):
-            with patch("agentops.backends.foundry_backend.urllib.request.urlopen", side_effect=responses):
+            with patch(
+                "agentops.backends.foundry_backend.urllib.request.urlopen",
+                side_effect=responses,
+            ):
                 result = FoundryBackend().execute(context)
 
     assert result.backend == "foundry"
@@ -248,7 +288,10 @@ def test_foundry_backend_rejects_unsupported_local_evaluator(tmp_path: Path) -> 
         backend_output_dir=tmp_path / "out-agent-unsupported-local",
     )
 
-    with patch("agentops.backends.foundry_backend._acquire_token", return_value="fake-agent-token"):
+    with patch(
+        "agentops.backends.foundry_backend._acquire_token",
+        return_value="fake-agent-token",
+    ):
         try:
             FoundryBackend().execute(context)
             assert False, "expected ValueError"
@@ -281,8 +324,12 @@ def test_foundry_backend_model_direct_target(tmp_path: Path) -> None:
             return "4"
         return "8"
 
-    with patch("agentops.backends.foundry_backend._acquire_token", return_value="fake-token"):
-        with patch.object(FoundryBackend, "_invoke_model_direct", _fake_invoke_model_direct):
+    with patch(
+        "agentops.backends.foundry_backend._acquire_token", return_value="fake-token"
+    ):
+        with patch.object(
+            FoundryBackend, "_invoke_model_direct", _fake_invoke_model_direct
+        ):
             result = FoundryBackend().execute(context)
 
     assert result.backend == "foundry"
@@ -335,13 +382,19 @@ def test_cloud_evaluator_data_mapping_similarity() -> None:
     assert "context" not in mapping
 
 
-def test_cloud_evaluator_data_mapping_groundedness_uses_expected_when_no_context_field() -> None:
+def test_cloud_evaluator_data_mapping_groundedness_uses_expected_when_no_context_field() -> (
+    None
+):
     mapping = _cloud_evaluator_data_mapping("groundedness", "input", "expected")
     assert mapping["context"] == "{{item.expected}}"
 
 
-def test_cloud_evaluator_data_mapping_groundedness_uses_context_field_when_set() -> None:
-    mapping = _cloud_evaluator_data_mapping("groundedness", "input", "expected", context_field="context")
+def test_cloud_evaluator_data_mapping_groundedness_uses_context_field_when_set() -> (
+    None
+):
+    mapping = _cloud_evaluator_data_mapping(
+        "groundedness", "input", "expected", context_field="context"
+    )
     assert mapping["context"] == "{{item.context}}"
     assert "ground_truth" not in mapping
 

--- a/tests/unit/test_foundry_backend.py
+++ b/tests/unit/test_foundry_backend.py
@@ -5,7 +5,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 from agentops.backends.base import BackendRunContext
-from agentops.backends.foundry_backend import FoundryBackend, FoundryEvaluatorRuntime
+from agentops.backends.foundry_backend import (
+    FoundryBackend,
+    FoundryEvaluatorRuntime,
+    _cloud_evaluator_data_mapping,
+    _default_foundry_input_mapping,
+)
 from agentops.core.models import BackendConfig
 from agentops.utils.yaml import save_yaml
 
@@ -320,11 +325,6 @@ def test_foundry_backend_model_target_requires_explicit_model(tmp_path: Path) ->
 # ---------------------------------------------------------------------------
 # Unit tests for _cloud_evaluator_data_mapping and _default_foundry_input_mapping
 # ---------------------------------------------------------------------------
-
-from agentops.backends.foundry_backend import (
-    _cloud_evaluator_data_mapping,
-    _default_foundry_input_mapping,
-)
 
 
 def test_cloud_evaluator_data_mapping_similarity() -> None:

--- a/tests/unit/test_initializer.py
+++ b/tests/unit/test_initializer.py
@@ -15,7 +15,9 @@ def test_init_creates_expected_files(tmp_path: Path) -> None:
 
     assert (tmp_path / ".agentops" / "config.yaml").is_file()
     assert (tmp_path / ".agentops" / "bundles" / "model_direct_baseline.yaml").is_file()
-    assert (tmp_path / ".agentops" / "bundles" / "rag_retrieval_baseline.yaml").is_file()
+    assert (
+        tmp_path / ".agentops" / "bundles" / "rag_retrieval_baseline.yaml"
+    ).is_file()
     assert (tmp_path / ".agentops" / "bundles" / "agent_tools_baseline.yaml").is_file()
     assert (tmp_path / ".agentops" / "datasets" / "smoke-model-direct.yaml").is_file()
     assert (tmp_path / ".agentops" / "datasets" / "smoke-rag.yaml").is_file()

--- a/tests/unit/test_reporter.py
+++ b/tests/unit/test_reporter.py
@@ -7,7 +7,10 @@ def _sample_result(overall_passed: bool = True) -> RunResult:
         {
             "version": 1,
             "status": "completed",
-            "bundle": {"name": "rag_baseline", "path": ".agentops/bundles/rag_baseline.yaml"},
+            "bundle": {
+                "name": "rag_baseline",
+                "path": ".agentops/bundles/rag_baseline.yaml",
+            },
             "dataset": {"name": "smoke", "path": ".agentops/datasets/smoke-agent.yaml"},
             "execution": {
                 "backend": "subprocess",
@@ -23,11 +26,20 @@ def _sample_result(overall_passed: bool = True) -> RunResult:
             ],
             "run_metrics": [
                 {"name": "run_pass", "value": 0.0 if not overall_passed else 1.0},
-                {"name": "threshold_pass_rate", "value": 0.5 if not overall_passed else 1.0},
+                {
+                    "name": "threshold_pass_rate",
+                    "value": 0.5 if not overall_passed else 1.0,
+                },
                 {"name": "accuracy", "value": 0.84},
             ],
             "thresholds": [
-                {"evaluator": "groundedness", "criteria": ">=", "expected": "0.800000", "actual": "0.840000", "passed": True},
+                {
+                    "evaluator": "groundedness",
+                    "criteria": ">=",
+                    "expected": "0.800000",
+                    "actual": "0.840000",
+                    "passed": True,
+                },
                 {
                     "evaluator": "relevance",
                     "criteria": ">=",

--- a/tests/unit/test_subprocess_backend.py
+++ b/tests/unit/test_subprocess_backend.py
@@ -58,7 +58,10 @@ def test_execute_builds_command_and_writes_logs(tmp_path: Path) -> None:
         stderr="ok stderr",
     )
 
-    with patch("agentops.backends.subprocess_backend.subprocess.run", return_value=fake_completed) as run_mock:
+    with patch(
+        "agentops.backends.subprocess_backend.subprocess.run",
+        return_value=fake_completed,
+    ) as run_mock:
         result = backend.execute(context)
 
     run_kwargs = run_mock.call_args.kwargs

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -30,6 +31,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=5.0" },
@@ -52,6 +54,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
 ]
 
 [[package]]
@@ -177,6 +188,33 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/c4/7fb4db12296cdb11893d61c92048fe617ee853f8523b9b296ac03b43757e/identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd", size = 99580, upload-time = "2026-03-15T18:39:50.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737", size = 99394, upload-time = "2026-03-15T18:39:48.915Z" },
 ]
 
 [[package]]
@@ -331,6 +369,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -349,12 +396,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
 ]
 
 [[package]]
@@ -522,6 +594,74 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/90/bcce6b46823c9bec1757c964dc37ed332579be512e17a30e9698095dcae4/python_discovery-1.2.0.tar.gz", hash = "sha256:7d33e350704818b09e3da2bd419d37e21e7c30db6e0977bb438916e06b41b5b1", size = 58055, upload-time = "2026-03-19T01:43:08.248Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/3c/2005227cb951df502412de2fa781f800663cccbef8d90ec6f1b371ac2c0d/python_discovery-1.2.0-py3-none-any.whl", hash = "sha256:1e108f1bbe2ed0ef089823d28805d5ad32be8e734b86a5f212bf89b71c266e4a", size = 31524, upload-time = "2026-03-19T01:43:07.045Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -665,4 +805,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
 ]


### PR DESCRIPTION
This pull request updates the import statements in the `tests/unit/test_foundry_backend.py` file to centralize all imports from `agentops.backends.foundry_backend` at the top of the file. This change improves code organization and clarity by grouping related imports together.

- **Test file import organization:**
  * Consolidated imports from `agentops.backends.foundry_backend` at the top of `test_foundry_backend.py`, ensuring that `_cloud_evaluator_data_mapping` and `_default_foundry_input_mapping` are imported only once and in a single location. [[1]](diffhunk://#diff-e526edf5d1d949943aeca7da8c3652c56c9864c6228b1675f743380a33f15910L8-R13) [[2]](diffhunk://#diff-e526edf5d1d949943aeca7da8c3652c56c9864c6228b1675f743380a33f15910L324-L328)