### PR TITLE
docs(baseline): soften PR-gate claim to match shipped workflow (#132)

### DIFF
--- a/docs/tutorial-baseline-comparison.md
+++ b/docs/tutorial-baseline-comparison.md
@@ -86,18 +86,36 @@ similarity is good.
 ## 4. Wire into a PR check
 
 The `agentops-pr.yml` workflow shipped by `agentops workflow generate`
-already supports this — drop a baseline file in your repo (e.g.
-`.agentops/baseline/results.json`) and add this step:
+runs `agentops eval run --config agentops.yaml` **without** a baseline by
+default. To turn it into a regression gate, drop a baseline file in your
+repo and modify the eval step to pass `--baseline`:
+
+```powershell
+New-Item -ItemType Directory -Force .agentops\baseline | Out-Null
+Copy-Item .agentops\results\latest\results.json .agentops\baseline\results.json
+git add .agentops/baseline/results.json
+git commit -m "chore: capture AgentOps baseline"
+```
+
+Then edit `.github/workflows/agentops-pr.yml` (or the Azure DevOps
+equivalent under `.azuredevops/pipelines/`) and add `--baseline` to the
+eval step:
 
 ```yaml
 - name: Run AgentOps eval against baseline
   run: |
-    agentops eval run --baseline .agentops/baseline/results.json
+    agentops eval run \
+      --config agentops.yaml \
+      --baseline .agentops/baseline/results.json
 ```
 
 When a PR causes a metric to regress past your threshold, the run
 exits `2` and the workflow fails, blocking merge until somebody
 either fixes the regression or refreshes the baseline.
+
+> **Roadmap note.** Auto-detecting a committed baseline file from the
+> shipped templates (no manual workflow edit) is tracked in
+> [#155](https://github.com/Azure/agentops/issues/155).
 
 ## 5. Refresh the baseline
 


### PR DESCRIPTION
Closes #132. Tracks the workflow auto-detect enhancement in [#155](https://github.com/Azure/agentops/issues/155).

## Summary

Doc-only validation pass for `docs/tutorial-baseline-comparison.md` against current `develop`. The tutorial said the shipped `agentops-pr.yml` workflow 'already supports' baseline comparison, but the templates run `agentops eval run --config <cfg>` with **no `--baseline` flag**.

Rather than change the templates in this PR, softened Section 4 to honestly describe today's behaviour and linked the auto-detect enhancement to issue #155 for separate consideration.

## Drift fixed

| Issue | Evidence |
|---|---|
| Section 4 implied the shipped workflow auto-consumes a baseline file dropped at `.agentops/baseline/results.json`. | `grep -c baseline src/agentops/templates/workflows/agentops-pr.yml src/agentops/templates/pipelines/azuredevops/agentops-pr.yml` returns 0 in both. The workflow only calls `agentops eval run --config`. |

## Doc changes

- Updated Section 4 to spell out that today's default workflow runs without a baseline.
- Provided the manual edit needed to turn it into a regression gate.
- Added a 'Roadmap note' linking to #155 for the auto-detect enhancement.

## Other claims verified

| Tutorial claim | Verified |
|---|---|
| `results.json` includes top-level `comparison` block | ✅ verified end-to-end in earlier validation runs (keys: `baseline_path`, `baseline_started_at`, `baseline_overall_passed`, `metrics[]`, `rows[]`) |
| Markdown report grows 'Comparison vs Baseline' table with 🟢/🔴/⚪ | ✅ verified in PRs #149, #150, #152, #153 |
| Exit-code contract still applies | ✅ baseline doesn't override threshold gating |
| AgentOps loads baseline before refreshing `latest/` | ✅ `baseline_path` in comparison block points to pre-refresh location |

## Tests

Full suite: **346 passed, 1 skipped** (with the pre-existing `test_cli_platform_invalid_value_fails` deselected — Click 8.2 stderr issue on develop, unrelated).

## Note for reviewers

Branched directly off current `develop`. No dependency on other PRs. The previous PR #154 attempted to ship the workflow auto-detection as part of this validation; closed at the maintainer's request to keep this issue doc-only — the code change now lives as #155.