### PR TITLE
fix(agent): use ruamel.yaml instead of pyyaml in agent modules

### DIFF
--- a/src/agentops/agent/checks/opex_workspace.py
+++ b/src/agentops/agent/checks/opex_workspace.py
@@ -24,7 +24,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 
 from agentops.agent.findings import Category, Finding, Severity
 
@@ -552,8 +553,8 @@ def _safe_load_yaml(path: Path) -> Optional[dict]:
         return None
     try:
         with path.open("r", encoding="utf-8") as handle:
-            data = yaml.safe_load(handle)
-    except (OSError, yaml.YAMLError):
+            data = YAML(typ="safe").load(handle)
+    except (OSError, YAMLError):
         return None
     return data if isinstance(data, dict) else None
 

--- a/src/agentops/agent/checks/spec_conformance.py
+++ b/src/agentops/agent/checks/spec_conformance.py
@@ -22,7 +22,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, List, Optional
 
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 
 from agentops.agent.config import SpecConformanceCheckConfig
 from agentops.agent.findings import Category, Finding, Severity
@@ -297,8 +298,8 @@ def _check_agent_drift(workspace: Path, doc: SpecDocument) -> List[Finding]:
     if not run_yaml.exists():
         return []
     try:
-        raw = yaml.safe_load(run_yaml.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError):
+        raw = YAML(typ="safe").load(run_yaml.read_text(encoding="utf-8"))
+    except (OSError, YAMLError):
         return []
     if not isinstance(raw, dict):
         return []
@@ -342,8 +343,8 @@ def _collect_evaluator_names(workspace: Path) -> set[str]:
         return out
     for p in bundles_dir.glob("*.y*ml"):
         try:
-            raw = yaml.safe_load(p.read_text(encoding="utf-8"))
-        except (OSError, yaml.YAMLError):
+            raw = YAML(typ="safe").load(p.read_text(encoding="utf-8"))
+        except (OSError, YAMLError):
             continue
         if not isinstance(raw, dict):
             continue

--- a/src/agentops/agent/cockpit.py
+++ b/src/agentops/agent/cockpit.py
@@ -2286,11 +2286,11 @@ def _resolve_agent_identity(workspace: Path) -> Tuple[Optional[str], str]:
     ``agentops.yaml``) takes precedence over the legacy layered schema
     (``target.endpoint.agent_id`` in ``run.yaml``).
     """
-    import yaml  # noqa: PLC0415
+    from ruamel.yaml import YAML  # noqa: PLC0415
 
     def _read_yaml(path: Path) -> Optional[dict]:
         try:
-            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+            data = YAML(typ="safe").load(path.read_text(encoding="utf-8"))
         except Exception:  # noqa: BLE001
             return None
         return data if isinstance(data, dict) else None

--- a/src/agentops/agent/llm_assist/_bundle_rule.py
+++ b/src/agentops/agent/llm_assist/_bundle_rule.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 
 from agentops.agent.findings import Category, Finding
 from agentops.agent.llm_assist._base import (
@@ -106,8 +107,8 @@ def check_bundle_coverage(
 
     # Sanity check: skip when the YAML is unparseable.
     try:
-        yaml.safe_load(bundle_text)
-    except yaml.YAMLError:
+        YAML(typ="safe").load(bundle_text)
+    except YAMLError:
         return []
 
     ih = hash_text("bundle_coverage", bundle_text, agent_excerpt)


### PR DESCRIPTION
## What

Refactor four `agentops/agent/*` modules from `import yaml` (PyYAML) to the existing `ruamel.yaml` dependency.

## Why

PyYAML is not declared in `pyproject.toml` (we declare `ruamel.yaml>=0.18,<1.0`). On a clean CI runner with no PyYAML in the venv, `agentops doctor` crashes with:

```
ModuleNotFoundError: No module named 'yaml'
```

That's exactly what happens in the dev-deploy workflow generated by `agentops workflow generate` — the doctor step fails on a freshly-provisioned project that's only seen `pip install agentops-accelerator`.

## Files

- `src/agentops/agent/checks/opex_workspace.py`
- `src/agentops/agent/checks/spec_conformance.py`
- `src/agentops/agent/llm_assist/_bundle_rule.py`
- `src/agentops/agent/cockpit.py` (preserved lazy-import semantics inside `_resolve_agent_identity`)

Same pattern used in the existing `src/agentops/utils/yaml.py`:

```python
from ruamel.yaml import YAML
from ruamel.yaml.error import YAMLError

data = YAML(typ="safe").load(text_or_handle)
```

## Verification

- `python -m pytest tests/ -x -q` — **784 passed, 3 skipped** locally on Windows.
- Real diff: `+16/-13` across 4 files (commit shows `+6565/-6562` due to CRLF normalization; ignore).
- No new dependencies declared in `pyproject.toml`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
