### PR TITLE
docs(rag): clarify 'context' as reference passages; add named-agents constraint (#128)

### DIFF
--- a/docs/tutorial-rag.md
+++ b/docs/tutorial-rag.md
@@ -123,13 +123,26 @@ seed file with something like:
 Each row has:
 - `input` — the question sent to the agent
 - `expected` — the reference answer
-- `context` — the retrieved document context that `GroundednessEvaluator` uses
+- `context` — the reference passages that `GroundednessEvaluator` uses
 
 When any row has a `context` field, the RAG evaluator set is added
 automatically.
 
-> **Tip**: For a real RAG scenario, populate the `context` field with
-> actual retrieved passages from your knowledge base.
+> **The `context` field is always required.** AgentOps maps the dataset's
+> `context` column directly into `GroundednessEvaluator`. The evaluator
+> scores the agent's answer against this reference context — populate it
+> with the canonical passages you want the agent's answers to align with.
+
+> **Populating `context` for production datasets.** Two practical
+> workflows:
+>
+> 1. **Manual reference passages.** Hand-pick the canonical passages
+>    each question should be answered from. Best for curated, stable
+>    golden datasets.
+> 2. **Pre-script retrieval.** Query your knowledge base (Azure AI
+>    Search, etc.) for each test question with your own script, capture
+>    the top-K passages, and write them into the JSONL `context` field.
+>    Best when curating manually doesn't scale.
 
 ## Part 5: Run evaluation
 
@@ -168,3 +181,7 @@ For model-only evaluation (no retrieval), see the [Model-Direct Tutorial](tutori
   one deployment, this is optional.
 - Authentication is automatic via `DefaultAzureCredential`.
 - For local development, `az login` is enough.
+- **Named agents only**: AgentOps targets the Foundry Responses API,
+  which addresses agents by `name:version`. Legacy classic-portal
+  `asst_*` IDs are not supported today (see
+  [#143](https://github.com/Azure/agentops/issues/143)).


### PR DESCRIPTION
Closes #128. Tracks gaps in [#143](https://github.com/Azure/agentops/issues/143), [#145](https://github.com/Azure/agentops/issues/145).

## Summary

Re-validated `docs/tutorial-rag.md` end-to-end on current `develop` (170 lines). Two drifts fixed.

## Drifts fixed

| # | Issue | Evidence |
|---|---|---|
| 1 | Part 4 described `context` as 'the retrieved document context' and a 'Tip' said to populate it with 'actual retrieved passages from your knowledge base' — both imply AgentOps captures the agent's runtime retrieval. | `grep -rn '\$context\\|extract.*retriev\\|tool_result' src/agentops/pipeline/` shows `\$context` is always mapped to the dataset row's `context` column (`runtime.py:316`). No code captures agent runtime retrieval. Tracked in #145. |
| 2 | Notes section lacked the named-agents-only constraint that other Foundry-target tutorials now carry. | Same evidence as #127: `classify_agent()` rejects bare `asst_*`; no Threads API code path. Tracked in #143. |

## Doc changes

- 'context' bullet now reads 'the **reference passages** that GroundednessEvaluator uses'.
- New 'The context field is always required' callout makes it explicit AgentOps doesn't capture runtime retrieval.
- New 'Populating context for production datasets' callout gives two practical workflows (manual curation vs pre-script retrieval) — replacing the vague 'populate with retrieved passages' tip.
- New 'Named agents only' bullet in Notes linking to #143.

Part 1 step 3's instruction to add a knowledge base / file search tool was deliberately left in place — that's accurate Foundry portal guidance, and a real KB makes the agent's response reflect real retrieval (the evaluator just doesn't see the retrieval directly).

## Runtime verification

End-to-end against the existing named agent `qa-bot:1`:

```text
[3/3] scored: coherence=4.00, fluency=3.00, similarity=5.00, f1_score=0.83, groundedness=5.00, relevance=4.00, retrieval=5.00, response_completeness=5.00, avg_latency_seconds=1.49
Threshold status: PASSED
```

All 8 evaluators auto-selected (model-quality + RAG sets) because rows include a `context` field. Groundedness=5.0 across the board.

## Tests

Full suite: **346 passed, 1 skipped** (with `test_cli_platform_invalid_value_fails` deselected — Click 8.2 stderr issue on develop).

## Note for reviewers

Branched directly off current `develop`. No dependencies on PR #149, #150, or #152.