### PR TITLE
docs(copilot-skills): drop deprecated --force flag and deduplicate judge env vars (#133)

### DIFF
--- a/docs/tutorial-copilot-skills.md
+++ b/docs/tutorial-copilot-skills.md
@@ -48,7 +48,7 @@ python -m venv .venv
 python -m pip install -U pip
 python -m pip install "agentops-toolkit[foundry,agent]"
 
-agentops skills install --platform copilot --force
+agentops skills install --platform copilot
 ```
 
 Expected files:
@@ -83,8 +83,11 @@ Set local evaluator variables:
 $env:AZURE_AI_FOUNDRY_PROJECT_ENDPOINT = "https://<resource>.services.ai.azure.com/api/projects/<project>"
 $env:AZURE_OPENAI_ENDPOINT             = "https://<resource>.openai.azure.com"
 $env:AZURE_OPENAI_DEPLOYMENT           = "gpt-4o-mini"
-$env:AZURE_AI_MODEL_DEPLOYMENT_NAME    = "gpt-4o-mini"
 ```
+
+`AZURE_AI_MODEL_DEPLOYMENT_NAME` is accepted as a fallback name for the
+judge deployment if you prefer the Foundry-style variable. Set only one
+of the two — `AZURE_OPENAI_DEPLOYMENT` wins when both are set.
 
 ## 1. Ask Copilot to configure AgentOps
 


### PR DESCRIPTION
Closes #133. CLI help-text gap tracked in [#157](https://github.com/Azure/agentops/issues/157).

## Summary

Doc-only validation pass for `docs/tutorial-copilot-skills.md` against current `develop` (297 lines). Two drifts fixed.

## Drifts fixed

| # | Issue | Evidence |
|---|---|---|
| 1 | 'Option 2: CLI install' invoked `agentops skills install --platform copilot --force`. `--force` is now deprecated. | `agentops skills install --help`: `'--force  Deprecated — skills are always overwritten with the latest version.'` |
| 2 | 'Set local evaluator variables' set both `AZURE_OPENAI_DEPLOYMENT` and `AZURE_AI_MODEL_DEPLOYMENT_NAME` to the same value. | `_model_config()` reads them as fallbacks of each other (`os.getenv(AZURE_OPENAI_DEPLOYMENT) or os.getenv(AZURE_AI_MODEL_DEPLOYMENT_NAME)`); setting both is redundant. Reduced to one, added a one-line note about the alias. |

## Verified working

- `agentops skills install --platform copilot` writes the exact 7-file tree the tutorial lists (.github/copilot-instructions.md + 6 SKILL.md).
- `agentops skills install --platform claude` writes `.claude/commands/*.md`.
- `agentops skills install --platform cursor` writes `.github/skills/...` plus `.cursor/rules/agentops.mdc` (matches tutorial line 66-68).
- `agentops doctor --severity-fail critical` matches the documented Watchdog command.
- `agentops agent serve` still exists.
- `agentops workflow generate --kinds pr --force` still exists.

## CLI gap split out

The CLI help text for `agentops skills install --platform` currently lists only `copilot, claude` even though `cursor` is fully supported in code. This was bundled with doc fixes in closed PR #148; now tracked as its own issue #157 so the help-text update can land on its own merits.

## Tests

Full suite: **346 passed, 1 skipped** (with the pre-existing `test_cli_platform_invalid_value_fails` deselected — Click 8.2 stderr issue on develop, unrelated).

## Note for reviewers

Branched directly off current `develop`. No dependencies on other PRs.