### PR TITLE
ci(vsix): sync VSIX version from git tags in all pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for version derivation
+
+      - name: Sync VSIX version from git tag
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LAST_VERSION=${LAST_TAG#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+          if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+            BASE_VERSION="$LAST_VERSION"
+          else
+            BASE_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+          fi
+          jq --arg v "$BASE_VERSION" '.version = $v' \
+            plugins/agentops/package.json > plugins/agentops/package.json.tmp
+          mv plugins/agentops/package.json.tmp plugins/agentops/package.json
+          echo "VSIX version set to $BASE_VERSION (from tag $LAST_TAG)"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -224,6 +241,23 @@ jobs:
     environment: staging
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for version derivation
+
+      - name: Sync VSIX version from git tag
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LAST_VERSION=${LAST_TAG#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+          if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+            BASE_VERSION="$LAST_VERSION"
+          else
+            BASE_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+          fi
+          jq --arg v "$BASE_VERSION" '.version = $v' \
+            plugins/agentops/package.json > plugins/agentops/package.json.tmp
+          mv plugins/agentops/package.json.tmp plugins/agentops/package.json
+          echo "VSIX version set to $BASE_VERSION (from tag $LAST_TAG)"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,23 @@ jobs:
     environment: release  # same approval gate as PyPI
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for version derivation
+
+      - name: Sync VSIX version from git tag
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LAST_VERSION=${LAST_TAG#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+          if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+            BASE_VERSION="$LAST_VERSION"
+          else
+            BASE_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+          fi
+          jq --arg v "$BASE_VERSION" '.version = $v' \
+            plugins/agentops/package.json > plugins/agentops/package.json.tmp
+          mv plugins/agentops/package.json.tmp plugins/agentops/package.json
+          echo "VSIX version set to $BASE_VERSION (from tag $LAST_TAG)"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -124,6 +124,23 @@ jobs:
     environment: staging
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for version derivation
+
+      - name: Sync VSIX version from git tag
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LAST_VERSION=${LAST_TAG#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+          if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+            BASE_VERSION="$LAST_VERSION"
+          else
+            BASE_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+          fi
+          jq --arg v "$BASE_VERSION" '.version = $v' \
+            plugins/agentops/package.json > plugins/agentops/package.json.tmp
+          mv plugins/agentops/package.json.tmp plugins/agentops/package.json
+          echo "VSIX version set to $BASE_VERSION (from tag $LAST_TAG)"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/plugins/agentops/README.md
+++ b/plugins/agentops/README.md
@@ -25,7 +25,7 @@ pip install agentops-toolkit
 ## Installation
 
 Install from the
-[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=PUBLISHER_ID.agentops-skills)
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=AgentOpsToolkit.agentops-toolkit)
 or search **"AgentOps Skills"** in the VS Code Extensions view.
 
 A **pre-release** channel is available for early access to new skills and updates —

--- a/plugins/agentops/README.md
+++ b/plugins/agentops/README.md
@@ -59,9 +59,6 @@ The skills are invoked automatically when your request matches their domain.
 > Validate my dataset before running an eval
 ```
 
-> **Note:** To run evaluations, install the AgentOps CLI in your project's virtual
-> environment: `pip install agentops-toolkit`
-
 ## Links
 
 - [AgentOps Toolkit](https://github.com/Azure/agentops) — CLI and documentation

--- a/plugins/agentops/README.md
+++ b/plugins/agentops/README.md
@@ -14,14 +14,6 @@ Copilot agent skills for running standardized evaluation workflows with
 | **Browse & Inspect** | List and inspect evaluation runs, view per-row scores, browse run history |
 | **Dataset Management** | Validate, describe, and import datasets for evaluation workflows |
 
-## Prerequisites
-
-Install the AgentOps CLI in your project's virtual environment:
-
-```bash
-pip install agentops-toolkit
-```
-
 ## Installation
 
 Install from the
@@ -34,14 +26,41 @@ enable it from the extension's Marketplace page or the Extensions view.
 ## Usage
 
 Open **Copilot Chat** in VS Code and describe what you want to do.
-The skills are invoked automatically when your request matches their domain:
+The skills are invoked automatically when your request matches their domain.
+
+**Set up a workspace**
 
 ```
-> Initialize an agentops workspace for my project
-> Run the default evaluation
-> Compare run abc123 with run def456
-> Which rows failed the groundedness threshold?
+> Initialize an agentops workspace for my Foundry agent project
+> Create a RAG evaluation bundle with groundedness and similarity
 ```
+
+**Run and compare evaluations**
+
+```
+> Run the default evaluation against my agent
+> Benchmark gpt-4o vs gpt-4o-mini using the smoke dataset
+> Compare the last two evaluation runs and summarize the differences
+```
+
+**Investigate results**
+
+```
+> Which rows failed the groundedness threshold?
+> Show me the worst-scoring items from the latest run
+> Why did similarity drop between run abc123 and run def456?
+```
+
+**Browse and manage**
+
+```
+> List all evaluation runs
+> Show details for the latest run
+> Validate my dataset before running an eval
+```
+
+> **Note:** To run evaluations, install the AgentOps CLI in your project's virtual
+> environment: `pip install agentops-toolkit`
 
 ## Links
 


### PR DESCRIPTION
## Summary

Sync the VSIX `package.json` version from git tags at CI time, so the extension and Python package versions stay consistent. Also cleans up the extension README for the VS Code Marketplace.

### Version sync

Added a **Sync VSIX version from git tag** step to all 4 VSIX jobs across `ci.yml`, `staging.yml`, and `release.yml`. Uses `git describe --tags --abbrev=0` + `jq` (both pre-installed on ubuntu-latest):

- **On exact tag** (release builds): uses tag version directly (e.g. `v0.2.0` → `0.2.0`)
- **Between tags** (dev/staging builds): bumps patch by 1 (e.g. `v0.2.0` → `0.2.1`)
- **No tags yet**: falls back to `0.0.0`

### README improvements

- Fixed Marketplace link placeholder (`PUBLISHER_ID.agentops-skills` → `AgentOpsToolkit.agentops-toolkit`)
- Removed misleading Prerequisites section (CLI install is not required before installing the extension)
- Expanded Usage section with categorized examples matching each skill
- Removed manual CLI install note (skills handle setup automatically)

### Files changed

- `.github/workflows/ci.yml` — version sync for `build-vsix` and `publish-vsix-dev`
- `.github/workflows/staging.yml` — version sync for `publish-vsix-prerelease`
- `.github/workflows/release.yml` — version sync for `publish-vsix`
- `plugins/agentops/README.md` — Marketplace README cleanup
