### PR TITLE
docs: rewrite skip-if-skill callouts as affirmative statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 ## [0.3.1] - 2026-05-29
 
 ### Changed
+- **Tutorials: state directly that the workflow skill already wired the first run.**
+  The `step 13` callout in `docs/tutorial-prompt-agent-quickstart.md` and the
+  baseline-run paragraph in `docs/tutorial-end-to-end.md` previously opened
+  with "if you used the workflow skill, this is already done…" plus a
+  manual-fallback block. That conditional framing was confusing because the
+  preceding step (`step 12` of the prompt-agent tutorial, `step 5` of the
+  end-to-end tutorial) only documents the workflow-skill path — there is no
+  alternative wired-by-hand path the reader could have taken. Both callouts
+  now state the skill's outcome directly ("the workflow skill already
+  committed your changes, pushed `main`, and triggered a first verification
+  run of …"), and the redundant `git add` / `commit` / `push` and
+  `gh workflow run agentops-pr.yml --ref main` blocks have been removed (the
+  skill already triggers the first run). A small `gh run list` /
+  `gh run watch` snippet remains as an opt-in way to wait on the run from
+  the terminal instead of the Actions UI.
 - **Tutorials now flag the workflow skill's setup actions as redundant in the manual follow-up steps.**
   When users run the `agentops-workflow` skill in the CI-wiring step of either
   the prompt-agent tutorial (step 12) or the end-to-end tutorial (step 5, the

--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -468,14 +468,10 @@ and rerun the same gate.
 
 ### Prompt Agent regression
 
-Make sure the original prompt version has one green workflow run before you
-change it. **If you used the workflow skill in step 5 above, this is already
-done** — the skill commits your changes, pushes to GitHub, and triggers a first
-verification run of `agentops-pr.yml`. Open the latest workflow run's Foundry
-Evaluations link and keep that page open as the baseline. If you skipped the
-skill and wired CI by hand, commit the generated workflow and `agentops.yaml`,
-run `gh workflow run agentops-pr.yml --ref main`, and use that run as the
-baseline.
+The workflow skill in step 5 above already committed your changes, pushed
+`main` to GitHub, and triggered a first verification run of `agentops-pr.yml`.
+Open the latest workflow run's Foundry Evaluations link and keep that page
+open as the baseline.
 
 1. In Foundry, edit the `travel-agent` instructions to this intentionally bad
    version:

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -761,34 +761,20 @@ This is the happy path. Before the regression step, you need a clean
 green baseline so the rolling-history Doctor checks (regression, drift)
 have something to compare against.
 
-> **If you used the workflow skill in step 12, the next two code
-> blocks have already been done — skip straight to "Now open a feature
-> branch..." below.** The `agentops-workflow` skill commits your local
-> changes, pushes `main` to the GitHub remote, and triggers a first
-> verification run of both `agentops-pr.yml` and `agentops-deploy-dev.yml`
-> as part of its end-to-end setup. Open the repo's **Actions** tab and
-> confirm both runs are present — `Stage Foundry prompt candidate (PR)`
-> + `AgentOps eval (PR gate)` should be green on the PR workflow, and
-> `agentops-deploy-dev.yml` should have a matching run that also went
-> green. Only run the `git add` / `commit` / `push` and `gh workflow run`
-> commands below if you skipped the skill and wired CI by hand, or if
-> the skill stopped before pushing your latest local changes (run
-> `git status` first — if the working tree is clean and the remote has
-> your commits, the manual commands are no-ops).
+The workflow skill in step 12 already committed your local changes,
+pushed `main` to the GitHub remote, and triggered a first verification
+run of both `agentops-pr.yml` and `agentops-deploy-dev.yml` as part of
+its end-to-end setup. Open the repo's **Actions** tab and confirm both
+runs are green:
+
+- `agentops-pr.yml` — both `Stage Foundry prompt candidate (PR)` and
+  `AgentOps eval (PR gate)` jobs are green.
+- `agentops-deploy-dev.yml` — has a matching run that also went green.
+
+If you want to wait on the first PR run from the terminal instead of
+the Actions UI:
 
 ```powershell
-git add agentops.yaml .agentops .github\workflows
-git commit -m "Add AgentOps prompt agent gate + dev deploy"
-git push -u origin main
-```
-
-Open the repository in GitHub and confirm both workflows appear under
-**Actions**. Trigger the PR workflow once on `main` so the dev project
-has a known-good candidate run:
-
-```powershell
-gh workflow run agentops-pr.yml --ref main
-Start-Sleep -Seconds 10
 $runId = gh run list --workflow agentops-pr.yml --branch main --limit 1 --json databaseId --jq '.[0].databaseId'
 gh run view $runId --web
 gh run watch $runId --exit-status


### PR DESCRIPTION
## Why

PO feedback while running the prompt-agent tutorial: the `step 13` callout
opened with "If you used the workflow skill in step 12, …" — but step 12 only
documents the workflow-skill path. There is no manual fallback in step 12 that
the reader could have taken instead, so the `if` is confusing.

Same pattern in the end-to-end tutorial (step 5 → step 6 baseline-run
paragraph).

## What changed

- **`docs/tutorial-prompt-agent-quickstart.md` step 13**: callout is now a
  direct affirmative statement of what the skill did. The two redundant
  PowerShell blocks (`git add`/`commit`/`push` and `gh workflow run
  agentops-pr.yml --ref main`) are removed — the skill already triggers the
  first run. A small `gh run list` / `gh run watch` snippet remains as an
  opt-in way to wait on the run from the terminal instead of the Actions UI.
- **`docs/tutorial-end-to-end.md` step 6**: baseline-run paragraph rewritten
  in the same affirmative voice. The manual `gh workflow run` fallback is
  removed.
- **`CHANGELOG.md`** (`[Unreleased] → ### Changed`): new entry above the
  prior "Tutorials now flag the workflow skill's setup actions as redundant"
  entry, explaining the affirmative rewrite.

## Process note

Per PO directive set this session: docs-only changes go to `develop` and stay
there (no release cut needed). Library/code changes still require a release
patch.

## Validation

```
python -m pytest tests/ -x -q
802 passed, 3 skipped
```
