### PR TITLE
fix: remove duplicate _planned_command definition (ruff F811)

### DIFF
--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -102,16 +102,6 @@ log = get_logger(__name__)
 DEFAULT_REPORT_INPUT = Path(".agentops/results/latest/results.json")
 
 
-def _planned_command(command_name: str) -> None:
-    typer.echo(
-        "This command is planned but not implemented in this release:\n"
-        f"  {command_name}\n"
-        "Please use the currently available commands"
-        " (`init`, `eval run`, `eval compare`, `report`, `config cicd`) for now."
-    )
-    raise typer.Exit(code=1)
-
-
 # ---------------------------------------------------------------------------
 # Global callback — configures logging before any command runs
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
CI on develop fails with ruff F811:

src/agentops/cli/app.py:105:5: F811 Redefinition of unused _planned_command from line 27

PR #59 (feature/browse-commands) merged into develop before the refactor commit (6017f3a) that moved stubs into their own command files. The duplicate local def _planned_command shadowed the import from agentops.cli._planned.

## Fix
Remove the duplicate local definition (lines 105-111). The import on line 27 already provides the identical function -- all call sites continue to work.

## Verification
- ruff check src/ tests/ -- all checks passed
- pytest tests/ -x -q -- 112 passed, 1 skipped