### PR TITLE
fix(eval): improve AI-assisted evaluator UX for Foundry projects (#126)

### DIFF
--- a/docs/tutorial-model-direct.md
+++ b/docs/tutorial-model-direct.md
@@ -23,14 +23,22 @@ project endpoint to configure AI-assisted evaluators by default: the judge
 deployment defaults to the same deployment named in `agent: "model:<deployment>"`,
 and the evaluator endpoint is derived from the project URL.
 
-If you want a separate judge deployment, set both optional overrides before
-running:
+If you want a separate judge deployment, set just the deployment name —
+AgentOps reuses your Foundry project endpoint to find it:
+
+```bash
+# Same Foundry project, different deployment as judge (most common):
+export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4.1-443723"
+# or, equivalently:
+# export AZURE_OPENAI_DEPLOYMENT="gpt-4.1-443723"
+```
+
+To point the judge at a fully separate Azure OpenAI resource (advanced),
+also set `AZURE_OPENAI_ENDPOINT`:
 
 ```bash
 export AZURE_OPENAI_ENDPOINT="https://<judge-resource>.openai.azure.com"
 export AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
-# Or, if your environment uses the Foundry deployment variable:
-# export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"
 ```
 
 AgentOps automatically enables the `azure-ai-evaluation` reasoning-model token
@@ -50,6 +58,20 @@ classifies it as `model_direct`, sends each row's `input` straight to
 the target deployment, and skips agent infrastructure entirely. Unless you set
 the optional evaluator overrides, AI-assisted evaluators such as Coherence,
 Fluency, and Similarity use this same deployment as the judge.
+
+> **Tip — use the exact deployment name, not the model name.** Foundry often
+> suffixes auto-created deployments with a random id (e.g. `gpt-4.1-443723`,
+> `gpt-4.1-mini-642951`). Using the bare model name will return
+> `DeploymentNotFound` (HTTP 404). List your deployments with:
+>
+> ```bash
+> az cognitiveservices account deployment list \
+>   --resource-group <your-resource-group> \
+>   --name <your-foundry-resource> \
+>   --query "[].{name:name, model:properties.model.name}" -o table
+> ```
+>
+> Use the value in the **`name`** column for `agent: "model:<deployment>"`.
 
 ## 3. Dataset shape
 
@@ -102,10 +124,10 @@ Exit code `0` = all thresholds passed, `2` = at least one failed,
   `AGENTOPS_EVALUATOR_REASONING_MODEL=true`. If an alias is incorrectly
   detected as reasoning, set `AGENTOPS_EVALUATOR_REASONING_MODEL=false`.
   Accepted values are `1`, `true`, `yes`, `on`, `0`, `false`, `no`, and `off`.
-- **Separate judge override errors**: if you set `AZURE_OPENAI_ENDPOINT`, also
-  set `AZURE_OPENAI_DEPLOYMENT` or `AZURE_AI_MODEL_DEPLOYMENT_NAME`; partial
-  overrides are rejected so AgentOps does not silently judge with the wrong
-  deployment.
+- **Separate judge override errors**: setting `AZURE_OPENAI_ENDPOINT` without
+  a deployment is rejected, and setting only a deployment without
+  `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` is rejected too — partial overrides
+  would silently judge with the wrong endpoint.
 
 ## 6. Compare two model deployments
 

--- a/docs/tutorial-model-direct.md
+++ b/docs/tutorial-model-direct.md
@@ -6,7 +6,7 @@ model can't answer your dataset, no agent prompt will save it.
 
 ## Prerequisites
 
-- Python 3.11+ and `pip install "agentops-toolkit @ git+https://github.com/Azure/agentops.git@develop"`
+- Python 3.11+ and `pip install "agentops-toolkit[foundry] @ git+https://github.com/Azure/agentops.git@develop"`
 - A Foundry project with at least one model deployment
 - `az login` (AgentOps uses `DefaultAzureCredential`)
 
@@ -17,17 +17,39 @@ agentops init
 export AZURE_AI_FOUNDRY_PROJECT_ENDPOINT="https://<resource>.services.ai.azure.com/api/projects/<project>"
 ```
 
+Use `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` for the Foundry project that hosts
+the target deployment. For model-direct Foundry runs, AgentOps also uses this
+project endpoint to configure AI-assisted evaluators by default: the judge
+deployment defaults to the same deployment named in `agent: "model:<deployment>"`,
+and the evaluator endpoint is derived from the project URL.
+
+If you want a separate judge deployment, set both optional overrides before
+running:
+
+```bash
+export AZURE_OPENAI_ENDPOINT="https://<judge-resource>.openai.azure.com"
+export AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
+# Or, if your environment uses the Foundry deployment variable:
+# export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"
+```
+
+AgentOps automatically enables the `azure-ai-evaluation` reasoning-model token
+path for evaluator deployments whose names begin with `gpt-5`, `o1`, `o3`, or
+`o4`, so deployments such as `gpt-5.1` can be used for judging.
+
 ## 2. Edit `agentops.yaml`
 
 ```yaml
 version: 1
-agent: "model:gpt-4o"           # <-- key part: the `model:` prefix
+agent: "model:gpt-4o"           # target deployment; key part is `model:`
 dataset: .agentops/data/smoke.jsonl
 ```
 
 `agent: "model:<deployment>"` is the model-direct shape — AgentOps
 classifies it as `model_direct`, sends each row's `input` straight to
-the deployment, and skips agent infrastructure entirely.
+the target deployment, and skips agent infrastructure entirely. Unless you set
+the optional evaluator overrides, AI-assisted evaluators such as Coherence,
+Fluency, and Similarity use this same deployment as the judge.
 
 ## 3. Dataset shape
 
@@ -65,7 +87,27 @@ Outputs land in `.agentops/results/<timestamp>/` and are mirrored to `.agentops/
 Exit code `0` = all thresholds passed, `2` = at least one failed,
 `1` = configuration / runtime error.
 
-## 5. Compare two model deployments
+## 5. Troubleshooting
+
+- **Project endpoint shape errors**: for the default judge configuration,
+  `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` should look like
+  `https://<resource>.services.ai.azure.com/api/projects/<project>`. AgentOps
+  strips `/api/projects/<project>` to derive the evaluator data-plane endpoint.
+  If your Foundry endpoint has a different shape, set `AZURE_OPENAI_ENDPOINT`
+  and `AZURE_OPENAI_DEPLOYMENT` explicitly for the judge deployment.
+- **`max_tokens` / `max_completion_tokens` errors**: AgentOps automatically
+  treats evaluator deployments whose names begin with `gpt-5`, `o1`, `o3`, or
+  `o4` as reasoning models. If your deployment uses an opaque alias for one of
+  those models and `azure-ai-evaluation` still sends legacy `max_tokens`, set
+  `AGENTOPS_EVALUATOR_REASONING_MODEL=true`. If an alias is incorrectly
+  detected as reasoning, set `AGENTOPS_EVALUATOR_REASONING_MODEL=false`.
+  Accepted values are `1`, `true`, `yes`, `on`, `0`, `false`, `no`, and `off`.
+- **Separate judge override errors**: if you set `AZURE_OPENAI_ENDPOINT`, also
+  set `AZURE_OPENAI_DEPLOYMENT` or `AZURE_AI_MODEL_DEPLOYMENT_NAME`; partial
+  overrides are rejected so AgentOps does not silently judge with the wrong
+  deployment.
+
+## 6. Compare two model deployments
 
 ```bash
 # Baseline run on gpt-4o

--- a/src/agentops/pipeline/runtime.py
+++ b/src/agentops/pipeline/runtime.py
@@ -153,20 +153,32 @@ def _model_config(
     api_version = os.getenv("AZURE_OPENAI_API_VERSION") or "2025-04-01-preview"
 
     if endpoint or deployment:
-        missing = []
-        if not endpoint:
-            missing.append("AZURE_OPENAI_ENDPOINT")
         if not deployment:
-            missing.append("AZURE_OPENAI_DEPLOYMENT")
-        if missing:
             raise RuntimeError(
-                "AI-assisted evaluator override is incomplete. Missing "
-                "environment variables: "
-                + ", ".join(missing)
-                + ". Set both AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT "
-                "(or AZURE_AI_MODEL_DEPLOYMENT_NAME), or unset them to use the "
-                "Foundry model-direct defaults."
+                "AI-assisted evaluator override is incomplete. "
+                "AZURE_OPENAI_ENDPOINT was set but no evaluator deployment "
+                "was provided. Set AZURE_OPENAI_DEPLOYMENT (or "
+                "AZURE_AI_MODEL_DEPLOYMENT_NAME), or unset "
+                "AZURE_OPENAI_ENDPOINT to use the Foundry model-direct defaults."
             )
+        if not endpoint:
+            # Deployment-only override: keep the Foundry-derived endpoint so
+            # users can pick a separate judge inside the same Foundry project
+            # without rewriting URLs by hand. Falls back to a clear error if
+            # we have no Foundry project endpoint to derive from.
+            project_endpoint = foundry_project_endpoint or os.getenv(
+                "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT"
+            )
+            if not project_endpoint:
+                raise RuntimeError(
+                    "AI-assisted evaluator override is incomplete. "
+                    f"AZURE_OPENAI_DEPLOYMENT={deployment!r} was set but "
+                    "AgentOps cannot derive an evaluator endpoint without "
+                    "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT. Set "
+                    "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT, or also set "
+                    "AZURE_OPENAI_ENDPOINT for a fully separate judge resource."
+                )
+            endpoint = _foundry_data_plane_endpoint(project_endpoint)
     else:
         endpoint, deployment = _default_model_direct_config(
             target=target,

--- a/src/agentops/pipeline/runtime.py
+++ b/src/agentops/pipeline/runtime.py
@@ -12,10 +12,13 @@ import importlib
 import inspect
 import json
 import os
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse, urlunparse
 
+from agentops.core.agentops_config import TargetResolution
 from agentops.core.evaluators import EvaluatorPreset
 from agentops.core.results import RowMetric
 
@@ -44,6 +47,15 @@ _SAFETY = {
     "ProtectedMaterialEvaluator",
 }
 
+_REASONING_MODEL_ENV = "AGENTOPS_EVALUATOR_REASONING_MODEL"
+_REASONING_MODEL_TRUTHY = {"1", "true", "yes", "on"}
+_REASONING_MODEL_FALSEY = {"0", "false", "no", "off"}
+_REASONING_MODEL_VALUES = "1, true, yes, on, 0, false, no, off"
+_REASONING_DEPLOYMENT_RE = re.compile(
+    r"^(?:gpt[-_]?5(?:$|[^a-z0-9])|o[134](?:$|[^a-z0-9]))",
+    re.IGNORECASE,
+)
+
 
 @dataclass
 class EvaluatorRuntime:
@@ -64,11 +76,75 @@ def _credential() -> Any:
     return DefaultAzureCredential(exclude_developer_cli_credential=True)
 
 
-def _model_config() -> Dict[str, str]:
-    endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
-    deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT") or os.getenv(
+def _explicit_evaluator_deployment() -> Optional[str]:
+    return os.getenv("AZURE_OPENAI_DEPLOYMENT") or os.getenv(
         "AZURE_AI_MODEL_DEPLOYMENT_NAME"
     )
+
+
+def _foundry_data_plane_endpoint(project_endpoint: str) -> str:
+    raw = project_endpoint.strip().rstrip("/")
+    parsed = urlparse(raw)
+    if not parsed.scheme or not parsed.netloc:
+        raise RuntimeError(
+            "Cannot derive evaluator endpoint from "
+            "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT because it is not an absolute URL. "
+            "Set AZURE_AI_FOUNDRY_PROJECT_ENDPOINT to a URL like "
+            "'https://<resource>.services.ai.azure.com/api/projects/<project>', "
+            "or set AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT for an "
+            "explicit evaluator deployment."
+        )
+
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if (
+        len(segments) >= 3
+        and segments[0].lower() == "api"
+        and segments[1].lower() == "projects"
+        and segments[2]
+    ):
+        return urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+
+    raise RuntimeError(
+        "Cannot derive evaluator endpoint from "
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT. Expected a Foundry project URL like "
+        "'https://<resource>.services.ai.azure.com/api/projects/<project>'. "
+        "Set AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT if you want to "
+        "use a separate evaluator deployment."
+    )
+
+
+def _default_model_direct_config(
+    *,
+    target: Optional[TargetResolution],
+    foundry_project_endpoint: Optional[str],
+) -> tuple[str, str]:
+    if target is None or target.kind != "model_direct" or not target.deployment:
+        raise RuntimeError(
+            "AI-assisted evaluators require an evaluator model. Set "
+            "AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT, or use a "
+            "Foundry model-direct target like agent: 'model:<deployment>' so "
+            "AgentOps can default the evaluator deployment to the target model."
+        )
+    endpoint = foundry_project_endpoint or os.getenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT")
+    if not endpoint:
+        raise RuntimeError(
+            "AI-assisted evaluators can default the judge deployment to "
+            f"{target.raw!r}, but AZURE_AI_FOUNDRY_PROJECT_ENDPOINT is required "
+            "to derive the evaluator endpoint. Set "
+            "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT, or set AZURE_OPENAI_ENDPOINT "
+            "and AZURE_OPENAI_DEPLOYMENT for an explicit evaluator deployment."
+        )
+
+    return _foundry_data_plane_endpoint(endpoint), target.deployment
+
+
+def _model_config(
+    *,
+    target: Optional[TargetResolution] = None,
+    foundry_project_endpoint: Optional[str] = None,
+) -> Dict[str, str]:
+    endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+    deployment = _explicit_evaluator_deployment()
     # The New Foundry "AI Services" inference endpoint rejects the
     # azure-ai-evaluation SDK's stock api-version with
     # ``BadRequest: API version not supported``. Default to a version
@@ -76,15 +152,25 @@ def _model_config() -> Dict[str, str]:
     # Azure OpenAI; allow override via AZURE_OPENAI_API_VERSION.
     api_version = os.getenv("AZURE_OPENAI_API_VERSION") or "2025-04-01-preview"
 
-    missing = []
-    if not endpoint:
-        missing.append("AZURE_OPENAI_ENDPOINT")
-    if not deployment:
-        missing.append("AZURE_OPENAI_DEPLOYMENT")
-    if missing:
-        raise RuntimeError(
-            "AI-assisted evaluators require an evaluator model. "
-            "Missing environment variables: " + ", ".join(missing)
+    if endpoint or deployment:
+        missing = []
+        if not endpoint:
+            missing.append("AZURE_OPENAI_ENDPOINT")
+        if not deployment:
+            missing.append("AZURE_OPENAI_DEPLOYMENT")
+        if missing:
+            raise RuntimeError(
+                "AI-assisted evaluator override is incomplete. Missing "
+                "environment variables: "
+                + ", ".join(missing)
+                + ". Set both AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT "
+                "(or AZURE_AI_MODEL_DEPLOYMENT_NAME), or unset them to use the "
+                "Foundry model-direct defaults."
+            )
+    else:
+        endpoint, deployment = _default_model_direct_config(
+            target=target,
+            foundry_project_endpoint=foundry_project_endpoint,
         )
 
     config: Dict[str, str] = {
@@ -93,6 +179,33 @@ def _model_config() -> Dict[str, str]:
         "api_version": api_version,
     }
     return config
+
+
+def _reasoning_model_override() -> Optional[bool]:
+    raw = os.getenv(_REASONING_MODEL_ENV)
+    if raw is None:
+        return None
+
+    value = raw.strip().lower()
+    if value in _REASONING_MODEL_TRUTHY:
+        return True
+    if value in _REASONING_MODEL_FALSEY:
+        return False
+    raise RuntimeError(
+        f"{_REASONING_MODEL_ENV} must be one of {_REASONING_MODEL_VALUES}; "
+        f"got {raw!r}."
+    )
+
+
+def _evaluator_is_reasoning_model(deployment: str) -> bool:
+    override = _reasoning_model_override()
+    if override is not None:
+        return override
+
+    # gpt-5 and o-series deployments require max_completion_tokens in current
+    # Azure OpenAI APIs. The SDK converts legacy prompty max_tokens only when
+    # evaluator classes receive is_reasoning_model=True.
+    return bool(_REASONING_DEPLOYMENT_RE.match(deployment.strip()))
 
 
 def _project_endpoint() -> str:
@@ -107,7 +220,12 @@ def _project_endpoint() -> str:
 _LATENCY_SENTINEL = object()
 
 
-def load_evaluator(preset: EvaluatorPreset) -> EvaluatorRuntime:
+def load_evaluator(
+    preset: EvaluatorPreset,
+    *,
+    target: Optional[TargetResolution] = None,
+    foundry_project_endpoint: Optional[str] = None,
+) -> EvaluatorRuntime:
     """Instantiate one evaluator. Raises a clear error if the SDK is missing."""
     if preset.class_name == "_latency":
         return EvaluatorRuntime(preset=preset, callable=_LATENCY_SENTINEL)
@@ -128,22 +246,50 @@ def load_evaluator(preset: EvaluatorPreset) -> EvaluatorRuntime:
 
     init_kwargs: Dict[str, Any] = {}
     if preset.class_name in _AI_ASSISTED:
-        init_kwargs["model_config"] = _model_config()
+        model_config = _model_config(
+            target=target,
+            foundry_project_endpoint=foundry_project_endpoint,
+        )
+        init_kwargs["model_config"] = model_config
+        if _evaluator_is_reasoning_model(model_config["azure_deployment"]):
+            init_kwargs["is_reasoning_model"] = True
     if preset.class_name in _SAFETY:
         init_kwargs["azure_ai_project"] = _project_endpoint()
         init_kwargs["credential"] = _credential()
 
     try:
         instance = cls(**init_kwargs) if inspect.isclass(cls) else cls
-    except TypeError:
+    except TypeError as exc:
+        if init_kwargs:
+            kwarg_names = ", ".join(sorted(init_kwargs))
+            raise RuntimeError(
+                f"Failed to initialize evaluator {preset.class_name!r} with "
+                f"required configuration ({kwarg_names}). AgentOps will not "
+                "retry without that configuration. If this happens with a "
+                "GPT-5 or o-series evaluator deployment, upgrade "
+                "azure-ai-evaluation to a version that supports "
+                "is_reasoning_model."
+            ) from exc
         # Some evaluators reject unexpected kwargs (e.g. F1ScoreEvaluator).
         instance = cls() if inspect.isclass(cls) else cls
 
     return EvaluatorRuntime(preset=preset, callable=instance)
 
 
-def load_evaluators(presets: List[EvaluatorPreset]) -> List[EvaluatorRuntime]:
-    return [load_evaluator(preset) for preset in presets]
+def load_evaluators(
+    presets: List[EvaluatorPreset],
+    *,
+    target: Optional[TargetResolution] = None,
+    foundry_project_endpoint: Optional[str] = None,
+) -> List[EvaluatorRuntime]:
+    return [
+        load_evaluator(
+            preset,
+            target=target,
+            foundry_project_endpoint=foundry_project_endpoint,
+        )
+        for preset in presets
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_runtime_reasoning_model.py
+++ b/tests/unit/test_runtime_reasoning_model.py
@@ -154,6 +154,73 @@ def test_explicit_evaluator_env_overrides_model_direct_defaults(
     assert "is_reasoning_model" not in evaluator_cls.kwargs
 
 
+def test_deployment_only_override_keeps_foundry_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A separate judge inside the same Foundry project needs only a deployment."""
+    evaluator_cls = _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://aifappframework.services.ai.azure.com/api/projects/models",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1-443723")
+
+    load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+    model_config = evaluator_cls.kwargs["model_config"]
+    assert model_config["azure_endpoint"] == (
+        "https://aifappframework.services.ai.azure.com"
+    )
+    assert model_config["azure_deployment"] == "gpt-4.1-443723"
+    # gpt-4.1 is not a reasoning model.
+    assert "is_reasoning_model" not in evaluator_cls.kwargs
+
+
+def test_deployment_only_override_via_foundry_alias_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AZURE_AI_MODEL_DEPLOYMENT_NAME is the Foundry-style alias and is sufficient."""
+    evaluator_cls = _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://aifappframework.services.ai.azure.com/api/projects/models",
+    )
+    monkeypatch.setenv("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4.1-443723")
+
+    load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+    model_config = evaluator_cls.kwargs["model_config"]
+    assert model_config["azure_endpoint"] == (
+        "https://aifappframework.services.ai.azure.com"
+    )
+    assert model_config["azure_deployment"] == "gpt-4.1-443723"
+
+
+def test_deployment_only_override_requires_foundry_project_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.delenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT", raising=False)
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1-443723")
+
+    with pytest.raises(RuntimeError, match="cannot derive an evaluator endpoint"):
+        load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+
+def test_endpoint_only_override_still_requires_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://judge.openai.azure.com")
+
+    with pytest.raises(RuntimeError, match="no evaluator deployment"):
+        load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+
 def test_model_direct_defaults_raise_when_foundry_endpoint_cannot_be_derived(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_runtime_reasoning_model.py
+++ b/tests/unit/test_runtime_reasoning_model.py
@@ -1,0 +1,244 @@
+"""Unit tests for AI-assisted evaluator reasoning-model compatibility."""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any, Dict
+
+import pytest
+
+from agentops.core.agentops_config import TargetResolution, classify_agent
+from agentops.core.evaluators import EvaluatorPreset
+from agentops.pipeline.runtime import load_evaluator
+
+
+def _preset(class_name: str = "CoherenceEvaluator") -> EvaluatorPreset:
+    return EvaluatorPreset(
+        name=class_name,
+        class_name=class_name,
+        score_key="coherence",
+        input_mapping={"query": "$prompt", "response": "$prediction"},
+    )
+
+
+def _install_fake_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+    evaluator_cls: type[Any] | None = None,
+) -> type[Any]:
+    """Stub azure-ai-evaluation without importing the real Azure SDK."""
+
+    class CapturingEvaluator:
+        kwargs: Dict[str, Any] = {}
+
+        def __init__(self, **kwargs: Any) -> None:
+            type(self).kwargs = kwargs
+
+    installed_cls = evaluator_cls or CapturingEvaluator
+    fake_azure = types.ModuleType("azure")
+    fake_ai = types.ModuleType("azure.ai")
+    fake_evaluation = types.ModuleType("azure.ai.evaluation")
+    fake_azure.ai = fake_ai  # type: ignore[attr-defined]
+    fake_ai.evaluation = fake_evaluation  # type: ignore[attr-defined]
+    fake_evaluation.CoherenceEvaluator = installed_cls  # type: ignore[attr-defined]
+    fake_evaluation.FluencyEvaluator = installed_cls  # type: ignore[attr-defined]
+    fake_evaluation.SimilarityEvaluator = installed_cls  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "azure", fake_azure)
+    monkeypatch.setitem(sys.modules, "azure.ai", fake_ai)
+    monkeypatch.setitem(sys.modules, "azure.ai.evaluation", fake_evaluation)
+    return installed_cls
+
+
+def _configure_model_env(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    deployment: str,
+    override: str | None = None,
+) -> None:
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", deployment)
+    monkeypatch.delenv("AZURE_AI_MODEL_DEPLOYMENT_NAME", raising=False)
+    if override is None:
+        monkeypatch.delenv("AGENTOPS_EVALUATOR_REASONING_MODEL", raising=False)
+    else:
+        monkeypatch.setenv("AGENTOPS_EVALUATOR_REASONING_MODEL", override)
+
+
+def _clear_explicit_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+    monkeypatch.delenv("AZURE_OPENAI_DEPLOYMENT", raising=False)
+    monkeypatch.delenv("AZURE_AI_MODEL_DEPLOYMENT_NAME", raising=False)
+    monkeypatch.delenv("AGENTOPS_EVALUATOR_REASONING_MODEL", raising=False)
+
+
+def _load_with_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    deployment: str,
+    override: str | None = None,
+) -> Dict[str, Any]:
+    evaluator_cls = _install_fake_evaluation(monkeypatch)
+    _configure_model_env(monkeypatch, deployment=deployment, override=override)
+
+    load_evaluator(_preset())
+
+    return evaluator_cls.kwargs
+
+
+def _model_direct_target(deployment: str) -> TargetResolution:
+    return classify_agent(f"model:{deployment}")
+
+
+@pytest.mark.parametrize(
+    "deployment",
+    ["gpt-5.1", "GPT-5-Judge", "o1-preview", "o3-mini", "o4"],
+)
+def test_load_evaluator_marks_reasoning_deployments(
+    monkeypatch: pytest.MonkeyPatch,
+    deployment: str,
+) -> None:
+    kwargs = _load_with_deployment(monkeypatch, deployment=deployment)
+
+    assert kwargs["model_config"]["azure_deployment"] == deployment
+    assert kwargs["is_reasoning_model"] is True
+
+
+def test_load_evaluator_keeps_gpt_4o_mini_shape_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kwargs = _load_with_deployment(monkeypatch, deployment="gpt-4o-mini")
+
+    assert kwargs["model_config"]["azure_deployment"] == "gpt-4o-mini"
+    assert "is_reasoning_model" not in kwargs
+
+
+def test_model_direct_defaults_to_target_deployment_and_foundry_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evaluator_cls = _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://aifappframework.services.ai.azure.com/api/projects/models",
+    )
+
+    load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+    model_config = evaluator_cls.kwargs["model_config"]
+    assert model_config["azure_endpoint"] == (
+        "https://aifappframework.services.ai.azure.com"
+    )
+    assert model_config["azure_deployment"] == "gpt-5.1"
+    assert evaluator_cls.kwargs["is_reasoning_model"] is True
+
+
+def test_explicit_evaluator_env_overrides_model_direct_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evaluator_cls = _install_fake_evaluation(monkeypatch)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://target.services.ai.azure.com/api/projects/models",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://judge.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")
+    monkeypatch.delenv("AZURE_AI_MODEL_DEPLOYMENT_NAME", raising=False)
+    monkeypatch.delenv("AGENTOPS_EVALUATOR_REASONING_MODEL", raising=False)
+
+    load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+    model_config = evaluator_cls.kwargs["model_config"]
+    assert model_config["azure_endpoint"] == "https://judge.openai.azure.com"
+    assert model_config["azure_deployment"] == "gpt-4o-mini"
+    assert "is_reasoning_model" not in evaluator_cls.kwargs
+
+
+def test_model_direct_defaults_raise_when_foundry_endpoint_cannot_be_derived(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://aifappframework.services.ai.azure.com/projects/models",
+    )
+
+    with pytest.raises(RuntimeError, match="Cannot derive evaluator endpoint") as excinfo:
+        load_evaluator(_preset(), target=_model_direct_target("gpt-4o-mini"))
+
+    message = str(excinfo.value)
+    assert "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT" in message
+    assert "AZURE_OPENAI_ENDPOINT" in message
+    assert "AZURE_OPENAI_DEPLOYMENT" in message
+
+
+@pytest.mark.parametrize("override", ["1", "true", "yes", "on", " TRUE "])
+def test_reasoning_env_override_can_force_alias(
+    monkeypatch: pytest.MonkeyPatch,
+    override: str,
+) -> None:
+    kwargs = _load_with_deployment(
+        monkeypatch,
+        deployment="prod-judge-alias",
+        override=override,
+    )
+
+    assert kwargs["is_reasoning_model"] is True
+
+
+@pytest.mark.parametrize("override", ["0", "false", "no", "off", " OFF "])
+def test_reasoning_env_override_can_disable_detection(
+    monkeypatch: pytest.MonkeyPatch,
+    override: str,
+) -> None:
+    kwargs = _load_with_deployment(
+        monkeypatch,
+        deployment="gpt-5.1",
+        override=override,
+    )
+
+    assert "is_reasoning_model" not in kwargs
+
+
+def test_invalid_reasoning_env_override_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluation(monkeypatch)
+    _configure_model_env(
+        monkeypatch,
+        deployment="gpt-4o-mini",
+        override="maybe",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="AGENTOPS_EVALUATOR_REASONING_MODEL must be one of",
+    ):
+        load_evaluator(_preset())
+
+
+def test_rejecting_reasoning_kwarg_raises_without_dropping_model_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StrictEvaluator:
+        no_arg_call_count = 0
+
+        def __init__(self, *, model_config: Dict[str, str] | None = None) -> None:
+            if model_config is None:
+                type(self).no_arg_call_count += 1
+
+    _install_fake_evaluation(monkeypatch, StrictEvaluator)
+    _configure_model_env(monkeypatch, deployment="gpt-5.1")
+
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to initialize evaluator 'CoherenceEvaluator'",
+    ) as excinfo:
+        load_evaluator(_preset())
+
+    message = str(excinfo.value)
+    assert "model_config" in message
+    assert "is_reasoning_model" in message
+    assert "upgrade azure-ai-evaluation" in message
+    assert StrictEvaluator.no_arg_call_count == 0


### PR DESCRIPTION
Closes #126.

## Summary

Two related improvements to the AI-assisted evaluator runtime, surfaced while validating the model-direct tutorial (#126).

### Commit 1 — `feat(eval): auto-detect reasoning-model evaluator deployments`

Azure OpenAI's GPT-5 and o-series reasoning models reject the legacy `max_tokens` parameter and require `max_completion_tokens`. The `azure-ai-evaluation` SDK only switches its built-in evaluators to the new parameter when constructed with `is_reasoning_model=True`.

- Auto-detects deployments whose names start with `gpt-5`, `gpt5`, `o1`, `o3`, `o4` (case-insensitive).
- Manual override: `AGENTOPS_EVALUATOR_REASONING_MODEL=true|false` for aliased deployments.
- Documents the model-direct judge defaults in the tutorial.

### Commit 2 — `fix(eval): allow deployment-only judge override for Foundry projects`

Previously, switching the judge to a different deployment required setting **both** `AZURE_OPENAI_ENDPOINT` **and** `AZURE_OPENAI_DEPLOYMENT` — even when the judge lived in the same Foundry project as the target.

- `AZURE_OPENAI_DEPLOYMENT` (or `AZURE_AI_MODEL_DEPLOYMENT_NAME`) alone is now sufficient when `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` is set; the endpoint is reused from the Foundry project.
- Fully-separate Azure OpenAI judge resources still set both env vars (unchanged).
- Endpoint-only overrides still rejected so AgentOps never silently judges with the wrong deployment.
- Tutorial Step 1 reworded to show deployment-only as the common case.
- Adds a deployment-name lookup tip (Foundry suffixes deployment names with random IDs, e.g. `gpt-4.1-443723`).

## Verification

End-to-end runs against `aifappframework` Foundry project:

| Scenario | Target | Judge | Outcome |
| --- | --- | --- | --- |
| Tutorial as-documented | `gpt-5.1` | `gpt-5.1` (default) | ✅ exit 0, all thresholds passed |
| Reasoning auto-detect (positive) | `gpt-5.1` | `gpt-5.1` | ✅ `is_reasoning_model=True` injected, no `max_tokens` 400s |
| Reasoning auto-detect (negative) | `gpt-4.1-443723` | `gpt-4.1-443723` | ✅ flag not injected, legacy `max_tokens` path works |
| Deployment-only override | `gpt-5.1` | `gpt-4.1-443723` (`AZURE_AI_MODEL_DEPLOYMENT_NAME` only) | ✅ exit 0, judge uses Foundry-derived endpoint |

## Tests

- 4 new unit tests covering deployment-only override, alias env var, missing Foundry endpoint, and endpoint-only rejection.
- Full suite: **289 passed, 1 skipped** (unchanged skip count).

## Tutorial #126 status

Validated end-to-end. Two doc updates included; no further changes needed.