### PR TITLE
Fix AgentOps workflow evaluator environment

### DIFF
--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -395,6 +395,11 @@ loop you will wire into CI next.**
 > *shape* of the delta: tool/task metrics down, text-quality metrics
 > flat.
 
+Before wiring the workflow gate, switch `agentops.yaml` back to the
+tool-using version (`support-bot:1` in the example above) if you want
+the PR check to pass. Leave it on the degraded version only when you
+intentionally want to demonstrate a red quality gate.
+
 ## 7. Generate the GitFlow workflows
 
 ```powershell

--- a/src/agentops/templates/workflows/agentops-deploy-dev.yml
+++ b/src/agentops/templates/workflows/agentops-deploy-dev.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Run AgentOps eval
         env:
           AZURE_AI_FOUNDRY_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_FOUNDRY_PROJECT_ENDPOINT }}
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ vars.AZURE_OPENAI_DEPLOYMENT }}
         run: agentops eval run --config "${{ inputs.config || 'agentops.yaml' }}"
 
       - name: Upload AgentOps results

--- a/src/agentops/templates/workflows/agentops-deploy-prod.yml
+++ b/src/agentops/templates/workflows/agentops-deploy-prod.yml
@@ -73,6 +73,8 @@ jobs:
       - name: Run AgentOps eval (production gate)
         env:
           AZURE_AI_FOUNDRY_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_FOUNDRY_PROJECT_ENDPOINT }}
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ vars.AZURE_OPENAI_DEPLOYMENT }}
         run: agentops eval run --config "${{ inputs.config || 'agentops.yaml' }}"
 
       - name: Upload AgentOps results

--- a/src/agentops/templates/workflows/agentops-deploy-qa.yml
+++ b/src/agentops/templates/workflows/agentops-deploy-qa.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Run AgentOps eval
         env:
           AZURE_AI_FOUNDRY_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_FOUNDRY_PROJECT_ENDPOINT }}
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ vars.AZURE_OPENAI_DEPLOYMENT }}
         run: agentops eval run --config "${{ inputs.config || 'agentops.yaml' }}"
 
       - name: Upload AgentOps results

--- a/src/agentops/templates/workflows/agentops-pr.yml
+++ b/src/agentops/templates/workflows/agentops-pr.yml
@@ -70,6 +70,8 @@ jobs:
         id: eval
         env:
           AZURE_AI_FOUNDRY_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_FOUNDRY_PROJECT_ENDPOINT }}
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ vars.AZURE_OPENAI_DEPLOYMENT }}
         run: |
           set +e
           agentops eval run --config "${{ inputs.config || 'agentops.yaml' }}"

--- a/tests/unit/test_cicd.py
+++ b/tests/unit/test_cicd.py
@@ -120,6 +120,21 @@ def test_all_templates_are_valid_yaml(tmp_path: Path) -> None:
         assert "\non:" in text
 
 
+def test_all_templates_pass_foundry_and_evaluator_environment(tmp_path: Path) -> None:
+    generate_cicd_workflows(directory=tmp_path)
+    expected_env = (
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT: "
+        "${{ vars.AZURE_AI_FOUNDRY_PROJECT_ENDPOINT }}",
+        "AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}",
+        "AZURE_OPENAI_DEPLOYMENT: ${{ vars.AZURE_OPENAI_DEPLOYMENT }}",
+    )
+    for rel in ALL_PATHS:
+        content = (tmp_path / rel).read_text(encoding="utf-8")
+
+        for env_line in expected_env:
+            assert env_line in content
+
+
 def test_pr_template_triggers_and_no_environment(tmp_path: Path) -> None:
     generate_cicd_workflows(directory=tmp_path, kinds=["pr"])
     content = (tmp_path / _PR_PATH).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- pass Azure OpenAI evaluator variables through generated AgentOps workflows
- document switching back to the tool-using support-bot version before expecting a green CI gate
- add workflow template coverage for Foundry and evaluator environment variables

## Testing
- `C:\Users\paulolacerda\workspace\test-agentops\.venv\Scripts\python.exe -m pytest tests\ -x -q`