### PR TITLE
Harden publish-vsix job ahead of agentops-accelerator rename (#181)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,11 +174,13 @@ jobs:
 
   # ── VSIX Stable Publish ──────────────────────────────────────────────
   # Publish the VS Code extension as a stable release to the Marketplace.
-  # Runs in parallel with the TestPyPI→PyPI flow (only needs source checkout).
+  # Runs after PyPI publish so PyPI and Marketplace identity stay consistent on every release.
   publish-vsix:
-    needs: build # gate on successful lint + test
+    needs: [build, publish-pypi] # gate on successful lint + test (build) and on PyPI publish
     runs-on: ubuntu-latest
     environment: release # same approval gate as PyPI
+    env:
+      VSIX_FILE: agentops-skills.vsix
     steps:
       - uses: actions/checkout@v6
         with:
@@ -211,23 +213,40 @@ jobs:
 
       - name: Package VSIX
         working-directory: plugins/agentops
-        run: vsce package -o agentops-skills.vsix
+        run: vsce package -o "${VSIX_FILE}"
 
       - name: Publish stable to VS Code Marketplace
-        continue-on-error: true # Tolerate "already exists" if staging pre-release published this version
+        # Tolerate ONLY the "already exists" case (staging pre-release may have
+        # published the same version first). Any other failure must fail the job.
         working-directory: plugins/agentops
-        run: vsce publish --packagePath agentops-skills.vsix -p "${{ secrets.VSCE_PAT }}"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          set -o pipefail
+          if OUTPUT=$(vsce publish --packagePath "${VSIX_FILE}" -p "${VSCE_PAT}" 2>&1); then
+            RC=0
+          else
+            RC=$?
+          fi
+          echo "$OUTPUT"
+          if [ "$RC" -ne 0 ]; then
+            if echo "$OUTPUT" | grep -qi "already exists"; then
+              echo "::warning::VSIX version already published (likely by staging pre-release). Treating as success."
+              exit 0
+            fi
+            exit "$RC"
+          fi
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v7
         with:
           name: vsix
-          path: plugins/agentops/agentops-skills.vsix
+          path: plugins/agentops/${{ env.VSIX_FILE }}
 
   # Create GitHub Release with built artifacts (Python dist + VSIX)
   github-release:
     needs: [publish-pypi, publish-vsix]
-    if: always() && needs.publish-pypi.result == 'success'
+    if: always() && needs.publish-pypi.result == 'success' && needs.publish-vsix.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Refs #181. **PR-1 of 3** in the `agentops-toolkit` → `agentops-accelerator` rename strategy. **No rename in this PR** — purely workflow hardening so the eventual rename can ship through a single tag-driven release without surprises.

## Why this lands first

PR-2 will atomically rename the PyPI distribution and the VS Code extension publisher/name. The current `publish-vsix` job has three latent issues that would silently bite during the rename:

1. `publish-vsix` and `publish-pypi` both `needs: build` (independent) — a failed PyPI publish would still ship the VSIX, leaving the Marketplace listing pointing at a distribution name that does not exist on PyPI.
2. The VSIX filename `agentops-skills.vsix` is hard-coded in ~5 places in this file — the rename would require five synchronized edits with no compile-time safety net.
3. `continue-on-error: true` on the `vsce publish` step swallows **every** failure (auth, network, schema) — not just the idempotent "already exists" case it was intended for. A real publish failure would still produce a GitHub Release that quietly lacks the VSIX asset.

## Changes (all scoped to `.github/workflows/release.yml`, +26/-7)

| # | Change | Effect |
|---|---|---|
| 1 | `publish-vsix: needs: build` → `needs: [build, publish-pypi]` | VSIX publishes only after PyPI succeeds. Failed PyPI no longer strands a Marketplace artifact. |
| 2 | New job-level `env: VSIX_FILE: agentops-skills.vsix`; 3 substitutions in subsequent steps | Single source of truth for the VSIX filename. PR-2 flips one value. |
| 3 | `continue-on-error: true` replaced with shell block that captures `vsce publish` output, greps `-qi "already exists"`, exits 0 only in that case. `VSCE_PAT` moved from job-level to step-level `env:`. | Real failures now fail the job. Only the intended idempotency case is tolerated. Grep string verified against [`microsoft/vscode-vsce` `src/publish.ts:231,247`](https://github.com/microsoft/vscode-vsce/blob/main/src/publish.ts). |
| 4 | `github-release.if` gates on `needs.publish-vsix.result == 'success'` (in addition to existing conditions) | A non-idempotent VSIX failure no longer publishes a release missing its VSIX asset. |

## Validation

- Multi-Pass Coder + Critic (Correctness lens) — Critic returned 0 Critical / 0 Important / 0 Suggestions.
- Shell-pattern safety verified: `if OUTPUT=\$(cmd 2>&1); then RC=0; else RC=\$?; fi` correctly captures exit code under default `set -e -o pipefail` (the `if` construct suspends `set -e` for the test command).
- "already exists" grep substring verified against actual vscode-vsce source.
- YAML syntactically valid (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`).
- No behavior change for the happy path of an ordinary release.