### PR TITLE
fix(workflow): auto-detect committed baseline in agentops-pr.yml (#132)

### DIFF
--- a/docs/tutorial-baseline-comparison.md
+++ b/docs/tutorial-baseline-comparison.md
@@ -83,15 +83,19 @@ similarity is good.
 ## 4. Wire into a PR check
 
 The `agentops-pr.yml` workflow shipped by `agentops workflow generate`
-already supports this — drop a baseline file in your repo (e.g.
-`.agentops/baseline/results.json`) and add this step:
+already supports this — drop a baseline file at
+`.agentops/baseline/results.json` in your repo and the PR gate
+auto-detects it (no workflow edit needed):
 
-```yaml
-- name: Run AgentOps eval against baseline
-  run: |
-    agentops eval run \
-      --baseline .agentops/baseline/results.json
+```bash
+mkdir -p .agentops/baseline
+cp .agentops/results/latest/results.json .agentops/baseline/results.json
+git add .agentops/baseline/results.json
+git commit -m "chore: capture AgentOps baseline"
 ```
+
+When the file is absent, the workflow runs without baseline comparison.
+When present, it runs `agentops eval run --baseline .agentops/baseline/results.json` automatically.
 
 When a PR causes a metric to regress past your threshold, the run
 exits `2` and the workflow fails, blocking merge until somebody

--- a/docs/tutorial-basic-foundry-agent.md
+++ b/docs/tutorial-basic-foundry-agent.md
@@ -38,9 +38,13 @@ If you see agent scores drop to 1.0 on questions that the model-direct handles a
 
 - Python 3.11+
 - Azure CLI (`az login`)
-- A Foundry project with a deployed agent
-- A model deployment in the same project (used as the judge model for SimilarityEvaluator)
-- `pip install "agentops-toolkit @ git+https://github.com/Azure/agentops.git@develop"`
+- A Foundry project with a deployed **named, versioned** agent (e.g.,
+  `qa-bot:1`). Legacy classic-portal agents identified only by an
+  `asst_*` ID are not supported by AgentOps today — recreate them as
+  named agents in the new Foundry experience.
+- A model deployment in the same project (used as the judge model for
+  AI-assisted evaluators such as SimilarityEvaluator).
+- `pip install "agentops-toolkit[foundry] @ git+https://github.com/Azure/agentops.git@develop"`
 
 ## Part 1: Create the agent in Foundry
 
@@ -69,12 +73,17 @@ Choose a model deployment (e.g., `gpt-5.1`) and save the agent.
 
 ### 3) Note the agent identifier
 
-After saving, you need the agent's identifier for the run config. There are two types:
+After saving, you need the agent's identifier for the run config. AgentOps
+uses the Foundry **Responses API**, which addresses agents by
+`name:version` — for example `qa-bot:1` or `customer-support:3`.
 
-- **Named agents** (new Foundry experience): use the agent name, optionally with a version — e.g., `my-agent` or `my-agent:3`
-- **Legacy agents** (asst_ prefix): use the full ID — e.g., `asst_ftDQySPlKUwcgR1eiXEzUEO5`
-
-AgentOps handles both. Named agents use the Foundry Responses API; legacy agents use the Threads API.
+> **Legacy `asst_*` agents (classic Foundry):** agents created in the
+> classic Foundry portal are identified by an `asst_*` ID and are
+> served by the older Threads/Assistants API. AgentOps does **not**
+> support that API path today. If you have a legacy agent, recreate it
+> as a named, versioned agent in the new Foundry experience (UI → Build
+> → Agents → New, or via `azure-ai-projects>=2.0.0`'s
+> `project.agents.create_version()`).
 
 ## Part 2: Set up AgentOps
 
@@ -84,17 +93,28 @@ AgentOps handles both. Named agents use the Foundry Responses API; legacy agents
 az login
 ```
 
-### 2) Set the project endpoint
+### 2) Set the project endpoint and judge deployment
 
 PowerShell:
 ```powershell
 $env:AZURE_AI_FOUNDRY_PROJECT_ENDPOINT = "https://<resource>.services.ai.azure.com/api/projects/<project>"
+$env:AZURE_AI_MODEL_DEPLOYMENT_NAME = "gpt-5.1"   # judge for AI-assisted evaluators
 ```
 
 Bash/zsh:
 ```bash
 export AZURE_AI_FOUNDRY_PROJECT_ENDPOINT="https://<resource>.services.ai.azure.com/api/projects/<project>"
+export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-5.1"   # judge for AI-assisted evaluators
 ```
+
+`AZURE_AI_MODEL_DEPLOYMENT_NAME` selects the judge deployment that
+AI-assisted evaluators (Coherence, Similarity, etc.) call. AgentOps
+reuses the Foundry project endpoint to reach it, so you don't also
+need `AZURE_OPENAI_ENDPOINT` unless the judge lives in a different
+Azure OpenAI resource. Use the **exact deployment name** as it appears
+in Foundry — names are often suffixed with random IDs
+(e.g. `gpt-4.1-443723`). List your deployments with
+`az cognitiveservices account deployment list --resource-group <rg> --name <foundry-resource> -o table`.
 
 ### 3) Initialize the workspace
 
@@ -108,31 +128,38 @@ Open `agentops.yaml` at your project root and point it at your agent:
 
 ```yaml
 version: 1
-agent: "my-agent:1"                       # ← your agent name:version (or asst_ ID)
-dataset: .agentops/data/smoke-agent-tools.jsonl
+agent: "qa-bot:1"                         # ← your agent name:version
+dataset: .agentops/data/smoke.jsonl
 thresholds:
   similarity: ">=3"
   avg_latency_seconds: "<=20"
 ```
 
 Key points:
-- `agent` is a single string. AgentOps recognizes the `name:version` shape
-  and routes the run to the Foundry Agent Service automatically.
-- The judge model used by AI-assisted evaluators (SimilarityEvaluator) is
-  taken from `AZURE_OPENAI_DEPLOYMENT` (set in Part 2).
+- `agent` is a single `name:version` string. AgentOps routes the run
+  through the Foundry Responses API automatically.
+- The judge model used by AI-assisted evaluators (SimilarityEvaluator,
+  CoherenceEvaluator, etc.) comes from `AZURE_AI_MODEL_DEPLOYMENT_NAME`
+  (set in Part 2).
 - Evaluators are auto-selected from the dataset row shape — `input` +
-  `expected` triggers `SimilarityEvaluator`. No `bundle` to maintain.
+  `expected` triggers the model-quality set (Similarity, Coherence,
+  Fluency, F1Score, plus average latency). No `bundle` to maintain.
 
 ## Part 4: Review the dataset
 
-The sample dataset at `.agentops/data/smoke-agent-tools.jsonl` contains five prompts designed for an agent with tool capabilities:
+`agentops init` already created `.agentops/data/smoke.jsonl` with three
+short factual prompts:
 
 ```jsonl
-{"id":"1","input":"What is the weather in Seattle today?","expected":"I'll check the weather for Seattle..."}
-{"id":"2","input":"Convert 100 USD to EUR","expected":"100 USD is approximately 92 EUR..."}
+{"input": "Answer with exactly this sentence: Paris is the capital of France...", "expected": "Paris is the capital of France..."}
+{"input": "Answer with exactly this sentence: Mars is known as the Red Planet...", "expected": "Mars is known as the Red Planet..."}
+{"input": "Answer with exactly this sentence: Water has the chemical formula H2O...", "expected": "Water has the chemical formula H2O..."}
 ```
 
-These prompts include questions that might trigger tool calls (weather, currency conversion, search). If your agent does not have these tools, it will answer based on its knowledge, which may score lower on similarity. That is expected — the evaluation measures what the agent *actually does*, not what it could do with the right tools.
+These rows are intentionally easy — short, deterministic answers — so
+the first run focuses on proving the AgentOps loop works end-to-end
+rather than debugging subjective wording differences. Replace the rows
+with realistic prompts for your application once the smoke test passes.
 
 ### Adapting the dataset to your agent
 
@@ -211,7 +238,7 @@ The RAG scenario uses GroundednessEvaluator instead of SimilarityEvaluator becau
 
 - **Cloud vs local mode**: By default, AgentOps uses Foundry Cloud Evaluation with the `azure_ai_evaluator` API. Set `AGENTOPS_FOUNDRY_MODE=local` to invoke the agent row-by-row and run evaluators locally (requires `pip install azure-ai-evaluation`).
 - **Authentication**: `DefaultAzureCredential` handles auth automatically. For local dev, use `az login`. For CI, set `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
-- **Named vs legacy agents**: Named agents (e.g., `my-agent:3`) use the Responses API. Legacy agents (`asst_*`) use the Threads API. Both work transparently.
+- **Named agents only**: AgentOps targets the Foundry Responses API, which addresses agents by `name:version` (e.g., `qa-bot:1`). Legacy classic-portal agents identified by an `asst_*` ID are not supported today; recreate them as named agents in the new Foundry experience.
 - **Exit codes**: `0` = all thresholds passed, `2` = threshold failures, `1` = error.
 
 ## Next steps

--- a/docs/tutorial-model-direct.md
+++ b/docs/tutorial-model-direct.md
@@ -23,14 +23,22 @@ project endpoint to configure AI-assisted evaluators by default: the judge
 deployment defaults to the same deployment named in `agent: "model:<deployment>"`,
 and the evaluator endpoint is derived from the project URL.
 
-If you want a separate judge deployment, set both optional overrides before
-running:
+If you want a separate judge deployment, set just the deployment name —
+AgentOps reuses your Foundry project endpoint to find it:
+
+```bash
+# Same Foundry project, different deployment as judge (most common):
+export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4.1-443723"
+# or, equivalently:
+# export AZURE_OPENAI_DEPLOYMENT="gpt-4.1-443723"
+```
+
+To point the judge at a fully separate Azure OpenAI resource (advanced),
+also set `AZURE_OPENAI_ENDPOINT`:
 
 ```bash
 export AZURE_OPENAI_ENDPOINT="https://<judge-resource>.openai.azure.com"
 export AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
-# Or, if your environment uses the Foundry deployment variable:
-# export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"
 ```
 
 AgentOps automatically enables the `azure-ai-evaluation` reasoning-model token
@@ -50,6 +58,20 @@ classifies it as `model_direct`, sends each row's `input` straight to
 the target deployment, and skips agent infrastructure entirely. Unless you set
 the optional evaluator overrides, AI-assisted evaluators such as Coherence,
 Fluency, and Similarity use this same deployment as the judge.
+
+> **Tip — use the exact deployment name, not the model name.** Foundry often
+> suffixes auto-created deployments with a random id (e.g. `gpt-4.1-443723`,
+> `gpt-4.1-mini-642951`). Using the bare model name will return
+> `DeploymentNotFound` (HTTP 404). List your deployments with:
+>
+> ```bash
+> az cognitiveservices account deployment list \
+>   --resource-group <your-resource-group> \
+>   --name <your-foundry-resource> \
+>   --query "[].{name:name, model:properties.model.name}" -o table
+> ```
+>
+> Use the value in the **`name`** column for `agent: "model:<deployment>"`.
 
 ## 3. Dataset shape
 
@@ -102,10 +124,10 @@ Exit code `0` = all thresholds passed, `2` = at least one failed,
   `AGENTOPS_EVALUATOR_REASONING_MODEL=true`. If an alias is incorrectly
   detected as reasoning, set `AGENTOPS_EVALUATOR_REASONING_MODEL=false`.
   Accepted values are `1`, `true`, `yes`, `on`, `0`, `false`, `no`, and `off`.
-- **Separate judge override errors**: if you set `AZURE_OPENAI_ENDPOINT`, also
-  set `AZURE_OPENAI_DEPLOYMENT` or `AZURE_AI_MODEL_DEPLOYMENT_NAME`; partial
-  overrides are rejected so AgentOps does not silently judge with the wrong
-  deployment.
+- **Separate judge override errors**: setting `AZURE_OPENAI_ENDPOINT` without
+  a deployment is rejected, and setting only a deployment without
+  `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` is rejected too — partial overrides
+  would silently judge with the wrong endpoint.
 
 ## 6. Compare two model deployments
 

--- a/docs/tutorial-model-direct.md
+++ b/docs/tutorial-model-direct.md
@@ -6,7 +6,7 @@ model can't answer your dataset, no agent prompt will save it.
 
 ## Prerequisites
 
-- Python 3.11+ and `pip install "agentops-toolkit @ git+https://github.com/Azure/agentops.git@develop"`
+- Python 3.11+ and `pip install "agentops-toolkit[foundry] @ git+https://github.com/Azure/agentops.git@develop"`
 - A Foundry project with at least one model deployment
 - `az login` (AgentOps uses `DefaultAzureCredential`)
 
@@ -17,17 +17,39 @@ agentops init
 export AZURE_AI_FOUNDRY_PROJECT_ENDPOINT="https://<resource>.services.ai.azure.com/api/projects/<project>"
 ```
 
+Use `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` for the Foundry project that hosts
+the target deployment. For model-direct Foundry runs, AgentOps also uses this
+project endpoint to configure AI-assisted evaluators by default: the judge
+deployment defaults to the same deployment named in `agent: "model:<deployment>"`,
+and the evaluator endpoint is derived from the project URL.
+
+If you want a separate judge deployment, set both optional overrides before
+running:
+
+```bash
+export AZURE_OPENAI_ENDPOINT="https://<judge-resource>.openai.azure.com"
+export AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
+# Or, if your environment uses the Foundry deployment variable:
+# export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4o-mini"
+```
+
+AgentOps automatically enables the `azure-ai-evaluation` reasoning-model token
+path for evaluator deployments whose names begin with `gpt-5`, `o1`, `o3`, or
+`o4`, so deployments such as `gpt-5.1` can be used for judging.
+
 ## 2. Edit `agentops.yaml`
 
 ```yaml
 version: 1
-agent: "model:gpt-4o"           # <-- key part: the `model:` prefix
+agent: "model:gpt-4o"           # target deployment; key part is `model:`
 dataset: .agentops/data/smoke.jsonl
 ```
 
 `agent: "model:<deployment>"` is the model-direct shape — AgentOps
 classifies it as `model_direct`, sends each row's `input` straight to
-the deployment, and skips agent infrastructure entirely.
+the target deployment, and skips agent infrastructure entirely. Unless you set
+the optional evaluator overrides, AI-assisted evaluators such as Coherence,
+Fluency, and Similarity use this same deployment as the judge.
 
 ## 3. Dataset shape
 
@@ -65,7 +87,27 @@ Outputs land in `.agentops/results/<timestamp>/` and are mirrored to `.agentops/
 Exit code `0` = all thresholds passed, `2` = at least one failed,
 `1` = configuration / runtime error.
 
-## 5. Compare two model deployments
+## 5. Troubleshooting
+
+- **Project endpoint shape errors**: for the default judge configuration,
+  `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` should look like
+  `https://<resource>.services.ai.azure.com/api/projects/<project>`. AgentOps
+  strips `/api/projects/<project>` to derive the evaluator data-plane endpoint.
+  If your Foundry endpoint has a different shape, set `AZURE_OPENAI_ENDPOINT`
+  and `AZURE_OPENAI_DEPLOYMENT` explicitly for the judge deployment.
+- **`max_tokens` / `max_completion_tokens` errors**: AgentOps automatically
+  treats evaluator deployments whose names begin with `gpt-5`, `o1`, `o3`, or
+  `o4` as reasoning models. If your deployment uses an opaque alias for one of
+  those models and `azure-ai-evaluation` still sends legacy `max_tokens`, set
+  `AGENTOPS_EVALUATOR_REASONING_MODEL=true`. If an alias is incorrectly
+  detected as reasoning, set `AGENTOPS_EVALUATOR_REASONING_MODEL=false`.
+  Accepted values are `1`, `true`, `yes`, `on`, `0`, `false`, `no`, and `off`.
+- **Separate judge override errors**: if you set `AZURE_OPENAI_ENDPOINT`, also
+  set `AZURE_OPENAI_DEPLOYMENT` or `AZURE_AI_MODEL_DEPLOYMENT_NAME`; partial
+  overrides are rejected so AgentOps does not silently judge with the wrong
+  deployment.
+
+## 6. Compare two model deployments
 
 ```bash
 # Baseline run on gpt-4o

--- a/docs/tutorial-quickstart.md
+++ b/docs/tutorial-quickstart.md
@@ -23,8 +23,7 @@ The rest of the toolkit (legacy bundles, multi-file workspaces, custom adapters)
   - A **Foundry hosted endpoint** (`https://*.services.ai.azure.com/.../agents/<id>`).
   - A **generic HTTP/JSON agent** deployed anywhere (ACA, AKS, your own server).
   - A **raw Foundry model deployment** (e.g. `gpt-4o`).
-- For Foundry targets: `az login` (or a service principal) and `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` set.
-- For AI-assisted evaluators (Coherence, Groundedness, etc.): `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_DEPLOYMENT` set.
+- For Foundry targets: `az login` (or a service principal) and `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` set. AI-assisted evaluators (Coherence, Similarity, etc.) automatically default to the target deployment as the judge — no extra env vars required. Set `AZURE_OPENAI_ENDPOINT` + `AZURE_OPENAI_DEPLOYMENT` only if you want a fully separate Azure OpenAI judge resource.
 
 ## 1. Install
 
@@ -40,11 +39,14 @@ python -m pip install "agentops-toolkit @ git+https://github.com/Azure/agentops.
 agentops init
 ```
 
-This creates two files:
+This creates three files:
 
 - `agentops.yaml` — your evaluation config (3 lines + comments).
 - `.agentops/data/smoke.jsonl` — a 3-row seed dataset with short,
   deterministic factual answers.
+- `.gitignore` (project root) — only created if one does not already
+  exist; covers `.venv/`, Python build artifacts, and
+  `.agentops/results/` so run outputs are not accidentally committed.
 
 ## 3. Configure your agent
 
@@ -126,12 +128,13 @@ You did not pick evaluators — AgentOps inferred them:
 - **If your dataset rows include `context`:** Groundedness, Relevance, Retrieval, ResponseCompleteness.
 - **If your dataset rows include `tool_calls` or `tool_definitions`:** TaskCompletion, ToolCallAccuracy, IntentResolution, TaskAdherence.
 
-To override the auto-selection, list evaluator class names in `agentops.yaml`:
+To override the auto-selection, list evaluator class names in `agentops.yaml`
+under `name:` keys:
 
 ```yaml
 evaluators:
-  - GroundednessEvaluator
-  - CoherenceEvaluator
+  - name: GroundednessEvaluator
+  - name: CoherenceEvaluator
 ```
 
 ## Where to go next

--- a/docs/tutorial-rag.md
+++ b/docs/tutorial-rag.md
@@ -16,11 +16,15 @@ Goal: evaluate a **Foundry agent with retrieval** using **GroundednessEvaluator*
 1. Open `https://ai.azure.com`.
 2. Create a new Foundry project (or open an existing one).
 
-### 2) Create an agent with retrieval
+### 2) Create an agent
 
 1. In the project, go to **Build > Agents**.
 2. Click **New agent**.
-3. Add a **knowledge base** or **file search** tool so the agent retrieves documents.
+3. *(Optional)* Add a **knowledge base** or **file search** tool if you
+   want to evaluate your full production retrieval pipeline. For learning
+   AgentOps and gating against hallucinations, a plain prompt agent also
+   works — the evaluator scores the agent's final answer against the
+   reference context you supply in the dataset.
 
 ### 3) Add agent instructions
 
@@ -115,13 +119,26 @@ seed file with something like:
 Each row has:
 - `input` — the question sent to the agent
 - `expected` — the reference answer
-- `context` — the retrieved document context that `GroundednessEvaluator` uses
+- `context` — the reference passages that `GroundednessEvaluator` uses
 
 When any row has a `context` field, the RAG evaluator set is added
 automatically.
 
-> **Tip**: For a real RAG scenario, populate the `context` field with
-> actual retrieved passages from your knowledge base.
+> **The `context` field is always required.** AgentOps maps the dataset's
+> `context` column directly into `GroundednessEvaluator`. The evaluator
+> scores the agent's answer against this reference context — populate it
+> with the canonical passages you want the agent's answers to align with.
+
+> **Populating `context` for production datasets.** Two practical
+> workflows:
+>
+> 1. **Manual reference passages.** Hand-pick the canonical passages
+>    each question should be answered from. Best for curated, stable
+>    golden datasets.
+> 2. **Pre-script retrieval.** Query your knowledge base (Azure AI
+>    Search, etc.) for each test question with your own script, capture
+>    the top-K passages, and write them into the JSONL `context` field.
+>    Best when curating manually doesn't scale.
 
 ## Part 5: Run evaluation
 
@@ -160,3 +177,7 @@ For model-only evaluation (no retrieval), see the [Model-Direct Tutorial](tutori
   one deployment, this is optional.
 - Authentication is automatic via `DefaultAzureCredential`.
 - For local development, `az login` is enough.
+- **Named agents only**: AgentOps targets the Foundry Responses API,
+  which addresses agents by `name:version`. Legacy classic-portal
+  `asst_*` IDs are not supported (see
+  [#143](https://github.com/Azure/agentops/issues/143)).

--- a/src/agentops/pipeline/runtime.py
+++ b/src/agentops/pipeline/runtime.py
@@ -153,20 +153,32 @@ def _model_config(
     api_version = os.getenv("AZURE_OPENAI_API_VERSION") or "2025-04-01-preview"
 
     if endpoint or deployment:
-        missing = []
-        if not endpoint:
-            missing.append("AZURE_OPENAI_ENDPOINT")
         if not deployment:
-            missing.append("AZURE_OPENAI_DEPLOYMENT")
-        if missing:
             raise RuntimeError(
-                "AI-assisted evaluator override is incomplete. Missing "
-                "environment variables: "
-                + ", ".join(missing)
-                + ". Set both AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT "
-                "(or AZURE_AI_MODEL_DEPLOYMENT_NAME), or unset them to use the "
-                "Foundry model-direct defaults."
+                "AI-assisted evaluator override is incomplete. "
+                "AZURE_OPENAI_ENDPOINT was set but no evaluator deployment "
+                "was provided. Set AZURE_OPENAI_DEPLOYMENT (or "
+                "AZURE_AI_MODEL_DEPLOYMENT_NAME), or unset "
+                "AZURE_OPENAI_ENDPOINT to use the Foundry model-direct defaults."
             )
+        if not endpoint:
+            # Deployment-only override: keep the Foundry-derived endpoint so
+            # users can pick a separate judge inside the same Foundry project
+            # without rewriting URLs by hand. Falls back to a clear error if
+            # we have no Foundry project endpoint to derive from.
+            project_endpoint = foundry_project_endpoint or os.getenv(
+                "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT"
+            )
+            if not project_endpoint:
+                raise RuntimeError(
+                    "AI-assisted evaluator override is incomplete. "
+                    f"AZURE_OPENAI_DEPLOYMENT={deployment!r} was set but "
+                    "AgentOps cannot derive an evaluator endpoint without "
+                    "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT. Set "
+                    "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT, or also set "
+                    "AZURE_OPENAI_ENDPOINT for a fully separate judge resource."
+                )
+            endpoint = _foundry_data_plane_endpoint(project_endpoint)
     else:
         endpoint, deployment = _default_model_direct_config(
             target=target,

--- a/src/agentops/pipeline/runtime.py
+++ b/src/agentops/pipeline/runtime.py
@@ -12,10 +12,13 @@ import importlib
 import inspect
 import json
 import os
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse, urlunparse
 
+from agentops.core.agentops_config import TargetResolution
 from agentops.core.evaluators import EvaluatorPreset
 from agentops.core.results import RowMetric
 
@@ -44,6 +47,15 @@ _SAFETY = {
     "ProtectedMaterialEvaluator",
 }
 
+_REASONING_MODEL_ENV = "AGENTOPS_EVALUATOR_REASONING_MODEL"
+_REASONING_MODEL_TRUTHY = {"1", "true", "yes", "on"}
+_REASONING_MODEL_FALSEY = {"0", "false", "no", "off"}
+_REASONING_MODEL_VALUES = "1, true, yes, on, 0, false, no, off"
+_REASONING_DEPLOYMENT_RE = re.compile(
+    r"^(?:gpt[-_]?5(?:$|[^a-z0-9])|o[134](?:$|[^a-z0-9]))",
+    re.IGNORECASE,
+)
+
 
 @dataclass
 class EvaluatorRuntime:
@@ -64,11 +76,75 @@ def _credential() -> Any:
     return DefaultAzureCredential(exclude_developer_cli_credential=True)
 
 
-def _model_config() -> Dict[str, str]:
-    endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
-    deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT") or os.getenv(
+def _explicit_evaluator_deployment() -> Optional[str]:
+    return os.getenv("AZURE_OPENAI_DEPLOYMENT") or os.getenv(
         "AZURE_AI_MODEL_DEPLOYMENT_NAME"
     )
+
+
+def _foundry_data_plane_endpoint(project_endpoint: str) -> str:
+    raw = project_endpoint.strip().rstrip("/")
+    parsed = urlparse(raw)
+    if not parsed.scheme or not parsed.netloc:
+        raise RuntimeError(
+            "Cannot derive evaluator endpoint from "
+            "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT because it is not an absolute URL. "
+            "Set AZURE_AI_FOUNDRY_PROJECT_ENDPOINT to a URL like "
+            "'https://<resource>.services.ai.azure.com/api/projects/<project>', "
+            "or set AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT for an "
+            "explicit evaluator deployment."
+        )
+
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if (
+        len(segments) >= 3
+        and segments[0].lower() == "api"
+        and segments[1].lower() == "projects"
+        and segments[2]
+    ):
+        return urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+
+    raise RuntimeError(
+        "Cannot derive evaluator endpoint from "
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT. Expected a Foundry project URL like "
+        "'https://<resource>.services.ai.azure.com/api/projects/<project>'. "
+        "Set AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT if you want to "
+        "use a separate evaluator deployment."
+    )
+
+
+def _default_model_direct_config(
+    *,
+    target: Optional[TargetResolution],
+    foundry_project_endpoint: Optional[str],
+) -> tuple[str, str]:
+    if target is None or target.kind != "model_direct" or not target.deployment:
+        raise RuntimeError(
+            "AI-assisted evaluators require an evaluator model. Set "
+            "AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT, or use a "
+            "Foundry model-direct target like agent: 'model:<deployment>' so "
+            "AgentOps can default the evaluator deployment to the target model."
+        )
+    endpoint = foundry_project_endpoint or os.getenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT")
+    if not endpoint:
+        raise RuntimeError(
+            "AI-assisted evaluators can default the judge deployment to "
+            f"{target.raw!r}, but AZURE_AI_FOUNDRY_PROJECT_ENDPOINT is required "
+            "to derive the evaluator endpoint. Set "
+            "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT, or set AZURE_OPENAI_ENDPOINT "
+            "and AZURE_OPENAI_DEPLOYMENT for an explicit evaluator deployment."
+        )
+
+    return _foundry_data_plane_endpoint(endpoint), target.deployment
+
+
+def _model_config(
+    *,
+    target: Optional[TargetResolution] = None,
+    foundry_project_endpoint: Optional[str] = None,
+) -> Dict[str, str]:
+    endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+    deployment = _explicit_evaluator_deployment()
     # The New Foundry "AI Services" inference endpoint rejects the
     # azure-ai-evaluation SDK's stock api-version with
     # ``BadRequest: API version not supported``. Default to a version
@@ -76,15 +152,25 @@ def _model_config() -> Dict[str, str]:
     # Azure OpenAI; allow override via AZURE_OPENAI_API_VERSION.
     api_version = os.getenv("AZURE_OPENAI_API_VERSION") or "2025-04-01-preview"
 
-    missing = []
-    if not endpoint:
-        missing.append("AZURE_OPENAI_ENDPOINT")
-    if not deployment:
-        missing.append("AZURE_OPENAI_DEPLOYMENT")
-    if missing:
-        raise RuntimeError(
-            "AI-assisted evaluators require an evaluator model. "
-            "Missing environment variables: " + ", ".join(missing)
+    if endpoint or deployment:
+        missing = []
+        if not endpoint:
+            missing.append("AZURE_OPENAI_ENDPOINT")
+        if not deployment:
+            missing.append("AZURE_OPENAI_DEPLOYMENT")
+        if missing:
+            raise RuntimeError(
+                "AI-assisted evaluator override is incomplete. Missing "
+                "environment variables: "
+                + ", ".join(missing)
+                + ". Set both AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT "
+                "(or AZURE_AI_MODEL_DEPLOYMENT_NAME), or unset them to use the "
+                "Foundry model-direct defaults."
+            )
+    else:
+        endpoint, deployment = _default_model_direct_config(
+            target=target,
+            foundry_project_endpoint=foundry_project_endpoint,
         )
 
     config: Dict[str, str] = {
@@ -93,6 +179,33 @@ def _model_config() -> Dict[str, str]:
         "api_version": api_version,
     }
     return config
+
+
+def _reasoning_model_override() -> Optional[bool]:
+    raw = os.getenv(_REASONING_MODEL_ENV)
+    if raw is None:
+        return None
+
+    value = raw.strip().lower()
+    if value in _REASONING_MODEL_TRUTHY:
+        return True
+    if value in _REASONING_MODEL_FALSEY:
+        return False
+    raise RuntimeError(
+        f"{_REASONING_MODEL_ENV} must be one of {_REASONING_MODEL_VALUES}; "
+        f"got {raw!r}."
+    )
+
+
+def _evaluator_is_reasoning_model(deployment: str) -> bool:
+    override = _reasoning_model_override()
+    if override is not None:
+        return override
+
+    # gpt-5 and o-series deployments require max_completion_tokens in current
+    # Azure OpenAI APIs. The SDK converts legacy prompty max_tokens only when
+    # evaluator classes receive is_reasoning_model=True.
+    return bool(_REASONING_DEPLOYMENT_RE.match(deployment.strip()))
 
 
 def _project_endpoint() -> str:
@@ -107,7 +220,12 @@ def _project_endpoint() -> str:
 _LATENCY_SENTINEL = object()
 
 
-def load_evaluator(preset: EvaluatorPreset) -> EvaluatorRuntime:
+def load_evaluator(
+    preset: EvaluatorPreset,
+    *,
+    target: Optional[TargetResolution] = None,
+    foundry_project_endpoint: Optional[str] = None,
+) -> EvaluatorRuntime:
     """Instantiate one evaluator. Raises a clear error if the SDK is missing."""
     if preset.class_name == "_latency":
         return EvaluatorRuntime(preset=preset, callable=_LATENCY_SENTINEL)
@@ -128,22 +246,50 @@ def load_evaluator(preset: EvaluatorPreset) -> EvaluatorRuntime:
 
     init_kwargs: Dict[str, Any] = {}
     if preset.class_name in _AI_ASSISTED:
-        init_kwargs["model_config"] = _model_config()
+        model_config = _model_config(
+            target=target,
+            foundry_project_endpoint=foundry_project_endpoint,
+        )
+        init_kwargs["model_config"] = model_config
+        if _evaluator_is_reasoning_model(model_config["azure_deployment"]):
+            init_kwargs["is_reasoning_model"] = True
     if preset.class_name in _SAFETY:
         init_kwargs["azure_ai_project"] = _project_endpoint()
         init_kwargs["credential"] = _credential()
 
     try:
         instance = cls(**init_kwargs) if inspect.isclass(cls) else cls
-    except TypeError:
+    except TypeError as exc:
+        if init_kwargs:
+            kwarg_names = ", ".join(sorted(init_kwargs))
+            raise RuntimeError(
+                f"Failed to initialize evaluator {preset.class_name!r} with "
+                f"required configuration ({kwarg_names}). AgentOps will not "
+                "retry without that configuration. If this happens with a "
+                "GPT-5 or o-series evaluator deployment, upgrade "
+                "azure-ai-evaluation to a version that supports "
+                "is_reasoning_model."
+            ) from exc
         # Some evaluators reject unexpected kwargs (e.g. F1ScoreEvaluator).
         instance = cls() if inspect.isclass(cls) else cls
 
     return EvaluatorRuntime(preset=preset, callable=instance)
 
 
-def load_evaluators(presets: List[EvaluatorPreset]) -> List[EvaluatorRuntime]:
-    return [load_evaluator(preset) for preset in presets]
+def load_evaluators(
+    presets: List[EvaluatorPreset],
+    *,
+    target: Optional[TargetResolution] = None,
+    foundry_project_endpoint: Optional[str] = None,
+) -> List[EvaluatorRuntime]:
+    return [
+        load_evaluator(
+            preset,
+            target=target,
+            foundry_project_endpoint=foundry_project_endpoint,
+        )
+        for preset in presets
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/src/agentops/templates/workflows/agentops-pr.yml
+++ b/src/agentops/templates/workflows/agentops-pr.yml
@@ -74,7 +74,17 @@ jobs:
           AZURE_OPENAI_DEPLOYMENT: ${{ vars.AZURE_OPENAI_DEPLOYMENT }}
         run: |
           set +e
-          agentops eval run --config "${{ inputs.config || 'agentops.yaml' }}"
+          # Auto-detect a committed baseline so the PR gate becomes a
+          # regression check when .agentops/baseline/results.json is present.
+          # Drop or refresh that file with `cp .agentops/results/latest/results.json .agentops/baseline/results.json`.
+          BASELINE_ARG=""
+          if [ -f .agentops/baseline/results.json ]; then
+            BASELINE_ARG="--baseline .agentops/baseline/results.json"
+            echo "Using baseline: .agentops/baseline/results.json"
+          else
+            echo "No .agentops/baseline/results.json found; running without baseline comparison."
+          fi
+          agentops eval run --config "${{ inputs.config || 'agentops.yaml' }}" $BASELINE_ARG
           ec=$?
           echo "exit_code=$ec" >> "$GITHUB_OUTPUT"
           if [ $ec -eq 0 ]; then

--- a/tests/unit/test_cicd.py
+++ b/tests/unit/test_cicd.py
@@ -160,6 +160,19 @@ def test_pr_template_triggers_and_no_environment(tmp_path: Path) -> None:
     assert "<!-- agentops-pr-report -->" in content
 
 
+def test_pr_template_auto_detects_committed_baseline(tmp_path: Path) -> None:
+    """The shipped PR workflow turns into a regression gate when a baseline
+    file is committed at ``.agentops/baseline/results.json``."""
+    generate_cicd_workflows(directory=tmp_path, kinds=["pr"])
+    content = (tmp_path / _PR_PATH).read_text(encoding="utf-8")
+
+    # Baseline auto-detection: the run step checks for the committed file
+    # and passes --baseline only when it exists.
+    assert ".agentops/baseline/results.json" in content
+    assert "--baseline" in content
+    assert "$BASELINE_ARG" in content
+
+
 def test_dev_template_triggers_and_environment(tmp_path: Path) -> None:
     generate_cicd_workflows(directory=tmp_path, kinds=["dev"])
     content = (tmp_path / _DEV_PATH).read_text(encoding="utf-8")

--- a/tests/unit/test_runtime_reasoning_model.py
+++ b/tests/unit/test_runtime_reasoning_model.py
@@ -154,6 +154,73 @@ def test_explicit_evaluator_env_overrides_model_direct_defaults(
     assert "is_reasoning_model" not in evaluator_cls.kwargs
 
 
+def test_deployment_only_override_keeps_foundry_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A separate judge inside the same Foundry project needs only a deployment."""
+    evaluator_cls = _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://aifappframework.services.ai.azure.com/api/projects/models",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1-443723")
+
+    load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+    model_config = evaluator_cls.kwargs["model_config"]
+    assert model_config["azure_endpoint"] == (
+        "https://aifappframework.services.ai.azure.com"
+    )
+    assert model_config["azure_deployment"] == "gpt-4.1-443723"
+    # gpt-4.1 is not a reasoning model.
+    assert "is_reasoning_model" not in evaluator_cls.kwargs
+
+
+def test_deployment_only_override_via_foundry_alias_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AZURE_AI_MODEL_DEPLOYMENT_NAME is the Foundry-style alias and is sufficient."""
+    evaluator_cls = _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://aifappframework.services.ai.azure.com/api/projects/models",
+    )
+    monkeypatch.setenv("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4.1-443723")
+
+    load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+    model_config = evaluator_cls.kwargs["model_config"]
+    assert model_config["azure_endpoint"] == (
+        "https://aifappframework.services.ai.azure.com"
+    )
+    assert model_config["azure_deployment"] == "gpt-4.1-443723"
+
+
+def test_deployment_only_override_requires_foundry_project_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.delenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT", raising=False)
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1-443723")
+
+    with pytest.raises(RuntimeError, match="cannot derive an evaluator endpoint"):
+        load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+
+def test_endpoint_only_override_still_requires_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://judge.openai.azure.com")
+
+    with pytest.raises(RuntimeError, match="no evaluator deployment"):
+        load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+
 def test_model_direct_defaults_raise_when_foundry_endpoint_cannot_be_derived(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_runtime_reasoning_model.py
+++ b/tests/unit/test_runtime_reasoning_model.py
@@ -1,0 +1,244 @@
+"""Unit tests for AI-assisted evaluator reasoning-model compatibility."""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any, Dict
+
+import pytest
+
+from agentops.core.agentops_config import TargetResolution, classify_agent
+from agentops.core.evaluators import EvaluatorPreset
+from agentops.pipeline.runtime import load_evaluator
+
+
+def _preset(class_name: str = "CoherenceEvaluator") -> EvaluatorPreset:
+    return EvaluatorPreset(
+        name=class_name,
+        class_name=class_name,
+        score_key="coherence",
+        input_mapping={"query": "$prompt", "response": "$prediction"},
+    )
+
+
+def _install_fake_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+    evaluator_cls: type[Any] | None = None,
+) -> type[Any]:
+    """Stub azure-ai-evaluation without importing the real Azure SDK."""
+
+    class CapturingEvaluator:
+        kwargs: Dict[str, Any] = {}
+
+        def __init__(self, **kwargs: Any) -> None:
+            type(self).kwargs = kwargs
+
+    installed_cls = evaluator_cls or CapturingEvaluator
+    fake_azure = types.ModuleType("azure")
+    fake_ai = types.ModuleType("azure.ai")
+    fake_evaluation = types.ModuleType("azure.ai.evaluation")
+    fake_azure.ai = fake_ai  # type: ignore[attr-defined]
+    fake_ai.evaluation = fake_evaluation  # type: ignore[attr-defined]
+    fake_evaluation.CoherenceEvaluator = installed_cls  # type: ignore[attr-defined]
+    fake_evaluation.FluencyEvaluator = installed_cls  # type: ignore[attr-defined]
+    fake_evaluation.SimilarityEvaluator = installed_cls  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "azure", fake_azure)
+    monkeypatch.setitem(sys.modules, "azure.ai", fake_ai)
+    monkeypatch.setitem(sys.modules, "azure.ai.evaluation", fake_evaluation)
+    return installed_cls
+
+
+def _configure_model_env(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    deployment: str,
+    override: str | None = None,
+) -> None:
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", deployment)
+    monkeypatch.delenv("AZURE_AI_MODEL_DEPLOYMENT_NAME", raising=False)
+    if override is None:
+        monkeypatch.delenv("AGENTOPS_EVALUATOR_REASONING_MODEL", raising=False)
+    else:
+        monkeypatch.setenv("AGENTOPS_EVALUATOR_REASONING_MODEL", override)
+
+
+def _clear_explicit_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+    monkeypatch.delenv("AZURE_OPENAI_DEPLOYMENT", raising=False)
+    monkeypatch.delenv("AZURE_AI_MODEL_DEPLOYMENT_NAME", raising=False)
+    monkeypatch.delenv("AGENTOPS_EVALUATOR_REASONING_MODEL", raising=False)
+
+
+def _load_with_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    deployment: str,
+    override: str | None = None,
+) -> Dict[str, Any]:
+    evaluator_cls = _install_fake_evaluation(monkeypatch)
+    _configure_model_env(monkeypatch, deployment=deployment, override=override)
+
+    load_evaluator(_preset())
+
+    return evaluator_cls.kwargs
+
+
+def _model_direct_target(deployment: str) -> TargetResolution:
+    return classify_agent(f"model:{deployment}")
+
+
+@pytest.mark.parametrize(
+    "deployment",
+    ["gpt-5.1", "GPT-5-Judge", "o1-preview", "o3-mini", "o4"],
+)
+def test_load_evaluator_marks_reasoning_deployments(
+    monkeypatch: pytest.MonkeyPatch,
+    deployment: str,
+) -> None:
+    kwargs = _load_with_deployment(monkeypatch, deployment=deployment)
+
+    assert kwargs["model_config"]["azure_deployment"] == deployment
+    assert kwargs["is_reasoning_model"] is True
+
+
+def test_load_evaluator_keeps_gpt_4o_mini_shape_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kwargs = _load_with_deployment(monkeypatch, deployment="gpt-4o-mini")
+
+    assert kwargs["model_config"]["azure_deployment"] == "gpt-4o-mini"
+    assert "is_reasoning_model" not in kwargs
+
+
+def test_model_direct_defaults_to_target_deployment_and_foundry_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evaluator_cls = _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://aifappframework.services.ai.azure.com/api/projects/models",
+    )
+
+    load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+    model_config = evaluator_cls.kwargs["model_config"]
+    assert model_config["azure_endpoint"] == (
+        "https://aifappframework.services.ai.azure.com"
+    )
+    assert model_config["azure_deployment"] == "gpt-5.1"
+    assert evaluator_cls.kwargs["is_reasoning_model"] is True
+
+
+def test_explicit_evaluator_env_overrides_model_direct_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evaluator_cls = _install_fake_evaluation(monkeypatch)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://target.services.ai.azure.com/api/projects/models",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://judge.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")
+    monkeypatch.delenv("AZURE_AI_MODEL_DEPLOYMENT_NAME", raising=False)
+    monkeypatch.delenv("AGENTOPS_EVALUATOR_REASONING_MODEL", raising=False)
+
+    load_evaluator(_preset(), target=_model_direct_target("gpt-5.1"))
+
+    model_config = evaluator_cls.kwargs["model_config"]
+    assert model_config["azure_endpoint"] == "https://judge.openai.azure.com"
+    assert model_config["azure_deployment"] == "gpt-4o-mini"
+    assert "is_reasoning_model" not in evaluator_cls.kwargs
+
+
+def test_model_direct_defaults_raise_when_foundry_endpoint_cannot_be_derived(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluation(monkeypatch)
+    _clear_explicit_model_env(monkeypatch)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://aifappframework.services.ai.azure.com/projects/models",
+    )
+
+    with pytest.raises(RuntimeError, match="Cannot derive evaluator endpoint") as excinfo:
+        load_evaluator(_preset(), target=_model_direct_target("gpt-4o-mini"))
+
+    message = str(excinfo.value)
+    assert "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT" in message
+    assert "AZURE_OPENAI_ENDPOINT" in message
+    assert "AZURE_OPENAI_DEPLOYMENT" in message
+
+
+@pytest.mark.parametrize("override", ["1", "true", "yes", "on", " TRUE "])
+def test_reasoning_env_override_can_force_alias(
+    monkeypatch: pytest.MonkeyPatch,
+    override: str,
+) -> None:
+    kwargs = _load_with_deployment(
+        monkeypatch,
+        deployment="prod-judge-alias",
+        override=override,
+    )
+
+    assert kwargs["is_reasoning_model"] is True
+
+
+@pytest.mark.parametrize("override", ["0", "false", "no", "off", " OFF "])
+def test_reasoning_env_override_can_disable_detection(
+    monkeypatch: pytest.MonkeyPatch,
+    override: str,
+) -> None:
+    kwargs = _load_with_deployment(
+        monkeypatch,
+        deployment="gpt-5.1",
+        override=override,
+    )
+
+    assert "is_reasoning_model" not in kwargs
+
+
+def test_invalid_reasoning_env_override_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluation(monkeypatch)
+    _configure_model_env(
+        monkeypatch,
+        deployment="gpt-4o-mini",
+        override="maybe",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="AGENTOPS_EVALUATOR_REASONING_MODEL must be one of",
+    ):
+        load_evaluator(_preset())
+
+
+def test_rejecting_reasoning_kwarg_raises_without_dropping_model_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StrictEvaluator:
+        no_arg_call_count = 0
+
+        def __init__(self, *, model_config: Dict[str, str] | None = None) -> None:
+            if model_config is None:
+                type(self).no_arg_call_count += 1
+
+    _install_fake_evaluation(monkeypatch, StrictEvaluator)
+    _configure_model_env(monkeypatch, deployment="gpt-5.1")
+
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to initialize evaluator 'CoherenceEvaluator'",
+    ) as excinfo:
+        load_evaluator(_preset())
+
+    message = str(excinfo.value)
+    assert "model_config" in message
+    assert "is_reasoning_model" in message
+    assert "upgrade azure-ai-evaluation" in message
+    assert StrictEvaluator.no_arg_call_count == 0


### PR DESCRIPTION
Closes #132.

## Summary

Validated `docs/tutorial-baseline-comparison.md` end-to-end and found one real drift between docs and code: the tutorial said the shipped `agentops-pr.yml` workflow 'already supports' baseline comparison, but the generated workflow ran `agentops eval run --config <cfg>` with **no `--baseline` flag anywhere**. Users had to manually edit the workflow.

Fixed by making the doc claim true rather than softening the doc.

## Change

The PR workflow's 'Run AgentOps eval' step now auto-detects a committed baseline file at `.agentops/baseline/results.json` and passes `--baseline` when present:

```bash
BASELINE_ARG=""
if [ -f .agentops/baseline/results.json ]; then
  BASELINE_ARG="--baseline .agentops/baseline/results.json"
fi
agentops eval run --config "${{ inputs.config || 'agentops.yaml' }}" $BASELINE_ARG
```

Behaviour without that file: unchanged (no baseline, no comparison). Drop the file in your repo and the PR gate becomes a regression check — no workflow edit required.

## Files

- `src/agentops/templates/workflows/agentops-pr.yml` — auto-detect block
- `docs/tutorial-baseline-comparison.md` — Section 4 reworded to match the new behaviour (drop the file, done)
- `tests/unit/test_cicd.py` — new `test_pr_template_auto_detects_committed_baseline` asserting the generated workflow contains the detection block

## Other claims verified

| Tutorial claim | Verified |
|---|---|
| `results.json` includes top-level `comparison` block | ✅ keys: baseline_path, baseline_started_at, baseline_overall_passed, metrics[], rows[] |
| Markdown report grows 'Comparison vs Baseline' table with 🟢/🔴/⚪ | ✅ already verified in #126, #125, #127, #128 PRs |
| Exit code 0/2/1 contract still applies | ✅ baseline doesn't override threshold gating |
| AgentOps loads baseline before refreshing `latest/` | ✅ baseline_path in comparison block points to pre-refresh location |

## Tests

Full suite: **290 passed, 1 skipped** (+1 new test).

## Note for reviewers

Branched off `fix/issue-128-rag-validation`. After #146 merges, this PR's diff against develop reduces to the workflow + cicd test + doc edits.