### PR TITLE
docs: flag workflow-skill setup as already done in tutorial follow-up steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 ## [Unreleased]
 
 ### Changed
+- **Tutorials now flag the workflow skill's setup actions as redundant in the manual follow-up steps.**
+  When users run the `agentops-workflow` skill in the CI-wiring step of either
+  the prompt-agent tutorial (step 12B) or the end-to-end tutorial (the same
+  skill invocation that precedes the baseline-run step), the skill already
+  commits the workspace, pushes `main` to GitHub, and triggers a first
+  verification run of `agentops-pr.yml` (and `agentops-deploy-dev.yml` for the
+  prompt-agent flow). The next step previously asked users to repeat all
+  three actions, which was a no-op at best and confusing at worst (the
+  `git add` would find nothing to commit, the `git push` would report
+  up-to-date, the dispatched PR run would be the second one, not the first).
+  Step 13 of `docs/tutorial-prompt-agent-quickstart.md` and the baseline-run
+  paragraph in `docs/tutorial-end-to-end.md` now open with an explicit
+  "if you used the workflow skill above, this is already done" callout and
+  reframe the manual commands as a fallback for users who skipped the skill
+  or wired CI by hand. The deliberate baseline-PR step that follows (open a
+  feature branch, open a PR, merge once green) is unchanged — it must still
+  go through a real pull request, which the skill does not do for you, so
+  that the rolling Doctor history is seeded.
 - **Tutorial wording: "quickstart" → "tutorial", "workshop" → "tutorial".**
   The three documentation entries that were labeled "Prompt Agent quickstart",
   "Hosted Agent quickstart", and "End-to-end workshop" now read as "Foundry

--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -469,9 +469,13 @@ and rerun the same gate.
 ### Prompt Agent regression
 
 Make sure the original prompt version has one green workflow run before you
-change it. For example, commit the generated workflow and `agentops.yaml`, run
-`gh workflow run agentops-pr.yml --ref main`, and keep that Foundry evaluation
-page open as the baseline.
+change it. **If you used the workflow skill above, this is already done** — the
+skill commits your changes, pushes to GitHub, and triggers a first verification
+run of `agentops-pr.yml`. Open the latest workflow run's Foundry Evaluations
+link and keep that page open as the baseline. If you skipped the skill and
+wired CI by hand, commit the generated workflow and `agentops.yaml`, run
+`gh workflow run agentops-pr.yml --ref main`, and use that run as the
+baseline.
 
 1. In Foundry, edit the `travel-agent` instructions to this intentionally bad
    version:

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -761,6 +761,21 @@ This is the happy path. Before the regression step, you need a clean
 green baseline so the rolling-history Doctor checks (regression, drift)
 have something to compare against.
 
+> **If you used the workflow skill in step 12B, the next two code
+> blocks have already been done — skip straight to "Now open a feature
+> branch..." below.** The `agentops-workflow` skill commits your local
+> changes, pushes `main` to the GitHub remote, and triggers a first
+> verification run of both `agentops-pr.yml` and `agentops-deploy-dev.yml`
+> as part of its end-to-end setup. Open the repo's **Actions** tab and
+> confirm both runs are present — `Stage Foundry prompt candidate (PR)`
+> + `AgentOps eval (PR gate)` should be green on the PR workflow, and
+> `agentops-deploy-dev.yml` should have a matching run that also went
+> green. Only run the `git add` / `commit` / `push` and `gh workflow run`
+> commands below if you skipped the skill and wired CI by hand, or if
+> the skill stopped before pushing your latest local changes (run
+> `git status` first — if the working tree is clean and the remote has
+> your commits, the manual commands are no-ops).
+
 ```powershell
 git add agentops.yaml .agentops .github\workflows
 git commit -m "Add AgentOps prompt agent gate + dev deploy"


### PR DESCRIPTION
## Why

Continuation of the cross-tutorial consistency pass. After running the prompt-agent tutorial end-to-end, the redundancy between the `agentops-workflow` skill (run in step 12B) and the manual `git add` / `git commit` / `git push` / `gh workflow run agentops-pr.yml` commands in the very next step (step 13) was confusing — the manual commands are no-ops when the skill has already run, but the tutorial didn't say so.

The PO flagged this and asked for the same treatment across the other tutorials per the cross-tutorial consistency convention (stored memory: *"lembre de atualizar todos os tutoriais quando aplicavel"*).

## What changed

- **`docs/tutorial-prompt-agent-quickstart.md`** — step 13 opens with a multi-line callout: "If you used the workflow skill in step 12B, the next two code blocks have already been done — confirm both runs in the Actions tab and skip straight to 'Now open a feature branch…'." The manual `git add` / `git commit` / `git push` and `gh workflow run agentops-pr.yml` code blocks are preserved as a fallback for users who skipped the skill or wired CI by hand (with a `git status` first to make the no-op safe). The downstream baseline-PR step (open a feature branch, open a PR, merge once green) is **unchanged** — it must still go through a real pull request, which the skill does not do for you, so that the rolling Doctor history is seeded.

- **`docs/tutorial-end-to-end.md`** — the equivalent baseline-run prose paragraph now opens with the same "if you used the workflow skill above, this is already done" sentence and reframes the manual `gh workflow run agentops-pr.yml --ref main` command as a fallback.

- **`CHANGELOG.md`** — added an entry under `[Unreleased] → ### Changed`, placed above the existing wording-rename entry (most recent first).

## What did **not** change

- **`docs/tutorial-hosted-agent-quickstart.md`** — audited and confirmed clean. Step 10 (workflow skill) is followed by step 11 (Open Cockpit). There are no redundant `git push` or `gh workflow run` commands in between.

- **The baseline-PR step itself** in any tutorial — opening a feature branch, opening a PR, and merging once green is the deliberate human step that establishes the rolling Doctor history. The skill does not do this for you, and the tutorial still walks through it explicitly.

## Validation

```
python -m pytest tests/ -x -q
802 passed, 3 skipped in 28.84s
```

Docs-only change. No Python touched.
