### PR TITLE
fix(wizard): refuse cross-env endpoint pre-fill when --azd-env is explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   `5e0bd9bd-7b93-4f28-af87-19fc36ad61bd`) before dispatching the workflow.
 
 ### Fixed
+- **`agentops init --azd-env <name>` no longer pre-fills the endpoint from a different env.**
+  When the user explicitly targets a new azd env (e.g. `--azd-env dev` while the
+  active env is `sandbox`), the wizard now refuses to pre-fill
+  `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` from sources that don't match the
+  targeted env — process environment, legacy top-level `project_endpoint:` in
+  `agentops.yaml`, or a *different* `.azure/<env>/.env` file. Instead it
+  prompts with no default and prints a short note explaining where the
+  suspect default came from (e.g. "the active azd env `sandbox`'s
+  `.azure/sandbox/.env`"). This stops the silent sandbox→dev endpoint leak
+  that surfaced when users ran the multi-env tutorials; values picked up
+  from the targeted env's own `.azure/<env>/.env` are still honored. The
+  strict check only fires when `--azd-env` is passed explicitly — bare
+  `agentops init` keeps its existing best-effort default behavior.
 - **Cloud eval surfaces grader execution errors instead of silent nulls.**
   When a Foundry `azure_ai_evaluator` grader fails to execute (most
   commonly because the evaluator service principal lacks

--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -1587,6 +1587,7 @@ def cmd_init(
             on_answer=_on_answer,
             reconfigure=reconfigure,
             force_prompt_fields=force_prompt_fields,
+            target_env_name=azd_env_name,
         )
 
     # ----- Phase 4: apply (idempotent — covers scripted mode and any

--- a/src/agentops/services/setup_wizard.py
+++ b/src/agentops/services/setup_wizard.py
@@ -73,14 +73,35 @@ ENV_KEY_APPINSIGHTS = "APPLICATIONINSIGHTS_CONNECTION_STRING"
 # ---------------------------------------------------------------------------
 
 
+# Endpoint-default provenance — informational only, used by the wizard to
+# decide whether to suppress a discovered default value because it likely
+# belongs to a *different* environment than the one being configured.
+ENDPOINT_SOURCE_AZD_ENV_FILE = "azd-env-file"
+ENDPOINT_SOURCE_AGENTOPS_ENV_FILE = "agentops-env-file"
+ENDPOINT_SOURCE_PROCESS_ENV = "process-env"
+ENDPOINT_SOURCE_YAML_LEGACY = "yaml-legacy"
+ENDPOINT_SOURCE_NONE = "none"
+
+
 @dataclass
 class WizardAnswers:
-    """User answers collected by the wizard."""
+    """User answers collected by the wizard.
+
+    The ``project_endpoint_source`` / ``project_endpoint_source_path`` fields
+    are populated by :func:`discover_defaults` to record *where* the default
+    project endpoint came from. They are informational only — never persisted
+    by :func:`apply_answers` — and the prompt loop in :func:`run_wizard` uses
+    them to suppress cross-environment leak (for example, a sandbox endpoint
+    exported in ``$AZURE_AI_FOUNDRY_PROJECT_ENDPOINT`` bleeding into a
+    fresh ``--azd-env dev`` setup).
+    """
 
     project_endpoint: Optional[str] = None
     agent: Optional[str] = None
     dataset: Optional[str] = None
     appinsights_connection_string: Optional[str] = None
+    project_endpoint_source: Optional[str] = None
+    project_endpoint_source_path: Optional[Path] = None
 
 
 @dataclass
@@ -107,16 +128,40 @@ def discover_defaults(workspace: Path) -> WizardAnswers:
 
     Returns the *current effective values* the wizard should pre-fill as
     defaults. Empty fields mean "no current value, ask the user fresh".
+
+    The returned :class:`WizardAnswers` also carries provenance for
+    ``project_endpoint`` via ``project_endpoint_source`` and
+    ``project_endpoint_source_path`` so the prompt loop can detect and
+    suppress cross-environment leaks (e.g. a shell-exported sandbox
+    endpoint bleeding into a fresh ``--azd-env dev`` setup).
     """
     workspace = workspace.resolve()
     yaml_data = _read_agentops_yaml(workspace)
-    env_values = _read_active_env(workspace)
+    env_values, env_source_path = _read_active_env_with_source(workspace)
 
-    project_endpoint = (
-        env_values.get(ENV_KEY_PROJECT_ENDPOINT)
-        or os.environ.get(ENV_KEY_PROJECT_ENDPOINT)
-        or _as_str(yaml_data.get("project_endpoint"))
-    )
+    project_endpoint: Optional[str] = None
+    endpoint_source: str = ENDPOINT_SOURCE_NONE
+    endpoint_source_path: Optional[Path] = None
+
+    env_value = env_values.get(ENV_KEY_PROJECT_ENDPOINT)
+    if env_value:
+        project_endpoint = env_value
+        endpoint_source_path = env_source_path
+        if env_source_path is not None and ".azure" in env_source_path.parts:
+            endpoint_source = ENDPOINT_SOURCE_AZD_ENV_FILE
+        else:
+            endpoint_source = ENDPOINT_SOURCE_AGENTOPS_ENV_FILE
+    else:
+        proc_value = os.environ.get(ENV_KEY_PROJECT_ENDPOINT)
+        if proc_value:
+            project_endpoint = proc_value
+            endpoint_source = ENDPOINT_SOURCE_PROCESS_ENV
+        else:
+            yaml_value = _as_str(yaml_data.get("project_endpoint"))
+            if yaml_value:
+                project_endpoint = yaml_value
+                endpoint_source = ENDPOINT_SOURCE_YAML_LEGACY
+
     agent = _as_str(yaml_data.get("agent"))
     dataset = _as_str(yaml_data.get("dataset"))
     appinsights = (
@@ -129,6 +174,8 @@ def discover_defaults(workspace: Path) -> WizardAnswers:
         agent=agent,
         dataset=dataset,
         appinsights_connection_string=appinsights,
+        project_endpoint_source=endpoint_source,
+        project_endpoint_source_path=endpoint_source_path,
     )
 
 
@@ -393,15 +440,28 @@ def ensure_agentops_gitignore(agentops_dir: Path) -> bool:
 
 def _read_active_env(workspace: Path) -> dict[str, str]:
     """Read the active env file (azd env first, then AgentOps local env)."""
+    values, _ = _read_active_env_with_source(workspace)
+    return values
+
+
+def _read_active_env_with_source(
+    workspace: Path,
+) -> tuple[dict[str, str], Optional[Path]]:
+    """Read the active env file AND return the path it came from.
+
+    The path is what lets the wizard later detect that a discovered default
+    value came from a *different* azd environment than the one the user is
+    currently configuring.
+    """
     from agentops.utils.azd_env import discover_azd_env, parse_env_file  # noqa: PLC0415
 
     location = discover_azd_env(workspace)
     if location.found and location.env_path is not None:
-        return parse_env_file(location.env_path)
+        return parse_env_file(location.env_path), location.env_path
     agentops_env = workspace / ".agentops" / ".env"
     if agentops_env.is_file():
-        return parse_env_file(agentops_env)
-    return {}
+        return parse_env_file(agentops_env), agentops_env
+    return {}, None
 
 
 # ---------------------------------------------------------------------------
@@ -446,6 +506,7 @@ def run_wizard(
     on_answer: Optional[OnAnswerFn] = None,
     reconfigure: bool = False,
     force_prompt_fields: Optional[Collection[str]] = None,
+    target_env_name: Optional[str] = None,
 ) -> WizardAnswers:
     """Drive the interactive question loop.
 
@@ -469,6 +530,17 @@ def run_wizard(
     selected fields while still reusing other existing defaults. The CLI uses
     this on a first interactive run so starter ``agentops.yaml`` values remain
     visible defaults instead of being accepted as real user choices.
+
+    ``target_env_name`` is the azd environment the user is *explicitly*
+    configuring (i.e. ``agentops init --azd-env <name>``). When provided, the
+    wizard suppresses any discovered default for ``project_endpoint`` that
+    came from a *different* source than ``.azure/<target>/.env`` (for example,
+    an ``$AZURE_AI_FOUNDRY_PROJECT_ENDPOINT`` exported in the shell from a
+    sandbox project, or another azd env's ``.env``). The user is shown an
+    explicit note about the discovered cross-environment value and asked to
+    enter the endpoint for the targeted env explicitly. Without
+    ``target_env_name`` (the bare ``agentops init`` case), behavior is
+    unchanged.
     """
     defaults = discover_defaults(workspace)
     answers = WizardAnswers()
@@ -496,15 +568,37 @@ def run_wizard(
         echo(f"  {ok_glyph} {label}: {display}")
 
     # 1) Foundry project endpoint
-    if not _should_prompt("project_endpoint", defaults.project_endpoint):
+    #
+    # When the user explicitly asked for a specific azd env via --azd-env,
+    # any default value that did NOT come from that env's own .env file is
+    # suspect: it most likely belongs to a different environment (sandbox /
+    # qa / prod) that just happens to be active in the user's shell. We
+    # suppress the pre-fill and surface a note so the user knows what we
+    # ignored and why.
+    cross_env_note = _detect_cross_env_endpoint_leak(
+        workspace=workspace,
+        target_env_name=target_env_name,
+        defaults=defaults,
+    )
+    suppress_endpoint_default = cross_env_note is not None
+    effective_endpoint_default = (
+        None if suppress_endpoint_default else defaults.project_endpoint
+    )
+
+    if not suppress_endpoint_default and not _should_prompt(
+        "project_endpoint", defaults.project_endpoint
+    ):
         _confirm_existing(PROJECT_ENDPOINT_TITLE, defaults.project_endpoint or "")
         skipped.append("project_endpoint")
     else:
         echo("")
         echo(PROJECT_ENDPOINT_TITLE)
         echo(_indent(PROJECT_ENDPOINT_HELP))
+        if cross_env_note:
+            echo("")
+            echo(_indent(cross_env_note))
         while True:
-            raw = prompt("Foundry project endpoint", defaults.project_endpoint)
+            raw = prompt("Foundry project endpoint", effective_endpoint_default)
             value = raw.strip()
             if not value:
                 break  # keep current / leave blank
@@ -573,6 +667,54 @@ def run_wizard(
 
 def _indent(text: str, prefix: str = "    ") -> str:
     return "\n".join(prefix + line for line in text.splitlines())
+
+
+def _detect_cross_env_endpoint_leak(
+    *,
+    workspace: Path,
+    target_env_name: Optional[str],
+    defaults: WizardAnswers,
+) -> Optional[str]:
+    """Return a user-facing note when the discovered endpoint default looks
+    like it belongs to a *different* environment than ``target_env_name``.
+
+    Returns ``None`` when the default is trustworthy (or when the wizard
+    was not given a target env to be opinionated about). The returned
+    string is a complete multi-line explanation suitable to ``echo`` above
+    the project-endpoint prompt; the caller is responsible for suppressing
+    the pre-fill (so the user must type the correct endpoint explicitly).
+    """
+    if not target_env_name:
+        return None
+    if not defaults.project_endpoint:
+        return None
+    source = defaults.project_endpoint_source or ENDPOINT_SOURCE_NONE
+    if source in (ENDPOINT_SOURCE_NONE, ENDPOINT_SOURCE_AGENTOPS_ENV_FILE):
+        return None
+    if source == ENDPOINT_SOURCE_AZD_ENV_FILE:
+        target_env_file = (workspace / ".azure" / target_env_name / ".env").resolve()
+        source_path = defaults.project_endpoint_source_path
+        if source_path is not None and source_path.resolve() == target_env_file:
+            return None  # Same azd env as the user targeted — safe to reuse.
+        source_label = (
+            f"another azd env file ({source_path})"
+            if source_path is not None
+            else "another azd env file"
+        )
+    elif source == ENDPOINT_SOURCE_PROCESS_ENV:
+        source_label = f"your shell environment (${ENV_KEY_PROJECT_ENDPOINT})"
+    elif source == ENDPOINT_SOURCE_YAML_LEGACY:
+        source_label = "the legacy 'project_endpoint' field in agentops.yaml"
+    else:  # pragma: no cover - defensive
+        source_label = source
+
+    return (
+        f"Note: a Foundry project endpoint was discovered in {source_label}:\n"
+        f"    {defaults.project_endpoint}\n"
+        f"Not using it as a default for env '{target_env_name}' because it may "
+        f"belong to a different environment.\n"
+        f"Please paste the endpoint for the '{target_env_name}' Foundry project:"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -155,6 +155,78 @@ def test_discover_defaults_env_var_fallback_for_project_endpoint(
     assert defaults.project_endpoint and "from-shell" in defaults.project_endpoint
 
 
+def test_discover_defaults_tracks_endpoint_source_azd_env_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Endpoint read from .azure/<env>/.env reports source=azd-env-file."""
+    monkeypatch.delenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT", raising=False)
+    monkeypatch.delenv("AZURE_ENV_NAME", raising=False)
+    env_path = _seed_azd_env(
+        tmp_path,
+        "dev",
+        {
+            "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT": (
+                '"https://from-azd.services.ai.azure.com/api/projects/p"'
+            ),
+        },
+    )
+    defaults = discover_defaults(tmp_path)
+    assert defaults.project_endpoint_source == "azd-env-file"
+    assert defaults.project_endpoint_source_path == env_path
+
+
+def test_discover_defaults_tracks_endpoint_source_agentops_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Endpoint read from .agentops/.env reports source=agentops-env-file."""
+    monkeypatch.delenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT", raising=False)
+    (tmp_path / ".agentops").mkdir()
+    (tmp_path / ".agentops" / ".env").write_text(
+        'AZURE_AI_FOUNDRY_PROJECT_ENDPOINT="https://legacy.services.ai.azure.com/api/projects/p"\n',
+        encoding="utf-8",
+    )
+    defaults = discover_defaults(tmp_path)
+    assert defaults.project_endpoint_source == "agentops-env-file"
+    assert defaults.project_endpoint_source_path is not None
+
+
+def test_discover_defaults_tracks_endpoint_source_process_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Endpoint inherited from the shell reports source=process-env."""
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://from-shell.services.ai.azure.com/api/projects/p",
+    )
+    defaults = discover_defaults(tmp_path)
+    assert defaults.project_endpoint_source == "process-env"
+    assert defaults.project_endpoint_source_path is None
+
+
+def test_discover_defaults_tracks_endpoint_source_yaml_legacy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Endpoint from the legacy yaml field reports source=yaml-legacy."""
+    monkeypatch.delenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT", raising=False)
+    (tmp_path / "agentops.yaml").write_text(
+        "version: 1\n"
+        "agent: my-bot:1\n"
+        "project_endpoint: https://from-yaml.services.ai.azure.com/api/projects/p\n",
+        encoding="utf-8",
+    )
+    defaults = discover_defaults(tmp_path)
+    assert defaults.project_endpoint_source == "yaml-legacy"
+
+
+def test_discover_defaults_endpoint_source_none_when_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT", raising=False)
+    defaults = discover_defaults(tmp_path)
+    assert defaults.project_endpoint is None
+    assert defaults.project_endpoint_source == "none"
+
+
 # ---------------------------------------------------------------------------
 # Apply / persistence
 # ---------------------------------------------------------------------------
@@ -550,6 +622,212 @@ def test_run_wizard_re_prompts_on_invalid_input(
     assert answers.project_endpoint == "https://acct.services.ai.azure.com/api/projects/p"
     assert answers.agent == "my-bot:2"
     assert len(errors) == 2
+
+
+# ---------------------------------------------------------------------------
+# Cross-environment endpoint protection (--azd-env <name>)
+# ---------------------------------------------------------------------------
+
+
+def test_run_wizard_suppresses_cross_env_endpoint_from_process_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A shell-exported endpoint must NOT pre-fill when targeting --azd-env dev.
+
+    Reproduces the leak vector where ``$AZURE_AI_FOUNDRY_PROJECT_ENDPOINT``
+    points at the user's sandbox project but they are running
+    ``agentops init --azd-env dev`` against a freshly-created dev env.
+    """
+    monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_ENV_NAME", raising=False)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://sandbox.services.ai.azure.com/api/projects/p",
+    )
+    _seed_azd_env(tmp_path, "dev", {})  # dev env exists but is empty
+    (tmp_path / "agentops.yaml").write_text(
+        "version: 1\nagent: keep:1\ndataset: keep.jsonl\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "keep.jsonl").write_text("{}\n", encoding="utf-8")
+
+    seen_defaults: list = []
+    messages: list[str] = []
+
+    def prompt(_question: str, default):  # noqa: ANN001
+        seen_defaults.append(default)
+        return "https://dev.services.ai.azure.com/api/projects/p"
+
+    answers = run_wizard(
+        tmp_path,
+        prompt=prompt,
+        echo=messages.append,
+        target_env_name="dev",
+    )
+
+    assert answers.project_endpoint == (
+        "https://dev.services.ai.azure.com/api/projects/p"
+    )
+    # The endpoint prompt was called with no default (None) — not pre-filled.
+    assert seen_defaults and seen_defaults[0] is None
+    output = "\n".join(messages)
+    assert "sandbox.services.ai.azure.com" in output
+    assert "shell environment" in output
+
+
+def test_run_wizard_suppresses_cross_env_endpoint_from_yaml_legacy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A legacy yaml ``project_endpoint`` must NOT pre-fill an explicit env."""
+    monkeypatch.delenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT", raising=False)
+    monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_ENV_NAME", raising=False)
+    (tmp_path / "agentops.yaml").write_text(
+        "version: 1\n"
+        "agent: keep:1\n"
+        "dataset: keep.jsonl\n"
+        "project_endpoint: https://from-yaml.services.ai.azure.com/api/projects/p\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "keep.jsonl").write_text("{}\n", encoding="utf-8")
+    _seed_azd_env(tmp_path, "dev", {})
+
+    seen_defaults: list = []
+    messages: list[str] = []
+
+    def prompt(_question: str, default):  # noqa: ANN001
+        seen_defaults.append(default)
+        return "https://dev.services.ai.azure.com/api/projects/p"
+
+    run_wizard(
+        tmp_path,
+        prompt=prompt,
+        echo=messages.append,
+        target_env_name="dev",
+    )
+
+    assert seen_defaults and seen_defaults[0] is None
+    output = "\n".join(messages)
+    assert "from-yaml.services.ai.azure.com" in output
+    assert "agentops.yaml" in output
+
+
+def test_run_wizard_suppresses_cross_env_endpoint_from_other_azd_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Endpoint sitting in .azure/sandbox/.env must not pre-fill --azd-env dev."""
+    monkeypatch.delenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT", raising=False)
+    monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_ENV_NAME", raising=False)
+    # sandbox holds an endpoint and is the *active* azd env...
+    _seed_azd_env(
+        tmp_path,
+        "sandbox",
+        {
+            "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT": (
+                '"https://sandbox.services.ai.azure.com/api/projects/p"'
+            ),
+        },
+    )
+    (tmp_path / "agentops.yaml").write_text(
+        "version: 1\nagent: keep:1\ndataset: keep.jsonl\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "keep.jsonl").write_text("{}\n", encoding="utf-8")
+
+    seen_defaults: list = []
+    messages: list[str] = []
+
+    def prompt(_question: str, default):  # noqa: ANN001
+        seen_defaults.append(default)
+        return "https://dev.services.ai.azure.com/api/projects/p"
+
+    # ...but the user is explicitly running --azd-env dev.
+    run_wizard(
+        tmp_path,
+        prompt=prompt,
+        echo=messages.append,
+        target_env_name="dev",
+    )
+
+    assert seen_defaults and seen_defaults[0] is None
+    output = "\n".join(messages)
+    assert "sandbox.services.ai.azure.com" in output
+
+
+def test_run_wizard_keeps_endpoint_default_when_target_env_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When .azure/dev/.env already holds the endpoint, reuse it silently."""
+    monkeypatch.delenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT", raising=False)
+    monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_ENV_NAME", raising=False)
+    _seed_azd_env(
+        tmp_path,
+        "dev",
+        {
+            "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT": (
+                '"https://dev.services.ai.azure.com/api/projects/p"'
+            ),
+        },
+    )
+    (tmp_path / "agentops.yaml").write_text(
+        "version: 1\nagent: keep:1\ndataset: keep.jsonl\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "keep.jsonl").write_text("{}\n", encoding="utf-8")
+
+    messages: list[str] = []
+    prompt_calls: list[str] = []
+
+    def prompt(question: str, _default):  # noqa: ANN001
+        prompt_calls.append(question)
+        return ""
+
+    run_wizard(
+        tmp_path,
+        prompt=prompt,
+        echo=messages.append,
+        target_env_name="dev",
+    )
+
+    output = "\n".join(messages)
+    # Confirmed without re-prompting + no cross-env warning text leaked.
+    assert "Foundry project endpoint" in output
+    assert "shell environment" not in output
+    assert "may belong to a different environment" not in output
+    assert "Foundry project endpoint" not in prompt_calls
+
+
+def test_run_wizard_without_target_env_keeps_legacy_default_behavior(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Bare ``agentops init`` (no --azd-env) still pre-fills from the shell."""
+    monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_ENV_NAME", raising=False)
+    monkeypatch.setenv(
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "https://from-shell.services.ai.azure.com/api/projects/p",
+    )
+    (tmp_path / "agentops.yaml").write_text(
+        "version: 1\nagent: keep:1\ndataset: keep.jsonl\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "keep.jsonl").write_text("{}\n", encoding="utf-8")
+
+    prompt_calls: list[str] = []
+    messages: list[str] = []
+
+    def prompt(question: str, _default):  # noqa: ANN001
+        prompt_calls.append(question)
+        return ""
+
+    run_wizard(tmp_path, prompt=prompt, echo=messages.append)
+
+    output = "\n".join(messages)
+    assert "may belong to a different environment" not in output
+    # And the endpoint is silently reused (not re-prompted) on the bare path.
+    assert "Foundry project endpoint" not in prompt_calls
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

When you run `agentops init --azd-env <name>` to bootstrap a **fresh** env (e.g. `--azd-env dev` while the active env is `sandbox`), the wizard no longer pre-fills `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` from a source that belongs to a *different* env.

## Why

The previous behavior leaked the wrong endpoint into the target env. Concretely, the wizard would happily pre-fill the dev env's endpoint with:

- the process environment value of `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT`,
- a legacy top-level `project_endpoint:` field in `agentops.yaml`,
- or the `.azure/<other-env>/.env` of a sibling env (e.g. `sandbox`),

…and the user, used to `[Enter] to accept default`, would silently end up with the sandbox endpoint persisted under `.azure/dev/.env`. That's exactly the trap the multi-env tutorial users were falling into when promoting prompts sandbox → dev.

## How

- `services/setup_wizard.discover_defaults` now tracks the **provenance** of the endpoint default (5 source constants: azd-env-file, agentops-env-file, process-env, yaml-legacy, none) and stores it on the new `WizardAnswers.project_endpoint_source` / `project_endpoint_source_path` fields (informational only — never persisted).
- `run_wizard` accepts an optional `target_env_name` parameter. When passed, the wizard runs a strict "cross-env leak" check before pre-filling: if the source doesn't match the targeted env, it suppresses the default and prints a short note explaining where the suspect value came from.
- `cli/app.py` passes `target_env_name=azd_env_name` **only when the user passed `--azd-env` explicitly**. Bare `agentops init` keeps its existing best-effort default behavior — that path is "configure my currently-active env", which is exactly what the existing defaults are for.

## Tests

- `tests/unit/test_setup_wizard.py`: 11 new tests
  - 5 source-attribution tests for `discover_defaults` (one per source constant)
  - 5 cross-env suppression tests for `run_wizard` (process-env, yaml-legacy, other-azd-env, target-matches, no-target-keeps-legacy-behavior)
  - All seed an `agentops.yaml` with `agent: keep:1` + `dataset: keep.jsonl` placeholders so the agent/dataset questions hit the "confirm existing" path and don't infinite-loop on re-validation.
- Targeted suite: `python -m pytest tests/unit/test_setup_wizard.py -x -q` → **47 passed**.
- Full suite: `python -m pytest tests/ -x -q` → **802 passed, 3 skipped**.

## User-visible behavior change

| Scenario | Before | After |
|---|---|---|
| `agentops init` (no flag) | Pre-fills endpoint from first source found | **Unchanged** |
| `agentops init --azd-env dev` when `.azure/dev/.env` already has the endpoint | Pre-fills from `.azure/dev/.env` | **Unchanged** |
| `agentops init --azd-env dev` when only the process env has the value | Pre-fills from process env → silent leak | Prompts with no default + note |
| `agentops init --azd-env dev` when `.azure/sandbox/.env` has the value | Pre-fills from sandbox → silent leak | Prompts with no default + note |
| `agentops init --azd-env dev` when only legacy `project_endpoint:` in `agentops.yaml` has it | Pre-fills from yaml → silent leak | Prompts with no default + note |

## CHANGELOG

Entry added to `[Unreleased]` / `### Fixed`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>