### PR TITLE
hotfix(cloud-eval): extract scores from real Foundry azure_ai_evaluator result shape (cherry-pick #195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+- **Cloud-eval parser no longer returns null scores for Foundry
+  `azure_ai_evaluator` graders.** The parser now probes a wider set of
+  score-carrier keys (`score`, `value`, `result`, `metric_value`,
+  `rating`, `grader_score`, `numeric_value`), falls back to `passed`
+  (bool) and then `label` (`"pass"` / `"fail"` strings), and descends
+  into `sample` / `details` as a final resort. Treats `score: 0` as a
+  legitimate value (was previously coerced to `None` in some paths).
+  Without this fix, every metric in a Foundry cloud run came back
+  `value: null` against the real on-the-wire shape — the `report.md`
+  threshold table showed every metric as `actual=missing` and exit code
+  2 fired with `Threshold status: FAILED` even when the run itself
+  succeeded.
+
+### Added
+- **`cloud_output_items.json` raw dump.** Every cloud eval run now
+  writes the raw `output_items` it received from Foundry to
+  `<output_dir>/cloud_output_items.json`, in addition to the parsed
+  `results.json`. When a future grader / SDK upgrade changes the on-the-
+  wire shape and the parser stops finding scores, the artifact bundle
+  alone is enough to triage the issue. The orchestrator also emits an
+  explicit warning to the progress channel when a cloud run yields zero
+  usable metric scores despite returning rows, pointing the user at the
+  new dump file.
+
 ## [0.3.0] - 2026-05-28
 
 ### Added

--- a/src/agentops/pipeline/cloud_results.py
+++ b/src/agentops/pipeline/cloud_results.py
@@ -61,21 +61,86 @@ def _row_from_item(index: int, item: Dict[str, Any]) -> RowResult:
     )
 
 
+_NUMERIC_SCORE_KEYS = (
+    "score",
+    "value",
+    "result",
+    "metric_value",
+    "rating",
+    "grader_score",
+    "numeric_value",
+)
+_PASS_LABELS = {"pass", "passed", "true", "yes", "1", "ok", "success"}
+_FAIL_LABELS = {"fail", "failed", "false", "no", "0", "error", "errored"}
+
+
+def _score_from_label(value: Any) -> Optional[float]:
+    """Map a textual pass/fail label onto 1.0 / 0.0."""
+    if not isinstance(value, str):
+        return None
+    token = value.strip().lower()
+    if not token:
+        return None
+    if token in _PASS_LABELS:
+        return 1.0
+    if token in _FAIL_LABELS:
+        return 0.0
+    return None
+
+
+def _score_from_mapping(entry: Dict[str, Any]) -> Optional[float]:
+    """Probe a dict-like result envelope for a score using a wide net of
+    field names. Mirrors the loose-shape contract documented at the top
+    of this module: Foundry / OpenAI Evals API have shipped at least
+    ``score``, ``value``, ``result``, ``grader_score`` and ``rating`` as
+    the numeric carrier across SDK versions and grader types, plus
+    ``passed`` (bool) and ``label`` (string) as binary fallbacks."""
+    score = _coerce_float(*(entry.get(k) for k in _NUMERIC_SCORE_KEYS))
+    if score is not None:
+        return score
+    passed = entry.get("passed")
+    if isinstance(passed, bool):
+        return 1.0 if passed else 0.0
+    label_score = _score_from_label(entry.get("label"))
+    if label_score is not None:
+        return label_score
+    return None
+
+
 def _metric_from_result(entry: Any) -> Optional[RowMetric]:
     if not isinstance(entry, dict):
         return None
     name = entry.get("name") or entry.get("metric")
     if not isinstance(name, str) or not name:
         return None
-    score = _coerce_float(
-        entry.get("score"),
-        entry.get("value"),
-        entry.get("result"),
-    )
-    if score is None and isinstance(entry.get("passed"), bool):
-        score = 1.0 if entry["passed"] else 0.0
+
+    # First try the top-level envelope where azure_ai_evaluator graders
+    # populate `score` + `passed` directly.
+    score = _score_from_mapping(entry)
+
+    # Some Foundry server-side graders (especially custom prompt-based
+    # evaluators) tuck the score down inside `sample` or `details`
+    # instead. Probe those as a fallback so a missing top-level score
+    # doesn't mask an evaluator that actually returned a number.
+    if score is None:
+        sample = entry.get("sample")
+        if isinstance(sample, dict):
+            score = _score_from_mapping(sample)
+    if score is None:
+        details = entry.get("details")
+        if isinstance(details, dict):
+            score = _score_from_mapping(details)
+
     reason = entry.get("reason") if isinstance(entry.get("reason"), str) else None
     err = entry.get("error") if isinstance(entry.get("error"), str) else None
+    if score is None and err is None:
+        # Surface the missing-score case as a structured reason instead of
+        # silently writing null. The orchestrator/reporter use this string
+        # to point operators at `cloud_output_items.json` for triage.
+        err = (
+            "no numeric score returned by Foundry grader; inspect "
+            "cloud_output_items.json in the results directory."
+        )
     return RowMetric(name=name, value=score, error=err, reason=reason)
 
 

--- a/src/agentops/pipeline/orchestrator.py
+++ b/src/agentops/pipeline/orchestrator.py
@@ -392,6 +392,35 @@ def _run_evaluation_cloud(
     finished_at = datetime.now(timezone.utc)
     duration = time.perf_counter() - started_perf
 
+    # Always persist the raw Foundry output_items next to results.json /
+    # report.md so the run is debuggable from the artifact bundle alone.
+    # This is the only place the per-row grader payloads survive in their
+    # native shape; without it a parser regression looks the same in CI
+    # as a real eval failure.
+    try:
+        options.output_dir.mkdir(parents=True, exist_ok=True)
+        raw_items_path = options.output_dir / "cloud_output_items.json"
+        raw_items_path.write_text(
+            json.dumps(list(published.output_items), indent=2, default=str),
+            encoding="utf-8",
+        )
+    except (OSError, TypeError) as exc:
+        progress(f"warning: failed to write cloud_output_items.json: {exc}")
+        raw_items_path = None
+
+    # If the cloud run yielded zero usable metric values despite running
+    # graders, surface that loudly so the user does not chase a phantom
+    # "threshold failed" gate. The artifact dumped above is the triage
+    # entry point.
+    if presets and not aggregate and rows:
+        suffix = (
+            f" Inspect {raw_items_path}." if raw_items_path is not None else ""
+        )
+        progress(
+            "warning: cloud eval returned 0 usable metric scores across "
+            f"{len(rows)} row(s).{suffix}"
+        )
+
     result = RunResult(
         started_at=started_at.isoformat(),
         finished_at=finished_at.isoformat(),

--- a/tests/unit/test_cloud_results.py
+++ b/tests/unit/test_cloud_results.py
@@ -121,3 +121,116 @@ def test_passes_through_context_and_tool_calls_from_datasource():
     rows = rows_from_cloud_output_items(items)
     assert rows[0].context == "greeting context"
     assert rows[0].tool_calls == [{"name": "lookup"}]
+
+
+def test_extracts_score_zero_as_legitimate_value():
+    """``score: 0`` is the lowest valid number and must not be coerced to None.
+    Real Foundry safety graders (violence/sexual/self_harm) emit ``score: 0``
+    on a clean row plus ``label: "pass"``; treating zero as missing collapses
+    the row to ``missing`` in the threshold table."""
+    items = [
+        _item(
+            {"input": "hi"},
+            {"output_text": "hello"},
+            [{"name": "violence", "score": 0, "label": "pass", "passed": True}],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    by_name = {m.name: m.value for m in rows[0].metrics}
+    assert by_name == {"violence": 0.0}
+
+
+def test_extracts_real_foundry_azure_ai_evaluator_result_shape():
+    """The on-the-wire shape emitted by Foundry's ``azure_ai_evaluator``
+    grader carries both ``metric`` and ``name`` plus a ``label``, a
+    ``threshold``, and a ``passed`` boolean. The parser must find the
+    score under the canonical ``score`` field even with all the extra keys
+    present (extras must not shadow the score). Schema sourced from
+    Azure/azure-sdk-for-python evaluation fixture
+    ``evaluation_util_convert_expected_output.json``."""
+    items = [
+        _item(
+            {"input": "hi", "expected": "hello"},
+            {"output_text": "hello"},
+            [
+                {
+                    "type": "azure_ai_evaluator",
+                    "name": "violence",
+                    "metric": "violence",
+                    "score": 0,
+                    "label": "pass",
+                    "reason": "no violent content detected",
+                    "threshold": 3,
+                    "passed": True,
+                    "sample": {"output_text": "hello"},
+                    "status": "completed",
+                },
+                {
+                    "type": "azure_ai_evaluator",
+                    "name": "coherence",
+                    "metric": "coherence",
+                    "score": 4.5,
+                    "reason": "well-structured response",
+                    "passed": True,
+                    "status": "completed",
+                },
+            ],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    by_name = {m.name: m.value for m in rows[0].metrics}
+    assert by_name == {"violence": 0.0, "coherence": 4.5}
+
+
+def test_extracts_score_nested_in_sample_when_top_level_missing():
+    """Some custom Foundry prompt-based graders only populate
+    ``result["sample"]["score"]`` rather than ``result["score"]``. The
+    parser must descend into ``sample`` as a fallback so those metrics
+    don't show up as missing."""
+    items = [
+        _item(
+            {"input": "hi"},
+            {"output_text": "hello"},
+            [{"name": "custom_quality", "sample": {"score": 3.5}}],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    by_name = {m.name: m.value for m in rows[0].metrics}
+    assert by_name == {"custom_quality": 3.5}
+
+
+def test_extracts_score_from_label_when_no_numeric_score():
+    """Binary content-safety graders sometimes return only ``label: pass``
+    / ``label: fail`` with no numeric score. Treat those as 1.0 / 0.0 so
+    they don't drop out of the threshold table as missing."""
+    items = [
+        _item(
+            {"input": "hi"},
+            {"output_text": "hello"},
+            [
+                {"name": "protected_material", "label": "pass"},
+                {"name": "hate_unfairness", "label": "fail"},
+            ],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    by_name = {m.name: m.value for m in rows[0].metrics}
+    assert by_name == {"protected_material": 1.0, "hate_unfairness": 0.0}
+
+
+def test_records_diagnostic_reason_when_score_is_missing():
+    """When a grader returns absolutely no usable score the parser emits a
+    structured ``error`` pointing operators at the raw items file. Silent
+    nulls were the symptom that motivated this fix."""
+    items = [
+        _item(
+            {"input": "hi"},
+            {"output_text": "hello"},
+            [{"name": "coherence"}],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    metric = rows[0].metrics[0]
+    assert metric.value is None
+    assert metric.error is not None
+    assert "cloud_output_items.json" in metric.error


### PR DESCRIPTION
Cherry-picks #195 onto main so the fix ships to PyPI / Marketplace alongside v0.3.0 users without waiting for the next release cycle.

## What this is

Verbatim cherry-pick of the develop merge commit `0fe6b00`. CHANGELOG.md conflict resolved by re-applying the same `[Unreleased]` entries on top of main's current changelog (which had the same shape).

## Why ship to main directly

Same argument as #194 (PyYAML hotfix shipped to main last week): every tutorial user that hits the prompt-agent PR / deploy workflow today fires this bug, gets a red gate on first pass, and loses the `first pass is green` learning moment that the tutorial depends on. Cannot wait for the next minor.

## Validation

- `git diff --ignore-cr-at-eol --stat origin/main..HEAD` → `+239 / -7` across 4 files (matches the develop PR exactly).
- `python -m pytest tests/unit/test_cloud_results.py -x -q` → `11 passed`.
- Full suite on develop pre-merge: `789 passed, 3 skipped`.

## Background

See #195 for the full root-cause writeup, real Foundry on-the-wire schema, and the +5 new tests covering the real `azure_ai_evaluator` shape, `score: 0` boundary, `label`-only graders, nested `sample.score`, and the diagnostic-error path.