### PR TITLE
feat: default publish_foundry_evaluation to true

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -226,7 +226,7 @@ Both support two resolution modes (at least one required):
 
 - `path` — Output directory
 - `write_report` — Generate `report.md` (default: `true`)
-- `publish_foundry_evaluation` — Publish results to Foundry (default: `false`)
+- `publish_foundry_evaluation` — Publish results to Foundry (default: `true`)
 - `fail_on_foundry_publish_error` — Fail if Foundry publish fails (default: `false`)
 
 #### Validation rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,7 +363,7 @@ Callable protocol: `fn(input_text: str, context: dict) -> dict` returning `{"res
 `output` section:
 - `path` — Output directory
 - `write_report` — Generate `report.md` (default: `true`)
-- `publish_foundry_evaluation` — Publish results to Foundry (default: `false`)
+- `publish_foundry_evaluation` — Publish results to Foundry (default: `true`)
 - `fail_on_foundry_publish_error` — Fail if Foundry publish fails (default: `false`)
 
 Backend resolution:

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -360,7 +360,7 @@ Both support two resolution modes (at least one required):
 
 - `path` — Output directory
 - `write_report` — Generate `report.md` (default: `true`)
-- `publish_foundry_evaluation` — Publish results to Foundry (default: `false`)
+- `publish_foundry_evaluation` — Publish results to Foundry (default: `true`)
 - `fail_on_foundry_publish_error` — Fail if Foundry publish fails (default: `false`)
 
 #### Validation rules

--- a/docs/run-yaml-schema.md
+++ b/docs/run-yaml-schema.md
@@ -167,7 +167,7 @@ References the evaluation dataset. At least one of `name` or `path` is required.
 |---|---|---|---|---|
 | `path` | path | No | — | Output directory override |
 | `write_report` | bool | No | `true` | Generate `report.md` |
-| `publish_foundry_evaluation` | bool | No | `false` | Publish results to Foundry |
+| `publish_foundry_evaluation` | bool | No | `true` | Publish results to Foundry |
 | `fail_on_foundry_publish_error` | bool | No | `false` | Fail if Foundry publish fails |
 
 ---

--- a/src/agentops/core/models.py
+++ b/src/agentops/core/models.py
@@ -347,7 +347,7 @@ class RunMetadata(BaseModel):
 class OutputConfig(BaseModel):
     path: Optional[Path] = None
     write_report: bool = True
-    publish_foundry_evaluation: bool = False
+    publish_foundry_evaluation: bool = True
     fail_on_foundry_publish_error: bool = False
 
 


### PR DESCRIPTION
Change OutputConfig.publish_foundry_evaluation default from False to True so eval runs automatically publish results to the AI Foundry portal. Updated all docs (copilot-instructions, AGENTS.md, how-it-works, run-yaml-schema).