### PR TITLE
fix(cloud-eval): lift grader execution errors into RowMetric.error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 ## [Unreleased]
 
 ### Fixed
+- **Cloud eval surfaces grader execution errors instead of silent nulls.**
+  When a Foundry `azure_ai_evaluator` grader fails to execute (most
+  commonly because the evaluator service principal lacks
+  `Cognitive Services OpenAI User` on the target model deployment), the
+  per-metric `score` comes back `null` and the real cause is buried in
+  `result.sample.error.message`. The cloud-results parser now lifts that
+  message into `RowMetric.error` (including the error `code` prefix
+  when present), so the actionable error appears in `results.json` and
+  `report.md` instead of operators only seeing `actual=missing` in the
+  threshold table. The orchestrator's "0 usable metric scores" warning
+  also quotes the first grader error so CI logs carry the signal
+  without operators having to download the raw artifact.
+
+### Added
+- **`cloud_output_items.json` is now uploaded as a CI artifact.** Generated PR and deploy workflows (GitHub Actions and Azure DevOps) include `.agentops/results/latest/cloud_output_items.json` in the `agentops-*-results` artifact bundle alongside `results.json`, `report.md`, and `cloud_evaluation.json`. Pairs with the "0 usable scores" warning so operators can diagnose unrecognized Foundry grader shapes without re-running locally.
+- **`cloud_output_items.json` raw dump.** Every cloud eval run now
+  writes the raw `output_items` it received from Foundry to
+  `<output_dir>/cloud_output_items.json`, in addition to the parsed
+  `results.json`. When a future grader / SDK upgrade changes the on-the-
+  wire shape and the parser stops finding scores, the artifact bundle
+  alone is enough to triage the issue. The orchestrator also emits an
+  explicit warning to the progress channel when a cloud run yields zero
+  usable metric scores despite returning rows, pointing the user at the
+  new dump file.
+- **`.gitattributes`** pinning `*.yml` / `*.yaml` / `*.sh` / `*.md` /
+  `*.py` to LF line endings, preventing future CRLF↔LF churn from
+  Windows clones with `core.autocrlf=true`. Normalizes the existing
+  `_build.yml` and `ci.yml` (previously CRLF) to LF so all files in
+  `.github/workflows/` share a single line-ending convention.
+
+### Removed
+- **Retired tombstone publish jobs from CI.** The `agentops-toolkit` →
+  `agentops-accelerator` deprecation tombstones were one-shot publishes
+  for v0.3.0 / v0.3.1; the `build-pypi-tombstone`,
+  `publish-tombstone-testpypi`, `verify-tombstone-testpypi`,
+  `publish-tombstone-pypi`, and `publish-tombstone-vsix(-prerelease)`
+  jobs (plus their `cut-release.yml` plugin-version sync steps) have
+  been removed from `release.yml`, `staging.yml`, and `cut-release.yml`.
+  The `github-release` job now depends only on `publish-pypi` and
+  `publish-vsix` (both required), and the dead `always()` guard has
+  been dropped. Future releases ship only `agentops-accelerator` on
+  PyPI and the `AgentOpsAccelerator.agentops-accelerator` VSIX.
+  The orphaned `scripts/verify_tombstones.py` harness and
+  `docs/verifying-tombstones.md` checklist (both one-shot tools
+  whose CI counterpart no longer exists) have been removed, along
+  with the now-unused `tombstones/pypi/` package source and the
+  `tombstones/vscode/` extension source — only
+  `tombstones/vscode/CDN_DEPRECATION_REQUEST.md` survives as the
+  template for the still-pending Microsoft CDN deprecation request.
+
+### Fixed
 - **Cloud-eval parser no longer returns null scores for Foundry
   `azure_ai_evaluator` graders.** The parser now probes a wider set of
   score-carrier keys (`score`, `value`, `result`, `metric_value`,
@@ -19,21 +70,23 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   2 fired with `Threshold status: FAILED` even when the run itself
   succeeded.
 
-### Added
-- **`cloud_output_items.json` is now uploaded as a CI artifact.** Generated PR and deploy workflows (GitHub Actions and Azure DevOps) include `.agentops/results/latest/cloud_output_items.json` in the `agentops-*-results` artifact bundle alongside `results.json`, `report.md`, and `cloud_evaluation.json`. Pairs with the "0 usable scores" warning so operators can diagnose unrecognized Foundry grader shapes without re-running locally.
-- **`cloud_output_items.json` raw dump.** Every cloud eval run now
-  writes the raw `output_items` it received from Foundry to
-  `<output_dir>/cloud_output_items.json`, in addition to the parsed
-  `results.json`. When a future grader / SDK upgrade changes the on-the-
-  wire shape and the parser stops finding scores, the artifact bundle
-  alone is enough to triage the issue. The orchestrator also emits an
-  explicit warning to the progress channel when a cloud run yields zero
-  usable metric scores despite returning rows, pointing the user at the
-  new dump file.
-
 ## [0.3.0] - 2026-05-28
 
 ### Added
+- **Auto-bootstrap empty Foundry projects on first deploy.** New optional
+  `prompt_agent_bootstrap` block in `agentops.yaml` lets the prompt-agent
+  deploy workflow create the first version of an agent in a dev / qa / prod
+  Foundry project that does not yet have one. When the stage step looks up
+  the seed agent and gets a 404, it reads the model deployment (required)
+  plus optional `description`, `model_parameters`, and `tools` from
+  `prompt_agent_bootstrap`, combines them with `prompt_file`, and creates
+  the first version automatically. The deployment artifact records the new
+  `action: "bootstrapped"` for that first run; subsequent deploys follow
+  the normal reuse / next-version flow. Eliminates the previous
+  per-environment manual seeding step. `agentops workflow analyze` now
+  warns when a prompt-agent workspace is missing this block. Authentication
+  (401 / 403) and other non-404 errors continue to propagate — the
+  bootstrap path only triggers on a genuine "agent does not exist" 404.
 - **`--doctor-gate` flag on `agentops workflow generate`.** New option
   `--doctor-gate critical|warning|none` controls the Doctor severity floor
   in the PR workflow template. Default is `critical`, which makes the PR
@@ -401,3 +454,4 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   - `agentops report --in <results.json> [--out <report.md>]`
 - Unit tests for models, YAML/config loading, and workspace initialization behavior.
 - Initial documentation including generic quickstart and test running guide.
+

--- a/src/agentops/pipeline/cloud_results.py
+++ b/src/agentops/pipeline/cloud_results.py
@@ -132,7 +132,7 @@ def _metric_from_result(entry: Any) -> Optional[RowMetric]:
             score = _score_from_mapping(details)
 
     reason = entry.get("reason") if isinstance(entry.get("reason"), str) else None
-    err = entry.get("error") if isinstance(entry.get("error"), str) else None
+    err = _extract_grader_error(entry)
     if score is None and err is None:
         # Surface the missing-score case as a structured reason instead of
         # silently writing null. The orchestrator/reporter use this string
@@ -142,6 +142,63 @@ def _metric_from_result(entry: Any) -> Optional[RowMetric]:
             "cloud_output_items.json in the results directory."
         )
     return RowMetric(name=name, value=score, error=err, reason=reason)
+
+
+def _extract_grader_error(entry: Dict[str, Any]) -> Optional[str]:
+    """Pull a human-readable error out of a Foundry grader result envelope.
+
+    The on-the-wire shape we have seen in production when an
+    ``azure_ai_evaluator`` grader fails to execute (e.g., the evaluator
+    service principal lacks RBAC on the model deployment) is::
+
+        {
+          "name": "coherence",
+          "score": null,
+          "passed": null,
+          "status": "error",
+          "sample": {
+            "error": {
+              "code": "FAILED_EXECUTION",
+              "message": "(UserError) OpenAI API hits AuthenticationError: ..."
+            }
+          }
+        }
+
+    Without lifting ``sample.error.message`` into ``RowMetric.error``, the
+    real cause is buried in ``cloud_output_items.json`` and the user only
+    sees ``actual=missing`` in the threshold table. Probe (in order):
+
+    1. Top-level ``error`` (string or ``{message, code}`` dict).
+    2. ``sample.error`` (string or ``{message, code}`` dict).
+    3. ``status == "error"`` as a last-resort signal so we at least flag
+       the row even when no error payload is present.
+    """
+    primary = _normalize_error_payload(entry.get("error"))
+    if primary is not None:
+        return primary
+    sample = entry.get("sample")
+    if isinstance(sample, dict):
+        nested = _normalize_error_payload(sample.get("error"))
+        if nested is not None:
+            return nested
+    status = entry.get("status")
+    if isinstance(status, str) and status.strip().lower() == "error":
+        return "grader status: error (no error payload returned)"
+    return None
+
+
+def _normalize_error_payload(value: Any) -> Optional[str]:
+    """Flatten ``error`` (string or ``{message, code}`` dict) into one line."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, dict):
+        message = value.get("message") or value.get("error")
+        if isinstance(message, str) and message.strip():
+            code = value.get("code")
+            if isinstance(code, str) and code.strip():
+                return f"{code.strip()}: {message.strip()}"
+            return message.strip()
+    return None
 
 
 def _extract_response_text(sample: Dict[str, Any]) -> str:

--- a/src/agentops/pipeline/orchestrator.py
+++ b/src/agentops/pipeline/orchestrator.py
@@ -411,14 +411,19 @@ def _run_evaluation_cloud(
     # If the cloud run yielded zero usable metric values despite running
     # graders, surface that loudly so the user does not chase a phantom
     # "threshold failed" gate. The artifact dumped above is the triage
-    # entry point.
+    # entry point, but we also lift the first per-metric error string
+    # into the warning itself so CI logs carry the actionable cause
+    # (most often: the Foundry evaluator service principal lacks
+    # `Cognitive Services OpenAI User` on the model deployment).
     if presets and not aggregate and rows:
         suffix = (
             f" Inspect {raw_items_path}." if raw_items_path is not None else ""
         )
+        first_error = _first_metric_error(rows)
+        cause_suffix = f" First grader error: {first_error}" if first_error else ""
         progress(
             "warning: cloud eval returned 0 usable metric scores across "
-            f"{len(rows)} row(s).{suffix}"
+            f"{len(rows)} row(s).{cause_suffix}{suffix}"
         )
 
     result = RunResult(
@@ -756,6 +761,21 @@ def _aggregate_metrics(rows: List[RowResult]) -> Dict[str, float]:
         if values:
             aggregate[name] = statistics.fmean(values)
     return aggregate
+
+
+def _first_metric_error(rows: List[RowResult]) -> Optional[str]:
+    """Return the first non-empty per-metric error string across all rows.
+
+    Used by the cloud-eval orchestrator to lift the actionable cause of
+    an all-null aggregate (e.g., RBAC failure on the evaluator's model
+    deployment) into the user-facing warning so CI logs carry the signal
+    without operators having to download the raw artifact.
+    """
+    for row in rows:
+        for metric in row.metrics:
+            if isinstance(metric.error, str) and metric.error.strip():
+                return metric.error.strip()
+    return None
 
 
 def _summarize(

--- a/tests/unit/test_cloud_results.py
+++ b/tests/unit/test_cloud_results.py
@@ -234,3 +234,105 @@ def test_records_diagnostic_reason_when_score_is_missing():
     assert metric.value is None
     assert metric.error is not None
     assert "cloud_output_items.json" in metric.error
+
+
+def test_lifts_grader_execution_error_from_sample_error_dict():
+    """When a Foundry ``azure_ai_evaluator`` grader fails to execute (e.g.
+    the evaluator service principal lacks ``Cognitive Services OpenAI
+    User`` on the model deployment), the failure is buried inside
+    ``result.sample.error.message`` and the top-level score is just
+    ``null``. The parser must lift that message into ``RowMetric.error``
+    so the actionable cause shows up in ``results.json`` / ``report.md``
+    instead of operators seeing only ``actual=missing`` in the threshold
+    table. Schema mirrors the on-the-wire shape captured from real
+    Foundry ``cloud_output_items.json`` artifacts."""
+    items = [
+        _item(
+            {"input": "hi", "expected": "hello"},
+            {"output_text": "hello"},
+            [
+                {
+                    "name": "coherence",
+                    "metric": "coherence",
+                    "type": "azure_ai_evaluator",
+                    "score": None,
+                    "passed": None,
+                    "label": None,
+                    "reason": None,
+                    "threshold": None,
+                    "status": "error",
+                    "sample": {
+                        "error": {
+                            "code": "FAILED_EXECUTION",
+                            "message": (
+                                "(UserError) OpenAI API hits "
+                                "AuthenticationError: Error code: 401 - "
+                                "PermissionDenied: lacks the required data "
+                                "action chat/completions/action"
+                            ),
+                        }
+                    },
+                }
+            ],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    metric = rows[0].metrics[0]
+    assert metric.name == "coherence"
+    assert metric.value is None
+    assert metric.error is not None
+    assert metric.error.startswith("FAILED_EXECUTION: ")
+    assert "AuthenticationError" in metric.error
+    assert "PermissionDenied" in metric.error
+    assert "cloud_output_items.json" not in metric.error
+
+
+def test_lifts_grader_error_from_top_level_dict_payload():
+    """Some Foundry response shapes carry the error as a dict at the top
+    level of the result envelope rather than inside ``sample.error``.
+    The parser must accept both shapes interchangeably."""
+    items = [
+        _item(
+            {"input": "hi"},
+            {"output_text": "hello"},
+            [
+                {
+                    "name": "fluency",
+                    "score": None,
+                    "error": {
+                        "code": "RateLimited",
+                        "message": "rate limit exceeded",
+                    },
+                }
+            ],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    metric = rows[0].metrics[0]
+    assert metric.value is None
+    assert metric.error == "RateLimited: rate limit exceeded"
+
+
+def test_grader_error_payload_does_not_shadow_a_real_score():
+    """A grader can return ``status: completed`` plus a numeric score
+    even when ``sample.error`` exists for an upstream warning. In that
+    case the numeric score wins and ``RowMetric.error`` stays empty so
+    aggregation continues normally."""
+    items = [
+        _item(
+            {"input": "hi"},
+            {"output_text": "hello"},
+            [
+                {
+                    "name": "coherence",
+                    "score": 4.5,
+                    "status": "completed",
+                    "sample": {"error": None},
+                }
+            ],
+        ),
+    ]
+    rows = rows_from_cloud_output_items(items)
+    metric = rows[0].metrics[0]
+    assert metric.value == 4.5
+    assert metric.error is None


### PR DESCRIPTION
Hotfix mirror of #201 onto `main`.

Source-controlled trace of the same fix already merged to `develop` as commit `6bea832`.

## Summary

When a Foundry `azure_ai_evaluator` grader fails to execute (most commonly because the evaluator service principal lacks `Cognitive Services OpenAI User` on the target model deployment), the per-metric `score` comes back `null` and the real cause is buried in `result.sample.error.message`. The cloud-results parser now lifts that message into `RowMetric.error` (including the error `code` prefix when present), so the actionable error appears in `results.json` and `report.md` instead of operators only seeing `actual=missing` in the threshold table. The orchestrator's "0 usable metric scores" warning also quotes the first grader error so CI logs carry the signal without operators having to download the raw artifact.

## Files

- `src/agentops/pipeline/cloud_results.py` — new `_extract_grader_error` + `_normalize_error_payload` helpers; `_metric_from_result` now lifts grader errors.
- `src/agentops/pipeline/orchestrator.py` — new `_first_metric_error` helper; the "0 usable scores" warning quotes the first error.
- `tests/unit/test_cloud_results.py` — 3 new tests covering the RBAC failure shape, top-level `error` dict, and "real score wins over stale `sample.error`".
- `CHANGELOG.md` — entry under `[Unreleased]` ▸ `Fixed`.

## Verification

- `pytest tests/unit/test_cloud_results.py` → 14 passed (locally on develop before merge).
- `pytest tests/` → 792 passed, 3 skipped (locally on develop before merge).
- All 12 CI checks green on #201 (lint, build-vsix, coverage, 6× pytest matrix).

## Notes

- The amend ensures source files retain CRLF line endings consistent with `main`'s existing convention (no `.gitattributes` here yet).
- After this merges, sync `develop ← main` (no-op for code; merges only the branch pointer).

Closes the gap left by #195/#196 (parser widening) and #197/#199 (artifact upload): those probed for scores that never existed because the grader had errored. This PR finally surfaces the error.