### PR TITLE
docs(end-to-end): correct init output tree and workflow file count (#135)

### DIFF
--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -188,18 +188,18 @@ In an empty folder (or the GitHub repo you want to use):
 agentops init
 ```
 
-You get:
+You get three files:
 
+```text
+agentops.yaml                  # at the project root
+.agentops/data/smoke.jsonl     # 3-row seed dataset
+.gitignore                     # only if one doesn't already exist
 ```
-agentops.yaml
-.agentops/
-├── data/
-│   └── smoke.jsonl
-└── results/
-.github/
-└── skills/
-    └── agentops-*/SKILL.md
-```
+
+`agentops init` does **not** create `.agentops/results/` (that appears on
+the first `agentops eval run`) or `.github/skills/`. Coding-agent skills
+live in their own command: `agentops skills install --platform copilot`
+(or `claude` / `cursor`).
 
 Open `agentops.yaml` at the project root and configure it for the
 support agent:
@@ -405,7 +405,7 @@ intentionally want to demonstrate a red quality gate.
 agentops workflow generate
 ```
 
-Four files appear under `.github/workflows/`:
+Five files appear under `.github/workflows/`:
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
@@ -413,6 +413,7 @@ Four files appear under `.github/workflows/`:
 | `agentops-deploy-dev.yml` | Push to `develop` | Deploys to the **dev** environment after a passing eval. |
 | `agentops-deploy-qa.yml` | Push to a `release/*` branch | Deploys to **qa**. |
 | `agentops-deploy-prod.yml` | Push to `main` | Deploys to **prod** after a passing eval. |
+| `agentops-watchdog.yml` | Daily cron + `workflow_dispatch` | Runs `agentops doctor` against the run history and uploads the report as an artifact. |
 
 Read [`ci-github-actions.md`](ci-github-actions.md) for the full
 reference. The defaults are sane: you do not need to edit them yet.


### PR DESCRIPTION
Closes #135.

## Summary

Re-validated `docs/tutorial-end-to-end.md` against current `develop` (891 lines — the largest tutorial, composite of the other validated ones). Two real drifts fixed; the remaining sections hold up against the runtime verification already done in earlier PRs.

## Drifts fixed

| # | Issue | Evidence |
|---|---|---|
| 1 | Section 3 'Initialize the workspace' showed an init output tree containing `.agentops/results/` and `.github/skills/agentops-*/SKILL.md`. | `agentops init` in `/tmp/tut-135` produces exactly three files: `agentops.yaml`, `.agentops/data/smoke.jsonl`, `.gitignore`. `.agentops/results/` appears on the first `agentops eval run`. `.github/skills/...` is the output of the separate `agentops skills install` command. |
| 2 | Section 7 'Generate the GitFlow workflows' said *'Four files appear under `.github/workflows/`'*. | `agentops workflow generate` in `/tmp/tut-135` produces **five** files — the table was missing `agentops-watchdog.yml` (the daily cron running `agentops doctor`). Added the fifth row. |

## Sections that hold up (verified via earlier validation PRs)

| Section | Cross-reference |
|---|---|
| §2 helper script `scripts/create_support_agent.py` exists; lists three tools as claimed | confirmed |
| §5 evaluator auto-selection (model-quality + tool-aware) | verified in PRs #150, #159 |
| §6 baseline comparison flow + report.md `Comparison vs Baseline` section | verified in PR #156 |
| §9 watchdog wiring — `azure_monitor`/`azure_resources`/`foundry_control` flip to `ok` against real Azure resources | verified in PR #160 ([real-test comment](https://github.com/Azure/agentops/pull/160#issuecomment-4453682366)) |
| §8 OIDC + federated credentials | verbatim GitHub/Azure CLI; no AgentOps surface to drift |

## Tests

Full suite: **346 passed, 1 skipped** (with the pre-existing `test_cli_platform_invalid_value_fails` deselected — Click 8.2 stderr issue on develop, unrelated).

## Note for reviewers

Branched directly off current `develop`. No code changes, no dependencies on other PRs.
