### PR TITLE
docs: align tutorial resource naming guidance

### DIFF
--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -62,6 +62,14 @@ hosted endpoint itself is the per-environment artifact.
 > collisions become a real problem); dev is the gated promotion target
 > CI writes to.
 
+> **Name the Azure resources before provisioning.** When you use the Foundry
+> portal, `microsoft-foundry` skill, or Foundry Toolkit for this tutorial, specify
+> the resource group, Foundry / AI Services resource name, region, and model
+> deployment explicitly (for example `rg-agentops-travel-demo`,
+> `foundry-agentops-travel-demo`, `East US 2`, and `gpt-4o-mini`). A single shared
+> resource group is easiest for demos because RBAC and cleanup happen once;
+> production environments may use separate resource groups per stage.
+
 ## The cross-environment identity story (versioning callout)
 
 Each environment's Foundry version numbers or endpoint URLs diverge, but the

--- a/docs/tutorial-hosted-agent-quickstart.md
+++ b/docs/tutorial-hosted-agent-quickstart.md
@@ -143,6 +143,14 @@ FastAPI sample below emits custom OpenTelemetry spans only after you enable the
 observability step; a real Foundry Hosted Agent emits richer Foundry runtime
 spans.
 
+> **Name the Azure container resources up front.** If you use the
+> `microsoft-foundry` skill or Foundry Toolkit to create a hosted-agent project,
+> tell it the resource group, Foundry / AI Services resource name, region, and
+> model deployment you want, for example `rg-agentops-travel-demo`,
+> `foundry-agentops-travel-demo`, `East US 2`, and `gpt-4o-mini`. For a recorded
+> tutorial, one shared resource group is easiest because RBAC and cleanup happen
+> in one place; production teams may split resource groups by environment.
+
 ## 1. Create a clean workspace and install dependencies
 
 ```powershell


### PR DESCRIPTION
## Summary
- Adds matching resource naming guidance to hosted-agent and end-to-end tutorials.
- Clarifies that demos can use one shared resource group, while production may split per environment.

## Validation
- Docs-only change.