### PR TITLE
ci: remove duplicate test runs on release branches, add pre-commit hooks

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
+      - name: Lint with ruff
+        run: uv run ruff check src/ tests/
+
       - name: Run tests
         run: uv run pytest tests/ -v --tb=short
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ name: CI
 
 on:
   push:
-    branches: [develop, "release/**"]
+    branches: [develop]
   pull_request:
     branches: [main, develop]
 


### PR DESCRIPTION
## Summary

Removes redundant CI runs on release branches and adds pre-commit hooks for local lint enforcement.

### Changes

- **Remove duplicate CI on release branches**: `ci.yml` no longer triggers on `release/**` pushes — `staging.yml` (via `_build.yml`) handles lint + test for release branches, avoiding triple test execution.
- **Add lint to reusable build**: `_build.yml` now includes `ruff check` before tests, ensuring release branches get lint coverage.
- **Add pre-commit hooks**: Configured `ruff` lint and `ruff-format` as pre-commit hooks so lint issues are caught before commit.
- **Remove macOS from test matrix**: Avoids persistent queue delays on macOS runners.
- **Fix ruff E402 lint error**: Moved mid-file import to top in `test_foundry_backend.py`.

### CI Pipeline After This Change

| Trigger | Workflow | What runs |
|---|---|---|
| Push to `develop` | `ci.yml` | lint + test (ubuntu/windows x 3 Python versions) + coverage |
| PR to `main`/`develop` | `ci.yml` | lint + test + coverage |
| Push to `release/**` | `staging.yml` only | lint + test + build + TestPyPI publish + verify |
| Push `v*` tag | `release.yml` | lint + test + build + TestPyPI + PyPI + GitHub Release |