### PR TITLE
fix(cloud-eval): lift grader execution errors into RowMetric.error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+- **Cloud eval surfaces grader execution errors instead of silent nulls.**
+  When a Foundry `azure_ai_evaluator` grader fails to execute (most
+  commonly because the evaluator service principal lacks
+  `Cognitive Services OpenAI User` on the target model deployment), the
+  per-metric `score` comes back `null` and the real cause is buried in
+  `result.sample.error.message`. The cloud-results parser now lifts that
+  message into `RowMetric.error` (including the error `code` prefix
+  when present), so the actionable error appears in `results.json` and
+  `report.md` instead of operators only seeing `actual=missing` in the
+  threshold table. The orchestrator's "0 usable metric scores" warning
+  also quotes the first grader error so CI logs carry the signal
+  without operators having to download the raw artifact.
+
 ### Added
 - **`cloud_output_items.json` is now uploaded as a CI artifact.** Generated PR and deploy workflows (GitHub Actions and Azure DevOps) include `.agentops/results/latest/cloud_output_items.json` in the `agentops-*-results` artifact bundle alongside `results.json`, `report.md`, and `cloud_evaluation.json`. Pairs with the "0 usable scores" warning so operators can diagnose unrecognized Foundry grader shapes without re-running locally.
 - **`cloud_output_items.json` raw dump.** Every cloud eval run now

--- a/src/agentops/pipeline/cloud_results.py
+++ b/src/agentops/pipeline/cloud_results.py
@@ -132,7 +132,7 @@ def _metric_from_result(entry: Any) -> Optional[RowMetric]:
             score = _score_from_mapping(details)
 
     reason = entry.get("reason") if isinstance(entry.get("reason"), str) else None
-    err = entry.get("error") if isinstance(entry.get("error"), str) else None
+    err = _extract_grader_error(entry)
     if score is None and err is None:
         # Surface the missing-score case as a structured reason instead of
         # silently writing null. The orchestrator/reporter use this string
@@ -142,6 +142,63 @@ def _metric_from_result(entry: Any) -> Optional[RowMetric]:
             "cloud_output_items.json in the results directory."
         )
     return RowMetric(name=name, value=score, error=err, reason=reason)
+
+
+def _extract_grader_error(entry: Dict[str, Any]) -> Optional[str]:
+    """Pull a human-readable error out of a Foundry grader result envelope.
+
+    The on-the-wire shape we have seen in production when an
+    ``azure_ai_evaluator`` grader fails to execute (e.g., the evaluator
+    service principal lacks RBAC on the model deployment) is::
+
+        {
+          "name": "coherence",
+          "score": null,
+          "passed": null,
+          "status": "error",
+          "sample": {
+            "error": {
+              "code": "FAILED_EXECUTION",
+              "message": "(UserError) OpenAI API hits AuthenticationError: ..."
+            }
+          }
+        }
+
+    Without lifting ``sample.error.message`` into ``RowMetric.error``, the
+    real cause is buried in ``cloud_output_items.json`` and the user only
+    sees ``actual=missing`` in the threshold table. Probe (in order):
+
+    1. Top-level ``error`` (string or ``{message, code}`` dict).
+    2. ``sample.error`` (string or ``{message, code}`` dict).
+    3. ``status == "error"`` as a last-resort signal so we at least flag
+       the row even when no error payload is present.
+    """
+    primary = _normalize_error_payload(entry.get("error"))
+    if primary is not None:
+        return primary
+    sample = entry.get("sample")
+    if isinstance(sample, dict):
+        nested = _normalize_error_payload(sample.get("error"))
+        if nested is not None:
+            return nested
+    status = entry.get("status")
+    if isinstance(status, str) and status.strip().lower() == "error":
+        return "grader status: error (no error payload returned)"
+    return None
+
+
+def _normalize_error_payload(value: Any) -> Optional[str]:
+    """Flatten ``error`` (string or ``{message, code}`` dict) into one line."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, dict):
+        message = value.get("message") or value.get("error")
+        if isinstance(message, str) and message.strip():
+            code = value.get("code")
+            if isinstance(code, str) and code.strip():
+                return f"{code.strip()}: {message.strip()}"
+            return message.strip()
+    return None
 
 
 def _extract_response_text(sample: Dict[str, Any]) -> str:

--- a/src/agentops/pipeline/orchestrator.py
+++ b/src/agentops/pipeline/orchestrator.py
@@ -411,14 +411,19 @@ def _run_evaluation_cloud(
     # If the cloud run yielded zero usable metric values despite running
     # graders, surface that loudly so the user does not chase a phantom
     # "threshold failed" gate. The artifact dumped above is the triage
-    # entry point.
+    # entry point, but we also lift the first per-metric error string
+    # into the warning itself so CI logs carry the actionable cause
+    # (most often: the Foundry evaluator service principal lacks
+    # `Cognitive Services OpenAI User` on the model deployment).
     if presets and not aggregate and rows:
         suffix = (
             f" Inspect {raw_items_path}." if raw_items_path is not None else ""
         )
+        first_error = _first_metric_error(rows)
+        cause_suffix = f" First grader error: {first_error}" if first_error else ""
         progress(
             "warning: cloud eval returned 0 usable metric scores across "
-            f"{len(rows)} row(s).{suffix}"
+            f"{len(rows)} row(s).{cause_suffix}{suffix}"
         )
 
     result = RunResult(
@@ -756,6 +761,21 @@ def _aggregate_metrics(rows: List[RowResult]) -> Dict[str, float]:
         if values:
             aggregate[name] = statistics.fmean(values)
     return aggregate
+
+
+def _first_metric_error(rows: List[RowResult]) -> Optional[str]:
+    """Return the first non-empty per-metric error string across all rows.
+
+    Used by the cloud-eval orchestrator to lift the actionable cause of
+    an all-null aggregate (e.g., RBAC failure on the evaluator's model
+    deployment) into the user-facing warning so CI logs carry the signal
+    without operators having to download the raw artifact.
+    """
+    for row in rows:
+        for metric in row.metrics:
+            if isinstance(metric.error, str) and metric.error.strip():
+                return metric.error.strip()
+    return None
 
 
 def _summarize(

--- a/tests/unit/test_cloud_results.py
+++ b/tests/unit/test_cloud_results.py
@@ -234,3 +234,105 @@ def test_records_diagnostic_reason_when_score_is_missing():
     assert metric.value is None
     assert metric.error is not None
     assert "cloud_output_items.json" in metric.error
+
+
+def test_lifts_grader_execution_error_from_sample_error_dict():
+    """When a Foundry ``azure_ai_evaluator`` grader fails to execute (e.g.
+    the evaluator service principal lacks ``Cognitive Services OpenAI
+    User`` on the model deployment), the failure is buried inside
+    ``result.sample.error.message`` and the top-level score is just
+    ``null``. The parser must lift that message into ``RowMetric.error``
+    so the actionable cause shows up in ``results.json`` / ``report.md``
+    instead of operators seeing only ``actual=missing`` in the threshold
+    table. Schema mirrors the on-the-wire shape captured from real
+    Foundry ``cloud_output_items.json`` artifacts."""
+    items = [
+        _item(
+            {"input": "hi", "expected": "hello"},
+            {"output_text": "hello"},
+            [
+                {
+                    "name": "coherence",
+                    "metric": "coherence",
+                    "type": "azure_ai_evaluator",
+                    "score": None,
+                    "passed": None,
+                    "label": None,
+                    "reason": None,
+                    "threshold": None,
+                    "status": "error",
+                    "sample": {
+                        "error": {
+                            "code": "FAILED_EXECUTION",
+                            "message": (
+                                "(UserError) OpenAI API hits "
+                                "AuthenticationError: Error code: 401 - "
+                                "PermissionDenied: lacks the required data "
+                                "action chat/completions/action"
+                            ),
+                        }
+                    },
+                }
+            ],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    metric = rows[0].metrics[0]
+    assert metric.name == "coherence"
+    assert metric.value is None
+    assert metric.error is not None
+    assert metric.error.startswith("FAILED_EXECUTION: ")
+    assert "AuthenticationError" in metric.error
+    assert "PermissionDenied" in metric.error
+    assert "cloud_output_items.json" not in metric.error
+
+
+def test_lifts_grader_error_from_top_level_dict_payload():
+    """Some Foundry response shapes carry the error as a dict at the top
+    level of the result envelope rather than inside ``sample.error``.
+    The parser must accept both shapes interchangeably."""
+    items = [
+        _item(
+            {"input": "hi"},
+            {"output_text": "hello"},
+            [
+                {
+                    "name": "fluency",
+                    "score": None,
+                    "error": {
+                        "code": "RateLimited",
+                        "message": "rate limit exceeded",
+                    },
+                }
+            ],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    metric = rows[0].metrics[0]
+    assert metric.value is None
+    assert metric.error == "RateLimited: rate limit exceeded"
+
+
+def test_grader_error_payload_does_not_shadow_a_real_score():
+    """A grader can return ``status: completed`` plus a numeric score
+    even when ``sample.error`` exists for an upstream warning. In that
+    case the numeric score wins and ``RowMetric.error`` stays empty so
+    aggregation continues normally."""
+    items = [
+        _item(
+            {"input": "hi"},
+            {"output_text": "hello"},
+            [
+                {
+                    "name": "coherence",
+                    "score": 4.5,
+                    "status": "completed",
+                    "sample": {"error": None},
+                }
+            ],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    metric = rows[0].metrics[0]
+    assert metric.value == 4.5
+    assert metric.error is None


### PR DESCRIPTION
When a Foundry `azure_ai_evaluator` grader fails to execute (most commonly because the evaluator service principal lacks `Cognitive Services OpenAI User` on the target model deployment), the per-metric `score` comes back `null` and the real cause is buried in `result.sample.error.message`. Operators see only `actual=missing` in the threshold table and the CI gate fires as `threshold_failed` for the wrong reason.

## Root cause (real shape from PO's run)

```json
{
  "name": "coherence",
  "score": null,
  "passed": null,
  "status": "error",
  "sample": {
    "error": {
      "code": "FAILED_EXECUTION",
      "message": "OpenAI API hits AuthenticationError: 401 PermissionDenied: The principal lacks the required data action chat/completions/action"
    }
  }
}
```nThe parser only probed `error` as a top-level string. It never reached `sample.error.message`.

## Fix

- `cloud_results._metric_from_result` now calls a new `_extract_grader_error` that probes (in order): top-level `error`, `sample.error`, and `status == 'error'` as last resort. Accepts both string and `{code, message}` dict shapes; prefixes the error code when present.
- `orchestrator` 0-usable-scores warning now quotes the first per-metric error so CI logs carry the actionable cause without operators having to download the raw artifact.
- 3 new unit tests in `test_cloud_results.py` covering: `sample.error.message` dict lift, top-level `error` dict, and the case where a real score must not be shadowed by a stale `sample.error: null`.

## Verification

- `python -m pytest tests/unit/test_cloud_results.py -x -q` → 14 passed.
- `python -m pytest tests/ -x -q` → 792 passed, 3 skipped.
- Real artifact from `placerda/agentops-prompt-quickstart` run #26618645299 shown above as the source of the fixture.