### PR TITLE
fix(ci): migrate publish-dev to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,19 @@
 #
 # NOTE: VSIX publishing is handled exclusively by staging.yml (pre-release)
 # and release.yml (stable). CI only validates that the VSIX packages correctly.
+#
+# Trusted Publishing (OIDC):
+#   The publish-dev job uses PyPI Trusted Publishing — no API tokens required.
+#   Authentication is handled via OpenID Connect (OIDC) between GitHub Actions
+#   and TestPyPI.
+#
+# Setup (Trusted Publishing):
+#   1. https://test.pypi.org/manage/project/agentops-accelerator/settings/publishing/
+#      → Add publisher: GitHub, owner=Azure, repo=agentops, workflow=ci.yml, environment=staging
+#      (This is a SEPARATE entry from the workflow=staging.yml / workflow=release.yml
+#       publishers — TestPyPI matches workflow filename exactly.)
+#   2. GitHub repo → Settings → Environments → "staging" → confirm "Deployment branches
+#      and tags" allows `develop` (publish-dev is the only consumer triggered from develop).
 
 name: CI
 
@@ -109,6 +122,8 @@ jobs:
     needs: [lint, test]
     runs-on: ubuntu-latest
     environment: staging
+    permissions:
+      id-token: write  # Required for PyPI Trusted Publishing (OIDC)
     steps:
       - uses: actions/checkout@v6
         with:
@@ -138,7 +153,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           verbose: true
           skip-existing: true
 


### PR DESCRIPTION
## Summary

Fixes the `publish-dev` job in `ci.yml`, which has been failing on every push to `develop` since the rebrand. Migrates from a non-existent API token to PyPI Trusted Publishing (OIDC) — the same pattern already used by `staging.yml` and `release.yml`.

## Root cause

Failing run for reference: [ci #26618715632](https://github.com/Azure/agentops/actions/runs/26618715632)

```
OpenID Connect token retrieval failed: GitHub: missing or insufficient
OIDC token permissions, the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment
variable was unset
```

- Job passed `password: ${{ secrets.TEST_PYPI_TOKEN }}` to `pypa/gh-action-pypi-publish`
- `TEST_PYPI_TOKEN` secret was never configured in the `staging` environment (`gh secret list --env staging` shows only `VSCE_PAT`)
- The action fell back to OIDC Trusted Publishing, which failed because the job had no `permissions: id-token: write` declaration
- Even if the token existed, it would be scoped to the legacy `agentops-toolkit` project and wouldn't work for the rebranded `agentops-accelerator`

## Change (11 +/1 -)

1. **Add job-level OIDC permission** to `publish-dev`:
   ```yaml
   permissions:
     id-token: write  # Required for PyPI Trusted Publishing (OIDC)
   ```
2. **Remove the `password:` line** so `pypa/gh-action-pypi-publish` uses OIDC unambiguously.
3. **Document the Trusted Publishing setup** in the workflow header, mirroring the pattern proven in `staging.yml` and `release.yml`.

`verify-dev` is unchanged — it only installs from public TestPyPI and never authenticates.

## ⚠️ Required actions BEFORE merging

Without these the first post-merge run will fail with `not a trusted publisher` or an environment-policy error (different failure mode than today's, but still broken):

1. **Register Trusted Publisher on TestPyPI** at https://test.pypi.org/manage/project/agentops-accelerator/settings/publishing/
   - Owner: `Azure`
   - Repository: `agentops`
   - Workflow: `ci.yml`
   - Environment: `staging`

   This must be a **separate** entry from the existing `workflow=staging.yml` and `workflow=release.yml` publishers — TestPyPI matches the workflow filename exactly.

2. **Confirm `staging` GitHub Environment allows `develop`** under Settings → Environments → staging → "Deployment branches and tags". `publish-dev` is the only consumer of `staging` triggered from a non-`release/**`/non-`v*` ref.

## Validation

- ✅ YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- ✅ Zero `TEST_PYPI_TOKEN` references remain in `.github/` (`grep -rn TEST_PYPI_TOKEN .github/`)
- ✅ Pattern matches `staging.yml:56-75` and `release.yml:76-94` character-for-character
- ✅ No collateral changes (only the 3 chunks in ci.yml)
- ✅ Reviewed by Critic — CLEAN

