### PR TITLE
fix(release): correct VSIX tombstone identity + staging verify hygiene (v0.3.0 hotfix)

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -344,9 +344,27 @@ jobs:
         run: vsce package --pre-release -o agentops-skills.vsix
 
       - name: Publish pre-release to VS Code Marketplace
-        continue-on-error: true # Tolerate "already exists" for pre-release builds
+        # Tolerate ONLY the "already exists" case (re-run of the same pre-release
+        # version). Any other failure (auth, network, validation) must fail the job
+        # so staging surfaces real publish problems instead of silently green-lighting.
         working-directory: plugins/agentops
-        run: vsce publish --pre-release --packagePath agentops-skills.vsix -p "${{ secrets.VSCE_PAT }}"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          set -o pipefail
+          if OUTPUT=$(vsce publish --pre-release --packagePath agentops-skills.vsix -p "${VSCE_PAT}" 2>&1); then
+            RC=0
+          else
+            RC=$?
+          fi
+          echo "$OUTPUT"
+          if [ "$RC" -ne 0 ]; then
+            if echo "$OUTPUT" | grep -qi "already exists"; then
+              echo "::warning::VSIX pre-release version already published. Treating as success."
+              exit 0
+            fi
+            exit "$RC"
+          fi
 
       - name: Show VSIX info
         working-directory: plugins/agentops
@@ -421,9 +439,27 @@ jobs:
         run: vsce package --pre-release -o "${VSIX_FILE}"
 
       - name: Publish pre-release tombstone to VS Code Marketplace
-        continue-on-error: true # Tolerate "already exists" for pre-release builds
+        # Tolerate ONLY the "already exists" case (re-run of the same pre-release
+        # version). Any other failure (auth, network, validation) must fail the job
+        # so staging surfaces real publish problems instead of silently green-lighting.
         working-directory: tombstones/vscode
-        run: vsce publish --pre-release --packagePath "${VSIX_FILE}" -p "${{ secrets.VSCE_PAT }}"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          set -o pipefail
+          if OUTPUT=$(vsce publish --pre-release --packagePath "${VSIX_FILE}" -p "${VSCE_PAT}" 2>&1); then
+            RC=0
+          else
+            RC=$?
+          fi
+          echo "$OUTPUT"
+          if [ "$RC" -ne 0 ]; then
+            if echo "$OUTPUT" | grep -qi "already exists"; then
+              echo "::warning::Tombstone VSIX pre-release version already published. Treating as success."
+              exit 0
+            fi
+            exit "$RC"
+          fi
 
       - name: Show tombstone VSIX info
         working-directory: tombstones/vscode

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -220,6 +220,15 @@ jobs:
           echo "✅ agentops init succeeded"
 
   # Install the tombstone from TestPyPI and verify it redirects to agentops-accelerator.
+  #
+  # Staging-only divergence from release.yml: the main package (agentops-accelerator)
+  # is built with setuptools-scm and published to TestPyPI as 0.2.3.devN, while the
+  # tombstone (agentops-toolkit) hardcodes `agentops-accelerator>=0.3.0` in its
+  # pyproject.toml. In release.yml the two packages publish in lockstep at the
+  # same 0.3.x tag, so pip resolves the dep cleanly. In staging the dep can never
+  # resolve via a standard `pip install`, so we install the tombstone with
+  # `--no-deps` (to validate its wheel metadata) and then install the latest
+  # pre-release of agentops-accelerator separately (to satisfy `import agentops`).
   verify-tombstone-testpypi:
     needs: [build-pypi-tombstone, publish-tombstone-testpypi]
     runs-on: ubuntu-latest
@@ -229,14 +238,45 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install agentops-toolkit==${{ needs.build-pypi-tombstone.outputs.tombstone_version }} from TestPyPI
+      - name: Install agentops-toolkit==${{ needs.build-pypi-tombstone.outputs.tombstone_version }} from TestPyPI (no deps)
         env:
           TOMBSTONE_VERSION: ${{ needs.build-pypi-tombstone.outputs.tombstone_version }}
         run: |
+          # --no-deps: in staging the tombstone's `agentops-accelerator>=0.3.0`
+          # requirement cannot be satisfied (staging publishes 0.2.3.devN). We
+          # install the wheel for its metadata only; the dep is provided by the
+          # next step. Retries cover TestPyPI replication lag for the wheel that
+          # `publish-tombstone-testpypi` just uploaded.
           for i in 1 2 3 4 5; do
-            echo "Attempt $i: installing agentops-toolkit==${TOMBSTONE_VERSION} from TestPyPI"
+            echo "Attempt $i: installing agentops-toolkit==${TOMBSTONE_VERSION} from TestPyPI (no deps)"
             if pip install \
               "agentops-toolkit==${TOMBSTONE_VERSION}" \
+              --no-deps \
+              --index-url https://test.pypi.org/simple/; then
+              exit 0
+            fi
+            if [ "$i" -lt 5 ]; then
+              echo "Not available yet, waiting 30s..."
+              sleep 30
+            fi
+          done
+          echo "::error::agentops-toolkit==${TOMBSTONE_VERSION} was not available from TestPyPI after 5 attempts."
+          exit 1
+
+      - name: Install agentops-accelerator pre-release from TestPyPI
+        run: |
+          # Satisfies the tombstone's runtime dep so `import agentops` resolves
+          # to the real package. `--pre` is required because in staging TestPyPI
+          # only carries dev versions (0.2.3.devN); without it pip would refuse
+          # to install them. The extra-index-url lets transitive deps fall back
+          # to real PyPI. We don't pin a version here because the accelerator
+          # version is not exposed as a job output; the latest dev release is
+          # sufficient for an import smoke check.
+          for i in 1 2 3 4 5; do
+            echo "Attempt $i: installing agentops-accelerator (pre) from TestPyPI"
+            if pip install \
+              --pre \
+              "agentops-accelerator" \
               --index-url https://test.pypi.org/simple/ \
               --extra-index-url https://pypi.org/simple/; then
               exit 0
@@ -246,7 +286,7 @@ jobs:
               sleep 30
             fi
           done
-          echo "::error::agentops-toolkit==${TOMBSTONE_VERSION} was not available from TestPyPI after 5 attempts."
+          echo "::error::agentops-accelerator was not available from TestPyPI after 5 attempts."
           exit 1
 
       - name: Verify tombstone redirects to agentops-accelerator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,9 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
     The package long-description on PyPI links to the migration
     instructions.
   - **VS Code Marketplace tombstone**: a final
-    `AgentOpsToolkit.agentops-skills` extension at `tombstones/vscode/`
+    `AgentOpsToolkit.agentops-toolkit` extension at `tombstones/vscode/`
     activates with a one-time prompt offering to install
-    `AgentOpsAccelerator.agentops-skills` (or open the Marketplace
+    `AgentOpsAccelerator.agentops-accelerator` (or open the Marketplace
     page in a browser). A per-install storage sentinel prevents
     re-prompts after the user resolves it.
 

--- a/docs/verifying-tombstones.md
+++ b/docs/verifying-tombstones.md
@@ -2,9 +2,9 @@
 
 This is the maintainer-facing checklist for proving that a release's two
 deprecation tombstones — the [`agentops-toolkit` PyPI metapackage](../tombstones/pypi/pyproject.toml)
-and the [`AgentOpsToolkit.agentops-skills` VSIX](../tombstones/vscode/package.json) —
+and the [`AgentOpsToolkit.agentops-toolkit` VSIX](../tombstones/vscode/package.json) —
 are live, intact, and redirecting users to the renamed
-`agentops-accelerator` / `AgentOpsAccelerator.agentops-skills` artifacts.
+`agentops-accelerator` / `AgentOpsAccelerator.agentops-accelerator` artifacts.
 
 The CI workflow runs a pre-publish smoke test against TestPyPI
 (see [`.github/workflows/release.yml`](../.github/workflows/release.yml) line
@@ -78,7 +78,7 @@ venv created with `sys.executable` and then verifies:
 This mirrors the pre-publish CI verification but adds the shadow-free check
 and version-floor assertion that production needs.
 
-**VSIX (`Check 2`)** — runs `vsce show AgentOpsToolkit.agentops-skills --json`
+**VSIX (`Check 2`)** — runs `vsce show AgentOpsToolkit.agentops-toolkit --json`
 and verifies:
 
 1. `vsce` is on `PATH` and the JSON parses.
@@ -131,7 +131,7 @@ sentinel starts empty.
 
    ```bash
    code --profile fresh-toolkit-1 \
-        --install-extension AgentOpsToolkit.agentops-skills@0.3.0
+        --install-extension AgentOpsToolkit.agentops-toolkit@0.3.0
    ```
 
    Reload the window. Expected: an information notification appears reading:
@@ -144,7 +144,7 @@ sentinel starts empty.
 2. **`Install replacement` installs the new extension and suppresses the prompt.**
 
    In the `fresh-toolkit-1` profile, click `Install replacement`. Expected:
-   VS Code installs `AgentOpsAccelerator.agentops-skills` automatically.
+   VS Code installs `AgentOpsAccelerator.agentops-accelerator` automatically.
    Reload the window again — the prompt **must not** re-appear (the per-install
    sentinel suppresses it).
 
@@ -152,7 +152,7 @@ sentinel starts empty.
 
    ```bash
    code --profile fresh-toolkit-2 \
-        --install-extension AgentOpsToolkit.agentops-skills@0.3.0
+        --install-extension AgentOpsToolkit.agentops-toolkit@0.3.0
    ```
 
    Reload, click `Dismiss`, reload again. Expected: prompt does **not**
@@ -162,11 +162,11 @@ sentinel starts empty.
 
    ```bash
    code --profile fresh-toolkit-3 \
-        --install-extension AgentOpsToolkit.agentops-skills@0.3.0
+        --install-extension AgentOpsToolkit.agentops-toolkit@0.3.0
    ```
 
    Reload, click `Open in Marketplace`. Expected: the system browser opens to
-   <https://marketplace.visualstudio.com/items?itemName=AgentOpsAccelerator.agentops-skills>.
+   <https://marketplace.visualstudio.com/items?itemName=AgentOpsAccelerator.agentops-accelerator>.
 
 All four flows must pass before filing the CDN deprecation request.
 
@@ -178,10 +178,10 @@ Once automated + manual verification are both green:
    [`tombstones/vscode/CDN_DEPRECATION_REQUEST.md`](../tombstones/vscode/CDN_DEPRECATION_REQUEST.md).
 2. Wait 24–48 hours after Microsoft confirms receipt.
 3. Verify: the legacy listing at
-   <https://marketplace.visualstudio.com/items?itemName=AgentOpsToolkit.agentops-skills>
+   <https://marketplace.visualstudio.com/items?itemName=AgentOpsToolkit.agentops-toolkit>
    now shows the standard **Deprecated** banner and a pointer to the
    recommended replacement extension
-   (`AgentOpsAccelerator.agentops-skills`).
+   (`AgentOpsAccelerator.agentops-accelerator`).
 4. Update the tracking issue with the post-deprecation timestamp and a
    screenshot.
 

--- a/tombstones/vscode/CDN_DEPRECATION_REQUEST.md
+++ b/tombstones/vscode/CDN_DEPRECATION_REQUEST.md
@@ -1,6 +1,6 @@
 # VS Code Marketplace CDN Deprecation Request
 
-After the tombstone VSIX (`AgentOpsToolkit.agentops-skills` v0.3.0) is published and live on the Marketplace, file a deprecation request with the VS Code Marketplace team so the legacy listing is officially marked as deprecated and points to the new extension.
+After the tombstone VSIX (`AgentOpsToolkit.agentops-toolkit` v0.3.0) is published and live on the Marketplace, file a deprecation request with the VS Code Marketplace team so the legacy listing is officially marked as deprecated and points to the new extension.
 
 File the request as a new discussion in the VS Code Discussions repo (use the most current "Marketplace deprecation" thread if one already exists, otherwise open a new discussion):
 
@@ -8,15 +8,15 @@ File the request as a new discussion in the VS Code Discussions repo (use the mo
 
 Copy-paste the block below into the discussion, filling in the publisher contact details:
 
-> **Subject:** Mark `AgentOpsToolkit.agentops-skills` as deprecated; point users to `AgentOpsAccelerator.agentops-skills`
+> **Subject:** Mark `AgentOpsToolkit.agentops-toolkit` as deprecated; point users to `AgentOpsAccelerator.agentops-accelerator`
 >
-> **Legacy extension ID:** `AgentOpsToolkit.agentops-skills`
-> **New extension ID:** `AgentOpsAccelerator.agentops-skills`
+> **Legacy extension ID:** `AgentOpsToolkit.agentops-toolkit`
+> **New extension ID:** `AgentOpsAccelerator.agentops-accelerator`
 > **Reason:** Publisher rename. The project rebranded from "AgentOps Toolkit" to "AgentOps Accelerator". Because the Marketplace cannot rename a publisher in place, the extension was republished under a new publisher identifier. A final v0.3.0 tombstone build of the legacy extension has been shipped that prompts existing installs to migrate.
-> **Requested actions on the legacy listing (`AgentOpsToolkit.agentops-skills`):**
+> **Requested actions on the legacy listing (`AgentOpsToolkit.agentops-toolkit`):**
 >
 > 1. Mark the extension as **deprecated** in the Marketplace UI.
-> 2. Add a **migrate-to** pointer to `AgentOpsAccelerator.agentops-skills` so the Marketplace surfaces the replacement extension.
+> 2. Add a **migrate-to** pointer to `AgentOpsAccelerator.agentops-accelerator` so the Marketplace surfaces the replacement extension.
 > 3. (Optional) Hide the legacy listing from search results once the migrate-to pointer is in place.
 >
 > **Tracking issue:** <https://github.com/Azure/agentops/issues/181>
@@ -25,7 +25,7 @@ Copy-paste the block below into the discussion, filling in the publisher contact
 
 ## Pre-flight checklist
 
-- [ ] Tombstone VSIX (`AgentOpsToolkit.agentops-skills` v0.3.0) is published to the Marketplace and the listing is live.
-- [ ] New extension (`AgentOpsAccelerator.agentops-skills`) is published to the Marketplace and the listing is live.
+- [ ] Tombstone VSIX (`AgentOpsToolkit.agentops-toolkit` v0.3.0) is published to the Marketplace and the listing is live.
+- [ ] New extension (`AgentOpsAccelerator.agentops-accelerator`) is published to the Marketplace and the listing is live.
 - [ ] Tracking issue <https://github.com/Azure/agentops/issues/181> is up to date with the publish status of both extensions.
 - [ ] Publisher contact (email / Azure DevOps org admin) is filled in above before submitting.

--- a/tombstones/vscode/CHANGELOG.md
+++ b/tombstones/vscode/CHANGELOG.md
@@ -10,4 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- This extension (`AgentOpsToolkit.agentops-skills`) is deprecated. It has been renamed and republished as `AgentOpsAccelerator.agentops-skills` ("AgentOps Accelerator — Skills for GitHub Copilot"). This final build only prompts users to install the new extension and uninstall this one. See <https://github.com/Azure/agentops/issues/181>.
+- This extension (`AgentOpsToolkit.agentops-toolkit`) is deprecated. It has been renamed and republished as `AgentOpsAccelerator.agentops-accelerator` ("AgentOps Accelerator — Skills for GitHub Copilot"). This final build only prompts users to install the new extension and uninstall this one. See <https://github.com/Azure/agentops/issues/181>.

--- a/tombstones/vscode/README.md
+++ b/tombstones/vscode/README.md
@@ -4,8 +4,8 @@
 
 ## Migrate in two steps
 
-1. **Install the new extension** from the Marketplace: [AgentOpsAccelerator.agentops-skills](https://marketplace.visualstudio.com/items?itemName=AgentOpsAccelerator.agentops-skills).
-2. **Uninstall this extension** (`AgentOpsToolkit.agentops-skills`) from your Extensions view.
+1. **Install the new extension** from the Marketplace: [AgentOpsAccelerator.agentops-accelerator](https://marketplace.visualstudio.com/items?itemName=AgentOpsAccelerator.agentops-accelerator).
+2. **Uninstall this extension** (`AgentOpsToolkit.agentops-toolkit`) from your Extensions view.
 
 ## Why the rename?
 

--- a/tombstones/vscode/package.json
+++ b/tombstones/vscode/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "agentops-skills",
+  "name": "agentops-toolkit",
   "displayName": "[DEPRECATED] AgentOps Toolkit — Migrate to AgentOps Accelerator",
-  "description": "Deprecated. This extension was renamed to 'AgentOps Accelerator — Skills for GitHub Copilot' (AgentOpsAccelerator.agentops-skills). Please install the new extension and uninstall this one.",
+  "description": "Deprecated. This extension was renamed to 'AgentOps Accelerator — Skills for GitHub Copilot' (AgentOpsAccelerator.agentops-accelerator). Please install the new extension and uninstall this one.",
   "version": "0.3.0",
   "publisher": "AgentOpsToolkit",
   "license": "MIT",

--- a/tombstones/vscode/src/extension.ts
+++ b/tombstones/vscode/src/extension.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
 
-const NEW_EXTENSION_ID = 'AgentOpsAccelerator.agentops-skills';
+const NEW_EXTENSION_ID = 'AgentOpsAccelerator.agentops-accelerator';
 const STORAGE_KEY = 'agentops-toolkit.deprecation-prompt-shown';
 
 const DEPRECATION_MESSAGE =
     'The "AgentOps Toolkit" extension has been renamed to "AgentOps Accelerator". ' +
-    'Please install the new extension (AgentOpsAccelerator.agentops-skills) and uninstall this one ' +
+    `Please install the new extension (${NEW_EXTENSION_ID}) and uninstall this one ` +
     'to continue receiving updates.';
 
 const INSTALL_ACTION = 'Install new extension';


### PR DESCRIPTION
## Pre-tag-push hotfixes for v0.3.0

PR #187 was merged before two issues were caught:

1. **P0 — VSIX tombstone shipped with the wrong extension identity.** The tombstone scaffolded in `2f128d9` published as `AgentOpsToolkit.agentops-skills` (a brand-new extension that has never existed on the VS Code Marketplace) and pointed migrating users to `AgentOpsAccelerator.agentops-skills` (also wrong — the canonical new identity per `plugins/agentops/package.json` is `AgentOpsAccelerator.agentops-accelerator`).

   Without this fix, publishing v0.3.0 would create a brand-new extension nobody has installed, and the ~5 versions of the legacy `AgentOpsToolkit.agentops-toolkit` extension already in users' VS Code installs would never receive a deprecation prompt.

   `018cf74` rewrites the tombstone to identify itself as `AgentOpsToolkit.agentops-toolkit` (republishes onto the existing Marketplace listing, triggers in-place update for current users) and corrects all references to the new extension across `package.json`, `src/extension.ts`, the tombstone README/CHANGELOG/CDN deprecation request, the repo-root `CHANGELOG.md` (flows into the GitHub release body and PyPI tombstone long description), and `docs/verifying-tombstones.md` (verification commands users will copy-paste).

2. **CI hygiene — staging `verify-tombstone-testpypi` flaked when only dev versions of accelerator existed on TestPyPI.** `5af6936` splits the verification into two install steps (tombstone with `--no-deps`, then accelerator with `--pre`) so staging stays green between full releases. No effect on `release.yml` (PyPI prod always has both packages at the tagged version when the verify step runs).

## Verification

Staging on `release/v0.3.0` is fully green at `018cf74` (8/8 jobs, [run #26615257593](https://github.com/Azure/agentops/actions/runs/26615257593)):

- `build-pypi-tombstone` ✅
- `build / build` ✅
- `publish-vsix-prerelease` ✅
- `publish-testpypi` ✅
- `verify-testpypi` ✅
- `publish-tombstone-testpypi` ✅
- `publish-tombstone-vsix-prerelease` ✅ — confirms `AgentOpsToolkit.agentops-toolkit` v0.3.0-pre publishes cleanly under the existing publisher
- `verify-tombstone-testpypi` ✅ — confirms the redirect (`agentops-toolkit==0.3.0` → `agentops-accelerator>=0.3.0`) installs cleanly from TestPyPI

## Critic review (`tombstone-identity-critic`, Correctness lens)

- Identity coherence ✅ — `publisher`+`name` yield `AgentOpsToolkit.agentops-toolkit`
- Version monotonicity ✅ — `0.3.0 > 0.1.8` (highest existing) and `> 0.2.2` (highest in git history)
- `NEW_EXTENSION_ID` consistency ✅ — all 4 use sites + `DEPRECATION_MESSAGE` interpolation
- Storage key namespace preservation ✅ — `agentops-toolkit.deprecation-prompt-shown` unchanged
- Backward compatibility ✅ — legacy versions 0.1.7 and 0.2.2 verified declarative-only (`contributes.chatSkills` only, no `main`/commands/keybindings/settings), so zero state-collision risk
- Workflow cross-references ✅ — `release.yml` `publish-tombstone-vsix` and `staging.yml` `publish-tombstone-vsix-prerelease` consume the renamed manifest cleanly

## Plan after merge

1. Tag `v0.3.0` at this merge commit
2. `release.yml` triggers — publishes `agentops-accelerator==0.3.0` + `agentops-toolkit==0.3.0` tombstone to PyPI; publishes accelerator + tombstone VSIX to VS Code Marketplace; creates GitHub release
3. Verify all three tombstones live (PyPI, VSCode Marketplace, TestPyPI)
4. File the Microsoft CDN deprecation request per `tombstones/vscode/CDN_DEPRECATION_REQUEST.md`

Closes part of #181.
