### PR TITLE
fix(workflow): auto-detect committed baseline in PR templates; align doc (#132)

### DIFF
--- a/docs/tutorial-baseline-comparison.md
+++ b/docs/tutorial-baseline-comparison.md
@@ -86,14 +86,19 @@ similarity is good.
 ## 4. Wire into a PR check
 
 The `agentops-pr.yml` workflow shipped by `agentops workflow generate`
-already supports this — drop a baseline file in your repo (e.g.
-`.agentops/baseline/results.json`) and add this step:
+already supports this — drop a baseline file at
+`.agentops/baseline/results.json` in your repo and the PR gate
+auto-detects it (no workflow edit needed):
 
-```yaml
-- name: Run AgentOps eval against baseline
-  run: |
-    agentops eval run --baseline .agentops/baseline/results.json
+```powershell
+New-Item -ItemType Directory -Force .agentops\baseline | Out-Null
+Copy-Item .agentops\results\latest\results.json .agentops\baseline\results.json
+git add .agentops/baseline/results.json
+git commit -m "chore: capture AgentOps baseline"
 ```
+
+When the file is absent, the workflow runs without baseline comparison.
+When present, it runs `agentops eval run --baseline .agentops/baseline/results.json` automatically. The same auto-detection applies to the Azure DevOps Pipelines template (`agentops workflow generate --platform azure-devops`).
 
 When a PR causes a metric to regress past your threshold, the run
 exits `2` and the workflow fails, blocking merge until somebody

--- a/src/agentops/templates/pipelines/azuredevops/agentops-pr.yml
+++ b/src/agentops/templates/pipelines/azuredevops/agentops-pr.yml
@@ -63,7 +63,17 @@ stages:
                 python -m pip install --upgrade pip
                 # NOTE: pinned to develop branch until AgentOps 1.0 lands on PyPI.
                 python -m pip install "agentops-toolkit[foundry] @ git+https://github.com/Azure/agentops.git@develop"
-                agentops eval run --config "$(AGENTOPS_CONFIG)"
+                # Auto-detect a committed baseline so the PR gate becomes a
+                # regression check when .agentops/baseline/results.json is present.
+                # Drop or refresh that file with `cp .agentops/results/latest/results.json .agentops/baseline/results.json`.
+                BASELINE_ARG=""
+                if [ -f .agentops/baseline/results.json ]; then
+                  BASELINE_ARG="--baseline .agentops/baseline/results.json"
+                  echo "Using baseline: .agentops/baseline/results.json"
+                else
+                  echo "No .agentops/baseline/results.json found; running without baseline comparison."
+                fi
+                agentops eval run --config "$(AGENTOPS_CONFIG)" $BASELINE_ARG
                 ec=$?
                 echo "##vso[task.setvariable variable=evalExitCode;isOutput=true]$ec"
                 if [ $ec -eq 0 ]; then

--- a/src/agentops/templates/workflows/agentops-pr.yml
+++ b/src/agentops/templates/workflows/agentops-pr.yml
@@ -79,7 +79,17 @@ jobs:
           AZURE_OPENAI_DEPLOYMENT: ${{ vars.AZURE_OPENAI_DEPLOYMENT }}
         run: |
           set +e
-          agentops eval run --config "${{ inputs.config || 'agentops.yaml' }}"
+          # Auto-detect a committed baseline so the PR gate becomes a
+          # regression check when .agentops/baseline/results.json is present.
+          # Drop or refresh that file with `cp .agentops/results/latest/results.json .agentops/baseline/results.json`.
+          BASELINE_ARG=""
+          if [ -f .agentops/baseline/results.json ]; then
+            BASELINE_ARG="--baseline .agentops/baseline/results.json"
+            echo "Using baseline: .agentops/baseline/results.json"
+          else
+            echo "No .agentops/baseline/results.json found; running without baseline comparison."
+          fi
+          agentops eval run --config "${{ inputs.config || 'agentops.yaml' }}" $BASELINE_ARG
           ec=$?
           echo "exit_code=$ec" >> "$GITHUB_OUTPUT"
           if [ $ec -eq 0 ]; then

--- a/tests/unit/test_cicd.py
+++ b/tests/unit/test_cicd.py
@@ -163,6 +163,19 @@ def test_pr_template_triggers_and_no_environment(tmp_path: Path) -> None:
     assert "<!-- agentops-pr-report -->" in content
 
 
+def test_pr_template_auto_detects_committed_baseline(tmp_path: Path) -> None:
+    """The shipped PR workflow turns into a regression gate when a baseline
+    file is committed at ``.agentops/baseline/results.json``."""
+    generate_cicd_workflows(directory=tmp_path, kinds=["pr"])
+    content = (tmp_path / _PR_PATH).read_text(encoding="utf-8")
+
+    # Baseline auto-detection: the run step checks for the committed file
+    # and passes --baseline only when it exists.
+    assert ".agentops/baseline/results.json" in content
+    assert "--baseline" in content
+    assert "$BASELINE_ARG" in content
+
+
 def test_dev_template_triggers_and_environment(tmp_path: Path) -> None:
     generate_cicd_workflows(directory=tmp_path, kinds=["dev"])
     content = (tmp_path / _DEV_PATH).read_text(encoding="utf-8")
@@ -320,6 +333,13 @@ def test_azure_devops_pr_template_uses_ado_idioms(tmp_path: Path) -> None:
     assert "AZURE_SERVICE_CONNECTION" in content
     # PR comment marker preserved across platforms.
     assert "<!-- agentops-pr-report -->" in content
+
+    # Baseline auto-detection (same behaviour as the GitHub Actions
+    # template) so the PR gate becomes a regression check when the
+    # committed baseline file is present.
+    assert ".agentops/baseline/results.json" in content
+    assert "--baseline" in content
+    assert "$BASELINE_ARG" in content
 
 
 def test_azure_devops_deploy_templates_use_deployment_job(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #132.

## Summary

Validated `docs/tutorial-baseline-comparison.md` against current `develop`. Same drift as the closed PR #147: the tutorial said the shipped PR workflow 'already supports' baseline comparison, but neither the **GitHub Actions** nor the new **Azure DevOps Pipelines** templates passed `--baseline`. Users had to manually edit the workflow.

Made the doc claim true on **both platforms** rather than softening the doc.

## Change

The 'Run AgentOps eval' step (GitHub Actions) and the equivalent `AzureCLI@2` inline script (Azure DevOps) now auto-detect a committed baseline file at `.agentops/baseline/results.json`:

```bash
BASELINE_ARG=""
if [ -f .agentops/baseline/results.json ]; then
  BASELINE_ARG="--baseline .agentops/baseline/results.json"
fi
agentops eval run --config "..." $BASELINE_ARG
```

Behaviour without that file: unchanged (no baseline, no comparison). Drop the file in your repo and the PR gate becomes a regression check on both platforms — no workflow edit required.

## Files

- `src/agentops/templates/workflows/agentops-pr.yml` — GitHub Actions auto-detect block
- `src/agentops/templates/pipelines/azuredevops/agentops-pr.yml` — Azure DevOps auto-detect block (new since the closed PR #147 was opened)
- `docs/tutorial-baseline-comparison.md` — Section 4 reworded; mentions the same behaviour applies to the Azure DevOps template
- `tests/unit/test_cicd.py` — new `test_pr_template_auto_detects_committed_baseline` (GitHub Actions) + extended `test_azure_devops_pr_template_uses_ado_idioms` (Azure DevOps)

## Other claims verified

| Tutorial claim | Verified |
|---|---|
| `results.json` includes top-level `comparison` block | ✅ keys: baseline_path, baseline_started_at, baseline_overall_passed, metrics[], rows[] (verified end-to-end earlier in the validation series) |
| Markdown report grows 'Comparison vs Baseline' table with 🟢/🔴/⚪ | ✅ verified in #149, #150, #152, #153 PRs |
| Exit code 0/2/1 contract still applies | ✅ baseline doesn't override threshold gating |
| AgentOps loads baseline before refreshing `latest/` | ✅ `baseline_path` in comparison block points to pre-refresh location |

## Tests

Full suite: **347 passed, 1 skipped** (+1 new test), with the pre-existing `test_cli_platform_invalid_value_fails` deselected (Click 8.2 stderr issue on develop, unrelated).

## Note for reviewers

Branched directly off current `develop`. No dependencies on PR #149, #150, #152, or #153.