### PR TITLE
docs(model-direct): align dataset JSONL example with what 'agentops init' creates (#126)

### DIFF
--- a/docs/tutorial-model-direct.md
+++ b/docs/tutorial-model-direct.md
@@ -41,9 +41,9 @@ the deployment, and skips agent infrastructure entirely.
 `.agentops/data/smoke.jsonl` (one JSON object per line):
 
 ```jsonl
-{"id":"1","input":"Answer with exactly this sentence: Paris is the capital of France and one of Europe's major cultural centers.","expected":"Paris is the capital of France and one of Europe's major cultural centers."}
-{"id":"2","input":"Answer with exactly this sentence: Mars is known as the Red Planet because iron-rich dust gives its surface a reddish color.","expected":"Mars is known as the Red Planet because iron-rich dust gives its surface a reddish color."}
-{"id":"3","input":"Answer with exactly this sentence: Water has the chemical formula H2O because each molecule contains two hydrogen atoms and one oxygen atom.","expected":"Water has the chemical formula H2O because each molecule contains two hydrogen atoms and one oxygen atom."}
+{"input": "Answer with exactly this sentence: Paris is the capital of France and one of Europe's major cultural centers.", "expected": "Paris is the capital of France and one of Europe's major cultural centers."}
+{"input": "Answer with exactly this sentence: Mars is known as the Red Planet because iron-rich dust gives its surface a reddish color.", "expected": "Mars is known as the Red Planet because iron-rich dust gives its surface a reddish color."}
+{"input": "Answer with exactly this sentence: Water has the chemical formula H2O because each molecule contains two hydrogen atoms and one oxygen atom.", "expected": "Water has the chemical formula H2O because each molecule contains two hydrogen atoms and one oxygen atom."}
 ```
 
 The first model-direct smoke test intentionally uses short factual


### PR DESCRIPTION
Closes #126.

## Summary

Re-validated `docs/tutorial-model-direct.md` against current `develop` (the tutorial was simplified back to 103 lines on develop). One real drift fixed, no code change needed.

## Drift fixed

| Issue | Evidence |
|---|---|
| Section 3 'Dataset shape' showed JSONL rows with an `id` field, but `agentops init` (`src/agentops/templates/smoke.jsonl`) doesn't include one. | `diff` between init's seed and the doc example: text content matches, only the `id` key + JSON spacing differ. |

Aligned the doc example to the actual init output (drop `id`, use the same key spacing).

## Runtime verification

End-to-end against the `aifappframework/models` Foundry project:

| Step | Outcome |
|---|---|
| `agentops init` | ✅ seed now matches doc example |
| Set `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT=gpt-4.1-443723` | ✅ |
| `agent: "model:gpt-5.1"` + `agentops eval run` | ✅ exit 0, all thresholds PASSED |
| Confirmed `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` is still required for model-direct invocation | ✅ |

## What I deliberately did **not** change

The earlier closed PR #141 attempted to add reasoning-model auto-detection and a deployment-only judge override. `develop` has since simplified `_model_config()` to require both `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_DEPLOYMENT` explicitly — a deliberate architectural decision. This PR respects that decision and does not reintroduce the reasoning-detection / Foundry-derived-endpoint logic.

The tutorial's documented happy path uses a non-reasoning judge (`gpt-4o-mini`) which sidesteps the `max_tokens` vs `max_completion_tokens` issue, so the tutorial is consistent with the simpler `_model_config()`.

## Tests

Full suite: **346 passed, 1 skipped** (with the pre-existing `test_cli_platform_invalid_value_fails` deselected — Click 8.2 stderr issue on develop, unrelated).

## Note for reviewers

Branched directly off current `develop`. No chain dependency on PR #149.