### PR TITLE
docs: fix stale step references in skip-if-skill callouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 ### Changed
 - **Tutorials now flag the workflow skill's setup actions as redundant in the manual follow-up steps.**
   When users run the `agentops-workflow` skill in the CI-wiring step of either
-  the prompt-agent tutorial (step 12B) or the end-to-end tutorial (the same
-  skill invocation that precedes the baseline-run step), the skill already
+  the prompt-agent tutorial (step 12) or the end-to-end tutorial (step 5, the
+  same skill invocation that precedes the baseline-run step), the skill already
   commits the workspace, pushes `main` to GitHub, and triggers a first
   verification run of `agentops-pr.yml` (and `agentops-deploy-dev.yml` for the
   prompt-agent flow). The next step previously asked users to repeat all

--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -469,12 +469,12 @@ and rerun the same gate.
 ### Prompt Agent regression
 
 Make sure the original prompt version has one green workflow run before you
-change it. **If you used the workflow skill above, this is already done** — the
-skill commits your changes, pushes to GitHub, and triggers a first verification
-run of `agentops-pr.yml`. Open the latest workflow run's Foundry Evaluations
-link and keep that page open as the baseline. If you skipped the skill and
-wired CI by hand, commit the generated workflow and `agentops.yaml`, run
-`gh workflow run agentops-pr.yml --ref main`, and use that run as the
+change it. **If you used the workflow skill in step 5 above, this is already
+done** — the skill commits your changes, pushes to GitHub, and triggers a first
+verification run of `agentops-pr.yml`. Open the latest workflow run's Foundry
+Evaluations link and keep that page open as the baseline. If you skipped the
+skill and wired CI by hand, commit the generated workflow and `agentops.yaml`,
+run `gh workflow run agentops-pr.yml --ref main`, and use that run as the
 baseline.
 
 1. In Foundry, edit the `travel-agent` instructions to this intentionally bad

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -761,7 +761,7 @@ This is the happy path. Before the regression step, you need a clean
 green baseline so the rolling-history Doctor checks (regression, drift)
 have something to compare against.
 
-> **If you used the workflow skill in step 12B, the next two code
+> **If you used the workflow skill in step 12, the next two code
 > blocks have already been done — skip straight to "Now open a feature
 > branch..." below.** The `agentops-workflow` skill commits your local
 > changes, pushes `main` to the GitHub remote, and triggers a first


### PR DESCRIPTION
## Why

Follow-up to #207. The "if you used the workflow skill, this is already done" callout I added there referenced **step 12B** in the prompt-agent tutorial, but step 12 has no A/B split anymore since the wording-rename cleanup. The PO caught the inconsistency immediately and asked for a broader audit to make sure nothing else is stale.

## What changed

- **`docs/tutorial-prompt-agent-quickstart.md`** (step 13 callout): `step 12B` → `step 12`.
- **`docs/tutorial-end-to-end.md`** (step 6 callout): "workflow skill above" → "workflow skill in step 5 above" so readers can scroll back without guessing which "above" was meant. Step 5 is "Run the first eval" and ends with the workflow-skill invocation that this callout describes.
- **`CHANGELOG.md`** (`[Unreleased] → ### Changed`): matching fix — `step 12B` → `step 12`, plus added `step 5` for the end-to-end reference.

## Broader audit

I grep'd all three tutorial files for `\bstep \d+|\bStep \d+|in step|see step|from step` and for any A/B suffix patterns:

| Reference | File | Status |
|---|---|---|
| `step 2`, `step 3`, `step 7`, `step 8`, `step 11`, `step 13`, `step 16` | prompt-agent | ✅ all map to existing sections |
| `step 9` (Doctor output rules) | end-to-end | ✅ |
| `Path A` / `Path B` | prompt-agent steps 3, 8 | ✅ those sections still have sub-paths |
| `Option A` / `Option B` | end-to-end step 1 | ✅ still has sub-options |
| `12A` / `12B` anywhere in the repo | — | ✅ no matches after fix |

Hosted-agent tutorial has no internal step references at all (audited earlier in #207).

## Validation

```
python -m pytest tests/ -x -q
802 passed, 3 skipped
```

Docs-only.
