### PR TITLE
docs(quickstart): correct file count and evaluator override syntax (#125)

### DIFF
--- a/docs/tutorial-quickstart.md
+++ b/docs/tutorial-quickstart.md
@@ -71,11 +71,14 @@ later.
 agentops init
 ```
 
-This creates two files:
+This creates three files:
 
 - `agentops.yaml` — your evaluation config (3 lines + comments).
 - `.agentops/data/smoke.jsonl` — a 3-row seed dataset with short,
   deterministic factual answers.
+- `.gitignore` (project root) — only created if one does not already
+  exist; covers `.venv/`, Python build artifacts, and
+  `.agentops/results/` so run outputs are not accidentally committed.
 
 ## 3. Create the smoke-test Foundry agent
 
@@ -628,12 +631,13 @@ You did not pick evaluators — AgentOps inferred them:
 - **If your dataset rows include `context`:** Groundedness, Relevance, Retrieval, ResponseCompleteness.
 - **If your dataset rows include `tool_calls` or `tool_definitions`:** TaskCompletion, ToolCallAccuracy, IntentResolution, TaskAdherence.
 
-To override the auto-selection, list evaluator class names in `agentops.yaml`:
+To override the auto-selection, list evaluator class names in `agentops.yaml`
+under `name:` keys:
 
 ```yaml
 evaluators:
-  - GroundednessEvaluator
-  - CoherenceEvaluator
+  - name: GroundednessEvaluator
+  - name: CoherenceEvaluator
 ```
 
 ## Where to go next


### PR DESCRIPTION
Closes #125.

## Summary

Re-validated `docs/tutorial-quickstart.md` against current `develop` (the tutorial was rewritten from 116 to 643 lines since the previous attempt). Two real drifts survived the rewrite:

| # | Issue | Evidence |
|---|---|---|
| 1 | Step 2 said `agentops init` creates **two** files | `ls` after init shows three: `agentops.yaml`, `.agentops/data/smoke.jsonl`, and `.gitignore` (project root). Created by `src/agentops/services/initializer.py` when no `.gitignore` already exists. |
| 2 | Evaluator override YAML used plain strings (`- GroundednessEvaluator`) | `AgentOpsConfig.model_validate({..., 'evaluators': ['GroundednessEvaluator']})` raises `ValidationError` — entries must be objects with a `name:` key (`tests/unit/test_agentops_config.py:155`). |

Fixed both. Nothing else in the tutorial needed changes — the cloud-eval flow, agent creation steps, doctor / dashboard / CI sections all work as documented.

## Runtime verification

End-to-end against the `aifappframework/models` Foundry project, using the existing `qa-bot:1` named agent and `execution: cloud`:

```text
cloud: creating eval (4 criteria, item_schema fields: ['expected', 'input'])
cloud: starting run for agent qa-bot:1
cloud: run status -> completed (attempt 6/120)
cloud: downloaded 3 output item(s)
Submitted to New Foundry Evaluations: https://ai.azure.com/.../evaluations/eval_a48125feee984952a845a0824d276a49/run/evalrun_fe842da45f444d37a5402702e8eff3d5
Threshold status: PASSED
```

## Tests

Full suite: **346 passed, 1 skipped** (with the pre-existing `test_cli_platform_invalid_value_fails` deselected — a Click 8.2 `stderr` vs `stdout` issue on develop, unrelated to this PR).

## Note for reviewers

Branched directly off current `develop` (not a chained branch). Earlier PR #142 closed because develop has rewritten this tutorial extensively since.