### PR TITLE
docs(watchdog): clarify first-run results_history status (#134)

### DIFF
--- a/docs/tutorial-agent-watchdog.md
+++ b/docs/tutorial-agent-watchdog.md
@@ -38,9 +38,11 @@ agentops doctor
 ```
 
 The first run produces `.agentops/agent/report.md`. With no
-`agent.yaml` the analyzer uses defaults: results-history is the only
-active source, Azure Monitor and Foundry control are reported as
-`skipped` in the diagnostics block.
+`agent.yaml` the analyzer uses defaults: `results_history` is the only
+configured source, while `azure_monitor` and `foundry_control` are
+reported as `skipped` in the diagnostics block. On a brand-new
+workspace `results_history` shows as `missing` until you have at least
+one `agentops eval run` under `.agentops/results/` for it to read.
 
 ## 2. Wire production telemetry
 


### PR DESCRIPTION
Closes #134.

## Summary

Doc-only validation pass for `docs/tutorial-agent-watchdog.md` against current `develop` (330 lines). Most of the tutorial holds up after the recent `watchdog` to `doctor` rename. One small accuracy fix.

## What I verified

| Tutorial claim | Verified |
|---|---|
| `agentops doctor` CLI | produces `.agentops/agent/report.md` + `.agentops/agent/history.jsonl` with the documented section layout |
| `agentops agent serve --no-verify --port 8080` | all three flags exist; `--no-verify` documented as 'dev only' |
| `agentops doctor --severity-fail critical` and `--categories security` | both accepted; `--categories` help lists `quality, performance, reliability, mlops, security, responsible_ai` |
| `agentops doctor --exclude-rules waf.security.diagnostic_settings` | flag present |
| Source rows (results_history, azure_monitor, foundry_control, azure_resources) | all four appear in the generated report |
| `src/agentops/templates/agent.yaml` and `src/agentops/templates/agent-server/` (Dockerfile + main.bicep + README.md) | all present |
| Watchdog report structure (Verdict / Summary / Sources / Findings + per-finding Details + Evidence) | matches the example at lines 300-330 |

## Drift fixed

Section 1 'Local dry-run' said `results-history is the only active source` after the first `agentops doctor` run. But Section 1 has the reader create a brand-new workspace with `agentops init`, so there are no eval results yet, and the report shows `results_history` as `missing`, not active.

Reproduced in `/tmp/tut-134`: `Sources: results_history | missing | results directory not found at /tmp/tut-134/.agentops/results`.

Reworded to: `results_history is the only configured source... shows as missing until you have at least one agentops eval run under .agentops/results/`.

## Tests

Full suite: **346 passed, 1 skipped** (with the pre-existing `test_cli_platform_invalid_value_fails` deselected — Click 8.2 stderr issue on develop, unrelated).

## Note for reviewers

Branched directly off current `develop`. No code changes, no dependencies on other PRs.
