### PR TITLE
docs: deep audit of all three tutorials (8 procedural bugs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+- **Tutorials: end-to-end audit caught misleading dist URLs, phantom CLI commands, missing JSON fields, and stale Doctor advisory text.**
+  All three tutorials previously installed the development build from a
+  personal fork URL (`git+https://github.com/placerda/agentops.git@develop`);
+  they now point at the canonical
+  `git+https://github.com/Azure/agentops.git@develop`. The prompt-agent
+  tutorial referenced a non-existent `prompt_deploy record` subcommand in
+  two places — the actual command is `prompt_deploy summarize`, matching
+  `src/agentops/pipeline/prompt_deploy.py` and the deploy template's
+  `Mark candidate as deployed` step. The same tutorial's `foundry-agent.json`
+  sample was missing the `eval_config` field that the code writes at
+  `src/agentops/pipeline/prompt_deploy.py:186`. The step 12 skill prompt
+  and the step 13 prose did not tell the reader to rewrite the dev-deploy
+  trigger from `develop` to `main` for this trunk-on-`main` tutorial; the
+  generator's stock default is `develop`, which would silently no-op after
+  the first merge. Step 12 now instructs the skill to do the rewrite (and
+  the bullet list of skill actions calls it out as a required step, with
+  a manual-edit fallback). Step 13's "deploy fires automatically on `main`"
+  sentence now states the dependency on the step 12 rewrite explicitly,
+  and the placeholder phrase "your trunk branch" is now disambiguated as
+  "`main` in this tutorial". The end-to-end tutorial's step 5 and step 9
+  Doctor descriptions still read as if Doctor were advisory-only in PR
+  workflows — that text predates the `--doctor-gate critical` default;
+  both blocks now describe the actual behavior (critical findings block
+  the PR by default; warning/info are evidence-only).
+
 ### Changed
 - **Tutorials: skip-if-skill callouts now state the skill's outcome directly and accurately.**
   The `step 13` callout in `docs/tutorial-prompt-agent-quickstart.md` and the

--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -129,7 +129,7 @@ install the aligned reference branch so the CLI, generated workflows, and
 tutorial steps stay in sync:
 
 ```powershell
-python -m pip install "agentops-accelerator[foundry,agent] @ git+https://github.com/placerda/agentops.git@develop"
+python -m pip install "agentops-accelerator[foundry,agent] @ git+https://github.com/Azure/agentops.git@develop"
 ```
 
 You will provide the target values through the interactive `agentops init`
@@ -451,9 +451,13 @@ The generated workflow prepares a temporary cloud config, runs
 
 It also records release evidence after the gate.
 
-In PR workflows, that Doctor evidence is advisory: the eval step is the merge
-gate, and `Release readiness: blocked` means the evidence found release work to
-review. Production deploy workflows still run Doctor as a critical release gate.
+Doctor runs in the PR workflow with `--severity-fail critical` (the
+`--doctor-gate critical` default). A critical Doctor finding — for example
+`regression.coherence: critical` from a metric drop that still passes
+thresholds — fails the PR check the same way an eval threshold breach
+does. Warning- and info-level findings are advisory and attached to the
+PR as evidence. Production deploy workflows always run Doctor with
+`--severity-fail critical` regardless of this flag.
 
 No tutorial-only Action replacement is needed. The generated workflow keeps the
 evaluation in Foundry while AgentOps owns the CI threshold decision and the
@@ -751,10 +755,12 @@ show whether the repo has the release machinery reviewers expect. Use critical
 findings as release blockers and warning/info findings as the backlog that turns
 the POC into an operated service.
 
-If those same Doctor findings appear inside a PR workflow, treat them as
-evidence attached to the PR rather than as the merge gate. The eval step gates
-the PR; production deploy workflows are where critical Doctor findings block the
-release path.
+If those same Doctor findings appear inside a PR workflow, critical
+findings block the merge by default (the PR template runs Doctor with
+`--severity-fail critical`, the `--doctor-gate critical` default); warning
+and info findings are attached to the PR as evidence rather than as a
+gate. Production deploy workflows always run Doctor with
+`--severity-fail critical` and are the last-mile release gate.
 
 Open both files. The Doctor report is the diagnostic view: it tells you which
 signals are present, which are missing, and whether the finding is blocking or

--- a/docs/tutorial-hosted-agent-quickstart.md
+++ b/docs/tutorial-hosted-agent-quickstart.md
@@ -160,7 +160,7 @@ install the aligned reference branch so the CLI, generated workflows, and
 tutorial steps stay in sync:
 
 ```powershell
-python -m pip install "agentops-accelerator[foundry,agent] @ git+https://github.com/placerda/agentops.git@develop"
+python -m pip install "agentops-accelerator[foundry,agent] @ git+https://github.com/Azure/agentops.git@develop"
 ```
 
 ## 2. Create the Travel Agent endpoint

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -137,7 +137,7 @@ path, install the aligned reference branch so the CLI, generated
 workflows, and tutorial steps stay in sync:
 
 ```powershell
-python -m pip install "agentops-accelerator[foundry,agent] @ git+https://github.com/placerda/agentops.git@develop"
+python -m pip install "agentops-accelerator[foundry,agent] @ git+https://github.com/Azure/agentops.git@develop"
 ```
 
 ## 2. Install the AgentOps Copilot skills
@@ -670,7 +670,7 @@ The PR workflow now has two jobs:
 > candidate version numbers.
 
 The dev deploy workflow stages a candidate (same logic), evaluates it,
-records the deployment via `prompt_deploy record`, and uploads
+summarizes the deployment via `prompt_deploy summarize`, and uploads
 `.agentops/deployments/foundry-agent.json` as a workflow artifact.
 
 The `--doctor-gate critical` flag controls the Doctor severity floor in
@@ -725,6 +725,14 @@ the OpenAI User role, the Foundry cloud graders fail with a 401 and every
 metric comes back null), and do not set up `qa`, `production`, scheduled
 Doctor, or hosted deployment workflows yet.
 
+I am using trunk-based development with `main` as both my trunk and dev
+branch. The generator's stock dev-deploy trigger is `push: branches:
+[develop]`. Rewrite the `agentops-deploy-dev.yml` (and the matching
+`agentops-pr.yml` `pull_request: branches:` list, if it references
+`develop`) so they fire on `main` instead. The PR gate must run on PRs
+targeting `main`, and the dev deploy must auto-run on push to `main`
+after a merge.
+
 The dev Foundry project endpoint is in `.azure/dev/.env`; the sandbox
 endpoint is local-only and must not be added to CI.
 
@@ -741,6 +749,14 @@ it skips:
 - Set Actions variables `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`,
   `AZURE_CLIENT_ID`, `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` (the dev
   endpoint), and `APPLICATIONINSIGHTS_CONNECTION_STRING` if available.
+- **Rewrite the dev deploy trigger to `main`.** The generator emits the
+  stock GitFlow defaults (`pull_request: branches: [develop, "release/**",
+  main]` on `agentops-pr.yml`, `push: branches: [develop]` on
+  `agentops-deploy-dev.yml`). For this trunk-on-`main` tutorial the
+  skill should rewrite both so the PR gate fires on PRs into `main` and
+  the deploy fires on push to `main`. If the skill skips this rewrite,
+  open the two YAML files in `.github/workflows/` and edit the
+  `branches:` lists by hand before opening the first PR.
 - Verify the OIDC principal has **two** Azure RBAC roles before the first
   run. Both are required and the eval step fails silently (every metric
   returns `null`) if only one is in place:
@@ -768,9 +784,11 @@ end-to-end setup. Open the repo's **Actions** tab and confirm both the
 `Stage Foundry prompt candidate (PR)` and `AgentOps eval (PR gate)`
 jobs of that run are green.
 
-`agentops-deploy-dev.yml` does not run yet — it triggers on a real
-merge into your trunk branch (or on `workflow_dispatch`), and the first
-merge happens at the end of this section.
+`agentops-deploy-dev.yml` does not run yet — it triggers on push to
+your dev branch (`main` in this tutorial, after the trigger rewrite the
+skill performed in step 12; the generator's stock default is `develop`)
+or on `workflow_dispatch`. The first merge into `main` happens at the
+end of this section.
 
 If you want to wait on the first PR-workflow verification run from the
 terminal instead of the Actions UI:
@@ -840,10 +858,12 @@ Open the PR in GitHub. The PR check runs the same staging + eval flow,
 green again because the prompt is unchanged. Merge.
 
 After the merge, the **AgentOps deploy (dev)** workflow runs
-automatically on `main`. It stages the candidate (likely re-using the
-same version as the PR run, or bootstrapping again if dev has not yet
-caught up to the seed), evaluates it, runs `prompt_deploy record` to
-mark it as the dev deployment, and uploads the deployment artifact.
+automatically on `main` (the skill rewrote its trigger from `develop`
+to `main` in step 12 because this tutorial uses trunk-based flow). It
+stages the candidate (likely re-using the same version as the PR run,
+or bootstrapping again if dev has not yet caught up to the seed),
+evaluates it, runs `prompt_deploy summarize` to write the dev
+deployment summary, and uploads the deployment artifact.
 
 Open the deploy run and download the `foundry-agent-dev-deployment`
 artifact. Inside, open `foundry-agent.json`. On the very first deploy
@@ -864,6 +884,7 @@ this — note the actual field names AgentOps writes:
   "project_endpoint": "https://<your-resource>.services.ai.azure.com/api/projects/travel-agent-dev",
   "prompt_file": ".agentops/prompts/travel-agent.md",
   "prompt_sha256": "9c3a...e0b1",
+  "eval_config": ".agentops/deployments/agentops.candidate.yaml",
   "created_at": "2025-...",
   "git_sha": "5f1a2c...",
   "workflow_url": "https://github.com/.../actions/runs/...",


### PR DESCRIPTION
Deep audit of all three tutorials after the PO hit a confidence-breaking inconsistency mid-recording. Bugs were found by three parallel code-review agents plus an independent manual audit; the same fix is applied across tutorials wherever the pattern repeats.

## Bugs fixed

### `tutorial-prompt-agent-quickstart.md`

1. **Fork URL in install command** (line 140). Tutorial pointed at `git+https://github.com/placerda/agentops.git@develop` (personal fork). Fixed to `Azure/agentops.git@develop`.
2. **Phantom `prompt_deploy record` subcommand** (lines 673 + 845). No such subcommand exists. Source: `src/agentops/pipeline/prompt_deploy.py:446-460` defines only `stage` and `summarize`; the deploy template calls `summarize`. Both occurrences flipped.
3. **Missing `eval_config` field in `foundry-agent.json` sample** (after line 866). The code at `src/agentops/pipeline/prompt_deploy.py:186` writes this field; the JSON sample was missing it.
4. **Step 12 skill prompt did not tell the skill to rewrite the dev-deploy trigger from `develop` to `main`** for the trunk-on-`main` flow used throughout the tutorial. The generator's stock default is `develop`, so the "after merge, deploy auto-runs" claim at line 842 was silently false. Step 12 now instructs the skill to rewrite both the PR `pull_request: branches:` list and the deploy `push: branches:` list, with a manual-edit fallback called out in the bullet list of skill actions. Step 13's prose now states the dependency on the step 12 rewrite explicitly, and the ambiguous phrase "your trunk branch" is disambiguated to "`main` in this tutorial".

### `tutorial-hosted-agent-quickstart.md`

5. **Fork URL in install command** (line 163). Same `placerda/agentops` → `Azure/agentops` fix.

### `tutorial-end-to-end.md`

6. **Fork URL in install command** (line 132). Same `placerda/agentops` → `Azure/agentops` fix.
7. **Doctor "advisory in PR workflows" contradiction** (step 5, lines 454-456). Previously claimed Doctor evidence is advisory in PR workflows and that the eval step is the only merge gate. This directly contradicts the `--doctor-gate critical` default (introduced in the same step's earlier callout, lines 398-403) that runs `agentops doctor --severity-fail critical`. Rewritten to describe the actual behavior.
8. **Doctor "advisory in PR workflows" contradiction** (step 9, lines 754-757). Same stale wording in a second location. Rewritten similarly.

## Audit method (for next time)

- **Default-tier agents only for audits.** A Haiku-class quick audit earlier in the day returned "no critical issues" while missing every one of these bugs. The three default-class `code-review` agents in this round each found a subset; combined with a manual grep+view pass they covered everything.
- **Anchor known bugs in the prompt.** Each audit agent was given the three already-confirmed bugs as calibration anchors plus a 14-category verification checklist (CLI commands, workflow triggers, job/step names, artifact names, JSON schema, YAML keys, file paths, step cross-refs, skill behavior, doctor IDs, default evaluators, workflow secrets, branch assumptions, PowerShell correctness).
- **Cross-check agent silence.** The hosted-agent and end-to-end agents returned no findings, but a manual `grep placerda/agentops` and `grep "advisory"` pass caught three more bugs they missed. Never trust silence from an audit agent — always run an independent fact-check pass.

## Validation

`python -m pytest tests/ -x -q` → **802 passed, 3 skipped** locally.

This is a docs-only PR. Per the release policy in `.github/skills/release-management/SKILL.md`, no patch release is required; the fixes ship with the next release rolling out of `develop`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
