### PR TITLE
docs: correct skill verification claim to PR workflow only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
-## [0.3.1] - 2026-05-29
-
 ### Changed
-- **Tutorials: state directly that the workflow skill already wired the first run.**
+- **Tutorials: skip-if-skill callouts now state the skill's outcome directly and accurately.**
   The `step 13` callout in `docs/tutorial-prompt-agent-quickstart.md` and the
   baseline-run paragraph in `docs/tutorial-end-to-end.md` previously opened
   with "if you used the workflow skill, this is already done…" plus a
@@ -16,13 +14,22 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   preceding step (`step 12` of the prompt-agent tutorial, `step 5` of the
   end-to-end tutorial) only documents the workflow-skill path — there is no
   alternative wired-by-hand path the reader could have taken. Both callouts
-  now state the skill's outcome directly ("the workflow skill already
-  committed your changes, pushed `main`, and triggered a first verification
-  run of …"), and the redundant `git add` / `commit` / `push` and
-  `gh workflow run agentops-pr.yml --ref main` blocks have been removed (the
-  skill already triggers the first run). A small `gh run list` /
-  `gh run watch` snippet remains as an opt-in way to wait on the run from
-  the terminal instead of the Actions UI.
+  now state the skill's outcome directly, and the redundant `git add` /
+  `commit` / `push` and `gh workflow run agentops-pr.yml --ref main` blocks
+  have been removed (the skill already triggers the first run). A small
+  `gh run list` / `gh run watch` snippet remains as an opt-in way to wait
+  on the run from the terminal instead of the Actions UI. The previous
+  wording also over-claimed that the skill triggered verification runs of
+  **both** `agentops-pr.yml` and `agentops-deploy-dev.yml`; the skill only
+  dispatches the PR workflow as a sanity check (`workflow_dispatch`), while
+  `agentops-deploy-dev.yml` triggers on the first real merge into the trunk
+  branch. The callout now reflects this accurately and notes that the
+  deploy-dev run happens at the end of the section, not during the skill's
+  setup.
+
+## [0.3.1] - 2026-05-29
+
+### Changed
 - **Tutorials now flag the workflow skill's setup actions as redundant in the manual follow-up steps.**
   When users run the `agentops-workflow` skill in the CI-wiring step of either
   the prompt-agent tutorial (step 12) or the end-to-end tutorial (step 5, the

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -763,16 +763,17 @@ have something to compare against.
 
 The workflow skill in step 12 already committed your local changes,
 pushed `main` to the GitHub remote, and triggered a first verification
-run of both `agentops-pr.yml` and `agentops-deploy-dev.yml` as part of
-its end-to-end setup. Open the repo's **Actions** tab and confirm both
-runs are green:
+run of `agentops-pr.yml` (via `workflow_dispatch`) as part of its
+end-to-end setup. Open the repo's **Actions** tab and confirm both the
+`Stage Foundry prompt candidate (PR)` and `AgentOps eval (PR gate)`
+jobs of that run are green.
 
-- `agentops-pr.yml` — both `Stage Foundry prompt candidate (PR)` and
-  `AgentOps eval (PR gate)` jobs are green.
-- `agentops-deploy-dev.yml` — has a matching run that also went green.
+`agentops-deploy-dev.yml` does not run yet — it triggers on a real
+merge into your trunk branch (or on `workflow_dispatch`), and the first
+merge happens at the end of this section.
 
-If you want to wait on the first PR run from the terminal instead of
-the Actions UI:
+If you want to wait on the first PR-workflow verification run from the
+terminal instead of the Actions UI:
 
 ```powershell
 $runId = gh run list --workflow agentops-pr.yml --branch main --limit 1 --json databaseId --jq '.[0].databaseId'


### PR DESCRIPTION
## Why

PO feedback: "Cara, não tô seguro se ele roda os dois Pipeline… eu tenho a impressão que é só a do pull request."

Confirmed in the templates:

- `agentops-pr.yml` triggers on `pull_request` + `workflow_dispatch`. The
  workflow skill dispatches it as a verification step.
- `agentops-deploy-dev.yml` triggers on `push to develop` + `workflow_dispatch`.
  The skill does **not** dispatch it; the first real run happens when the
  user merges the baseline PR into the trunk branch (which is the step
  immediately below the callout).

PR #210 over-claimed that **both** workflows had verification runs.

## What changed

- **`docs/tutorial-prompt-agent-quickstart.md` step 13**: callout now
  mentions only `agentops-pr.yml` and explicitly tells the reader that
  `agentops-deploy-dev.yml` will fire on the merge later in the same
  section, not during the skill's setup.
- **`CHANGELOG.md`**: moves the PR #210 entry from `[0.3.1]` (already
  shipped) into `[Unreleased]` where post-release docs corrections
  belong, and merges the new correction into the same entry.

The end-to-end tutorial step 6 was already correct (only mentions
`agentops-pr.yml`) and is not touched.

## Validation

```
python -m pytest tests/ -x -q
802 passed, 3 skipped
```
