### PR TITLE
ci: add cut-release workflow, remove duplicate CI, pre-commit hooks, docs updates

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,128 @@
+# AgentOps Toolkit — Cut Release
+#
+# Workflows:
+#   1. ci.yml          — Lint + test on every push/PR
+#   2. _build.yml      — Reusable build (test + package), called by staging and release
+#   3. staging.yml     — Staging: release/* branch → TestPyPI → verify
+#   4. release.yml     — Production: v* tag → TestPyPI → verify → PyPI → GitHub Release
+#   5. cut-release.yml — Manual dispatch: create release branch + PR from develop
+#
+# One-click release branch creation. Triggered manually from the Actions tab.
+# Creates a release branch from develop, updates CHANGELOG.md, and opens a PR to main.
+# The branch push then triggers staging.yml automatically.
+#
+# Usage:
+#   Actions tab → "Cut Release" → "Run workflow" → enter version (e.g. 0.2.0)
+
+name: Cut Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 0.2.0) — no 'v' prefix"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cut-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must be in semver format (e.g. 0.2.0), got: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check release branch does not exist
+        run: |
+          if git ls-remote --exit-code origin "refs/heads/release/v${{ env.version }}" >/dev/null 2>&1; then
+            echo "::error::Branch release/v${{ env.version }} already exists. Delete it first or use a different version."
+            exit 1
+          fi
+
+      - name: Check CHANGELOG has Unreleased section
+        run: |
+          if ! grep -q '## \[Unreleased\]' CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing the [Unreleased] section."
+            exit 1
+          fi
+
+      - name: Create release branch
+        run: |
+          git checkout -b "release/v${{ env.version }}"
+
+      - name: Update CHANGELOG
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          # Replace [Unreleased] with versioned section, add fresh Unreleased above
+          sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [${{ env.version }}] - $DATE/" CHANGELOG.md
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and push
+        run: |
+          git add CHANGELOG.md
+          git commit -m "chore: prepare release ${{ env.version }}"
+          git push origin "release/v${{ env.version }}"
+
+      - name: Create PR to main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "release/v${{ env.version }}" \
+            --title "Release v${{ env.version }}" \
+            --body "## Release v${{ env.version }}
+
+          Automated release branch created from \`develop\`.
+
+          ### What happened
+          - Branch \`release/v${{ env.version }}\` created from \`develop\`
+          - \`CHANGELOG.md\` updated: \`[Unreleased]\` → \`[${{ env.version }}]\`
+          - Staging pipeline triggered automatically (build → TestPyPI → verify)
+
+          ### Next steps
+          1. Wait for the **Staging** pipeline to pass
+          2. Review and approve this PR
+          3. Merge to \`main\`
+          4. Tag and push: \`git tag v${{ env.version }} && git push origin v${{ env.version }}\`
+          5. Approve the PyPI publish in the **Release** workflow
+          6. Sync develop: \`git checkout develop && git merge main && git push origin develop\`
+
+          ### Checklist
+          - [ ] Staging pipeline passes (build + TestPyPI + verify)
+          - [ ] CHANGELOG entries reviewed
+          - [ ] PR approved and merged to main
+          - [ ] Tag \`v${{ env.version }}\` pushed
+          - [ ] PyPI publish approved
+          - [ ] develop synced from main"
+
+      - name: Summary
+        run: |
+          echo "## ✅ Release branch created" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch: \`release/v${{ env.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- CHANGELOG updated with version **${{ env.version }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- PR opened: \`release/v${{ env.version }}\` → \`main\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Staging pipeline triggered automatically" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Next: wait for staging, then tag \`v${{ env.version }}\` to publish" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -250,3 +250,21 @@ Remove or comment out the "Post report as PR comment" step in the workflow.
 | Missing artifacts | Ensure `.agentops/results/latest/` is not in `.gitignore` — the workflow reads this path |
 | Authentication errors | Verify the federated credential entity matches your repo/branch; check that `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` are set as repository variables; confirm the app registration has access to the Foundry project |
 | `agentops: command not found` | Ensure `pip install agentops-toolkit` runs before the eval step |
+
+---
+
+## Internal CI/CD Workflows (Contributors)
+
+If you are contributing to the agentops-toolkit repository itself, the project has separate CI/CD workflows for building and releasing the package:
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `ci.yml` | Push to `develop`, PRs to `main`/`develop` | Lint (ruff) + test (matrix) + coverage |
+| `_build.yml` | Called by staging/release | Reusable lint + test + build package |
+| `staging.yml` | Push to `release/**` | Build → TestPyPI → verify install |
+| `release.yml` | Push `v*` tag | TestPyPI → PyPI (with approval) → GitHub Release |
+| `cut-release.yml` | Manual dispatch (Actions tab button) | Create release branch from `develop`, update CHANGELOG, open PR to `main` |
+
+The **Cut Release** workflow provides a one-click way to start a release: enter a version number in the Actions UI, and it creates the release branch, updates the changelog, and opens the PR automatically.
+
+For full details, see [release-process.md](release-process.md).

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -208,7 +208,6 @@ The CI pipeline runs on **every push and PR** to `main` or `develop`.
 | --- | --- | --- | --- |
 | Ubuntu | ✅ | ✅ | ✅ |
 | Windows | ✅ | ✅ | ✅ |
-| macOS | — | ✅ | ✅ |
 
 ### What CI Catches
 
@@ -571,26 +570,31 @@ push tag v0.2.0
 
 ### Step-by-Step: Cutting a Release
 
-#### Step 1: Prepare the Release
+#### Step 1: Cut the Release (One-Click)
 
-Ensure all intended changes are merged to `develop` and the `CHANGELOG.md` is updated:
+1. Go to the **Actions** tab → select **Cut Release** workflow
+2. Click **Run workflow**
+3. Enter the version (e.g. `0.2.0`) — no `v` prefix
+4. Click **Run workflow**
 
-```bash
-git checkout develop
-git pull origin develop
+The workflow automatically:
+- Creates `release/v0.2.0` from `develop`
+- Updates `CHANGELOG.md` (`[Unreleased]` → `[0.2.0] - YYYY-MM-DD`)
+- Pushes the branch (triggers [staging pipeline](#7-staging-pipeline-testpypi))
+- Opens a PR: `release/v0.2.0` → `main`
 
-# Verify CHANGELOG has entries under [Unreleased]
-cat CHANGELOG.md
-```
+> **Alternative (manual)**: If you prefer to create the release branch locally:
+> ```bash
+> git checkout develop && git pull origin develop
+> git checkout -b release/v0.2.0
+> # Edit CHANGELOG.md manually
+> git commit -m "chore: prepare release 0.2.0"
+> git push origin release/v0.2.0
+> ```
 
-#### Step 2: Create the Release Branch
+#### Step 2: Wait for Staging
 
-```bash
-git checkout -b release/v0.2.0
-git push origin release/v0.2.0
-```
-
-This triggers the [staging pipeline](#7-staging-pipeline-testpypi). Wait for it to pass.
+The branch push triggers the staging pipeline automatically. Wait for it to pass.
 
 #### Step 3: Monitor Staging
 
@@ -602,36 +606,16 @@ This triggers the [staging pipeline](#7-staging-pipeline-testpypi). Wait for it 
 
 If any job fails, fix the issue on the release branch and push. The pipeline re-runs automatically.
 
-#### Step 4: Finalize the Changelog
+#### Step 4: Merge to Main
 
-On the release branch, move `[Unreleased]` entries to a versioned section:
-
-```markdown
-## [0.2.0] - 2026-03-23
-
-### Added
-- ...
-
-### Changed
-- ...
-```
-
-```bash
-git add CHANGELOG.md
-git commit -m "chore: finalize changelog for v0.2.0"
-git push origin release/v0.2.0
-```
-
-#### Step 5: Merge to Main
-
-Create a PR from `release/v0.2.0` → `main`:
+Create a PR from `release/v0.2.0` → `main` (or use the one already opened by Cut Release):
 
 1. Go to GitHub → **Pull Requests** → **New Pull Request**
 2. Base: `main` ← Compare: `release/v0.2.0`
 3. Title: `Release v0.2.0`
 4. Get the required reviews and merge
 
-#### Step 6: Tag the Release
+#### Step 5: Tag the Release
 
 ```bash
 git checkout main
@@ -642,7 +626,7 @@ git push origin v0.2.0
 
 This triggers the [production release pipeline](#8-production-release-pipeline-pypi).
 
-#### Step 7: Approve the PyPI Publish
+#### Step 6: Approve the PyPI Publish
 
 1. Go to **Actions** tab → find the **Release** workflow run for `v0.2.0`
 2. The pipeline will run through build → TestPyPI → verify
@@ -651,7 +635,7 @@ This triggers the [production release pipeline](#8-production-release-pipeline-p
 5. The package publishes to PyPI
 6. The `github-release` job creates a GitHub Release with the built artifacts and auto-generated release notes
 
-#### Step 8: Post-Release Cleanup
+#### Step 7: Post-Release Cleanup
 
 ```bash
 # Sync the tag back to develop
@@ -665,7 +649,7 @@ git push origin --delete release/v0.2.0
 git branch -d release/v0.2.0
 ```
 
-#### Step 9: Verify the Published Package
+#### Step 8: Verify the Published Package
 
 ```bash
 # Install from PyPI
@@ -787,6 +771,23 @@ Key details:
 - `github-release` uses `gh release create` with `--generate-notes` for automatic release notes
 - Built artifacts (.whl, .tar.gz) are attached to the GitHub Release
 
+### `cut-release.yml` — Cut Release (Manual Dispatch)
+
+```
+Trigger: workflow_dispatch (manual button in Actions tab)
+Input:   version — semver string (e.g. 0.2.0)
+Flow:    validate → create release branch → update CHANGELOG → push → open PR
+Purpose: One-click release branch creation from develop
+```
+
+Key details:
+- Creates `release/v<version>` branch from `develop`
+- Automatically updates `CHANGELOG.md` — renames `[Unreleased]` to `[<version>] - <date>` and adds a fresh `[Unreleased]` section
+- Opens a PR from `release/v<version>` → `main` with a checklist
+- The branch push triggers `staging.yml` automatically
+- Fails safely if the branch already exists or CHANGELOG is missing `[Unreleased]`
+- Does NOT auto-tag or auto-publish — tagging remains a manual, intentional step
+
 ---
 
 ## 12. Release Checklist
@@ -800,10 +801,10 @@ Use this checklist when cutting a release:
 - [ ] Version from setuptools-scm looks correct: `python -m setuptools_scm`
 
 **Staging**
-- [ ] Release branch created and pushed: `release/v0.X.Y`
+- [ ] Release branch created via **Cut Release** workflow (or manually)
+- [ ] CHANGELOG automatically updated with version and date
 - [ ] Staging pipeline passes: build + TestPyPI + verify (all 3 green)
-- [ ] CHANGELOG finalized with version and date
-- [ ] Release branch change pushed, staging re-runs and passes
+- [ ] PR opened: `release/v0.X.Y` → `main`
 
 **Production**
 - [ ] PR from `release/v0.X.Y` → `main` created and approved
@@ -878,7 +879,10 @@ Use this checklist when cutting a release:
                       ├──→ CI (ci.yml)
                       │    lint + test + coverage
                       │
-                      └──→ release/v0.2.0
+                      └──→ Cut Release (cut-release.yml)
+                           manual dispatch → enter version
+                           │
+                           └──→ release/v0.2.0
                                 │
                                 ├──→ Staging (staging.yml)
                                 │


### PR DESCRIPTION
## Summary

Adds a one-click Cut Release workflow, removes duplicate CI runs, adds pre-commit hooks, and updates release documentation.

### Changes

#### CI/CD Workflows
- **New: cut-release.yml** - Manual dispatch workflow (Actions tab button) to create release branches from develop
- **Remove duplicate CI on release branches** - ci.yml no longer triggers on release/** pushes
- **Add lint to reusable build** - _build.yml now includes ruff check before tests
- **Remove macOS from test matrix** - Avoids queue delays
- **Fix ruff E402 lint error** - Moved mid-file import in test_foundry_backend.py

#### Developer Experience
- **Add pre-commit hooks** - ruff lint and ruff-format on every commit
- **Add pre-commit to dev dependencies**

#### Documentation
- **release-process.md** - Added cut-release docs, updated steps, architecture diagram, checklist
- **ci-github-actions.md** - Added Internal CI/CD Workflows section

### CI Pipeline

| Trigger | Workflow | What runs |
|---|---|---|
| Push to develop | ci.yml | lint + test + coverage |
| PR to main/develop | ci.yml | lint + test + coverage |
| Push to release/** | staging.yml | lint + test + build + TestPyPI + verify |
| Push v* tag | release.yml | TestPyPI + PyPI + GitHub Release |
| Manual button | cut-release.yml | Create release branch + CHANGELOG + PR |
