### PR TITLE
docs: clarify unique Azure names in tutorials

### DIFF
--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -65,10 +65,14 @@ hosted endpoint itself is the per-environment artifact.
 > **Name the Azure resources before provisioning.** When you use the Foundry
 > portal, `microsoft-foundry` skill, or Foundry Toolkit for this tutorial, specify
 > the resource group, Foundry / AI Services resource name, region, and model
-> deployment explicitly (for example `rg-agentops-travel-demo`,
-> `foundry-agentops-travel-demo`, `East US 2`, and `gpt-4o-mini`). A single shared
-> resource group is easiest for demos because RBAC and cleanup happen once;
-> production environments may use separate resource groups per stage.
+> deployment explicitly (for example `rg-agentops-travel-<your-alias>`,
+> `foundry-agentops-travel-<your-alias>`, `East US 2`, and `gpt-4o-mini`).
+> Replace `<your-alias>` with a short unique suffix when multiple people share
+> the same subscription. Resource group names are unique within a subscription;
+> Foundry / AI Services resource names should also be unique enough to avoid
+> Azure naming conflicts. A single shared resource group is easiest for demos
+> because RBAC and cleanup happen once; production environments may use separate
+> resource groups per stage.
 
 ## The cross-environment identity story (versioning callout)
 

--- a/docs/tutorial-hosted-agent-quickstart.md
+++ b/docs/tutorial-hosted-agent-quickstart.md
@@ -146,10 +146,14 @@ spans.
 > **Name the Azure container resources up front.** If you use the
 > `microsoft-foundry` skill or Foundry Toolkit to create a hosted-agent project,
 > tell it the resource group, Foundry / AI Services resource name, region, and
-> model deployment you want, for example `rg-agentops-travel-demo`,
-> `foundry-agentops-travel-demo`, `East US 2`, and `gpt-4o-mini`. For a recorded
-> tutorial, one shared resource group is easiest because RBAC and cleanup happen
-> in one place; production teams may split resource groups by environment.
+> model deployment you want, for example `rg-agentops-travel-<your-alias>`,
+> `foundry-agentops-travel-<your-alias>`, `East US 2`, and `gpt-4o-mini`.
+> Replace `<your-alias>` with a short unique suffix when multiple people share
+> the same subscription. Resource group names are unique within a subscription;
+> Foundry / AI Services resource names should also be unique enough to avoid
+> Azure naming conflicts. For a recorded tutorial, one shared resource group is
+> easiest because RBAC and cleanup happen in one place; production teams may
+> split resource groups by environment.
 
 ## 1. Create a clean workspace and install dependencies
 

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -221,8 +221,8 @@ I want to set up two Azure AI Foundry projects in the same subscription
 for an AgentOps tutorial:
 
 Use these Azure container/resource names unless I say otherwise:
-- Resource group: rg-agentops-travel-demo
-- Azure AI Foundry resource / AI Services account: foundry-agentops-travel-demo
+- Resource group: rg-agentops-travel-<your-alias>
+- Azure AI Foundry resource / AI Services account: foundry-agentops-travel-<your-alias>
 - Region: East US 2
 - Model deployment name in both projects: gpt-4o-mini
 
@@ -247,11 +247,16 @@ For each project, please:
 Show me the planned changes and the resulting endpoints before applying.
 ```
 
-Replace `rg-agentops-travel-demo`, `foundry-agentops-travel-demo`,
-`East US 2`, and `gpt-4o-mini` with the resource group, Foundry / AI Services
-resource name, region, and deployment name you want to use. For a recorded
-tutorial, one shared resource group is easiest because RBAC and cleanup happen
-in one place; production teams may split resource groups by environment.
+Replace `<your-alias>` with a short unique suffix such as your initials,
+GitHub handle, or a date (`pl`, `contoso-dev1`, `video-0604`). This matters
+when multiple people run the tutorial in the same subscription: resource group
+names must be unique within that subscription, Foundry / AI Services resource
+names should be unique enough to avoid Azure naming conflicts, and project names
+must be unique inside the Foundry resource. The model deployment name
+`gpt-4o-mini` does **not** need to be globally unique, but it must be the same
+in both tutorial projects. For a recorded tutorial, one shared resource group is
+easiest because RBAC and cleanup happen in one place; production teams may split
+resource groups by environment.
 
 If the skill is not available, use Path A.
 


### PR DESCRIPTION
## Summary
- Clarify that tutorial Azure resource names should include a unique suffix for multi-user runs
- Update prompt-agent, hosted-agent, and end-to-end tutorials consistently
- Explain that the model deployment name only needs to match across tutorial projects

## Tests
- Not run (docs-only change)