### PR TITLE
fix(cicd): upload cloud_output_items.json as CI artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   succeeded.
 
 ### Added
+- **`cloud_output_items.json` is now uploaded as a CI artifact.** Generated PR and deploy workflows (GitHub Actions and Azure DevOps) include `.agentops/results/latest/cloud_output_items.json` in the `agentops-*-results` artifact bundle alongside `results.json`, `report.md`, and `cloud_evaluation.json`. Pairs with the "0 usable scores" warning so operators can diagnose unrecognized Foundry grader shapes without re-running locally.
 - **`cloud_output_items.json` raw dump.** Every cloud eval run now
   writes the raw `output_items` it received from Foundry to
   `<output_dir>/cloud_output_items.json`, in addition to the parsed

--- a/src/agentops/services/cicd.py
+++ b/src/agentops/services/cicd.py
@@ -319,7 +319,8 @@ def _github_eval_substitutions(eval_runner: str, config_path: str) -> Mapping[st
           exit $ec""",
             "__EVAL_ARTIFACT_PATHS__": f"""{_CI_EVAL_OUTPUT}/results.json
             {_CI_EVAL_OUTPUT}/report.md
-            {_CI_EVAL_OUTPUT}/cloud_evaluation.json""",
+            {_CI_EVAL_OUTPUT}/cloud_evaluation.json
+            {_CI_EVAL_OUTPUT}/cloud_output_items.json""",
         }
     if eval_runner == OFFICIAL_EVAL_RUNNER:
         official_action = official_eval_action_ref()
@@ -413,7 +414,8 @@ def _github_eval_substitutions(eval_runner: str, config_path: str) -> Mapping[st
           exit $ec""",
         "__EVAL_ARTIFACT_PATHS__": """.agentops/results/latest/results.json
             .agentops/results/latest/report.md
-            .agentops/results/latest/cloud_evaluation.json""",
+            .agentops/results/latest/cloud_evaluation.json
+            .agentops/results/latest/cloud_output_items.json""",
     }
 
 


### PR DESCRIPTION
Hotfix: include `cloud_output_items.json` in CI artifact bundle so operators can triage unrecognized Foundry grader shapes without re-running locally. Cherry-pick of #197 (already merged to `develop`). Real diff +5/-2 across 2 files.