### PR TITLE
docs(agent-workflow): deduplicate judge env var block (#130)

### DIFF
--- a/docs/tutorial-agent-workflow.md
+++ b/docs/tutorial-agent-workflow.md
@@ -180,8 +180,11 @@ agentops init
 $env:AZURE_AI_FOUNDRY_PROJECT_ENDPOINT = "https://<resource>.services.ai.azure.com/api/projects/<project>"
 $env:AZURE_OPENAI_ENDPOINT             = "https://<resource>.openai.azure.com"
 $env:AZURE_OPENAI_DEPLOYMENT           = "gpt-4o-mini"
-$env:AZURE_AI_MODEL_DEPLOYMENT_NAME    = "gpt-4o-mini"
 ```
+
+`AZURE_AI_MODEL_DEPLOYMENT_NAME` is accepted as a fallback name for the
+judge deployment. Set only one of the two — `AZURE_OPENAI_DEPLOYMENT`
+wins when both are set.
 
 ## 4. Write `agentops.yaml`
 


### PR DESCRIPTION
Closes #130.

## Summary

Doc-only validation pass for `docs/tutorial-agent-workflow.md` against current `develop` (291 lines). One drift fixed.

## Drift fixed

| Issue | Evidence |
|---|---|
| Section 3 'Initialize AgentOps' set both `AZURE_OPENAI_DEPLOYMENT` and `AZURE_AI_MODEL_DEPLOYMENT_NAME` to the same value. | `_model_config()` in `src/agentops/pipeline/runtime.py` reads them as fallbacks of each other (`os.getenv(AZURE_OPENAI_DEPLOYMENT) or os.getenv(AZURE_AI_MODEL_DEPLOYMENT_NAME)`); setting both is redundant. Same fix shipped in PR #158 for the Copilot-skills tutorial. |

## What I verified without re-deploying the Container App

Tutorial Section 1-2 builds + deploys a FastAPI tool-calling agent to ACA. That's heavy to re-spin every validation pass, so I validated the AgentOps-side claims directly against the code:

| Claim | Verified via |
|---|---|
| The documented `agentops.yaml` shape parses cleanly | `AgentOpsConfig.model_validate(...)` succeeded with all six top-level fields (`request_field`, `response_field`, `tool_calls_field`, `thresholds`, etc.) |
| All six documented thresholds are real evaluators | `grep -n score_key src/agentops/core/evaluators.py`: `coherence`, `fluency`, `tool_call_accuracy`, `intent_resolution`, `task_adherence`, `avg_latency_seconds` all present with matching default thresholds |
| Dataset shape (`input` + `expected` + `tool_definitions` + `tool_calls`) triggers the agent-evaluator set | Module docstring in `src/agentops/core/evaluators.py`: *'If rows include `tool_calls` or `tool_definitions`: add agent evaluators (ToolCallAccuracy, IntentResolution, TaskAdherence).'* |
| `agentops workflow generate --kinds pr --force` works | `--help` shows `--force` is still a valid `workflow generate` option (distinct from the deprecated `skills install --force`) |
| `agentops doctor --severity-fail critical` works | Confirmed in #133 / #156 validation |

## Tests

Full suite: **346 passed, 1 skipped** (with the pre-existing `test_cli_platform_invalid_value_fails` deselected — Click 8.2 stderr issue on develop, unrelated).

## Note for reviewers

Branched directly off current `develop`. No dependencies on other PRs.