### PR TITLE
docs: clarify skill RBAC guidance in tutorials

### DIFF
--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -70,9 +70,12 @@ hosted endpoint itself is the per-environment artifact.
 > Replace `<your-alias>` with a short unique suffix when multiple people share
 > the same subscription. Resource group names are unique within a subscription;
 > Foundry / AI Services resource names should also be unique enough to avoid
-> Azure naming conflicts. A single shared resource group is easiest for demos
-> because RBAC and cleanup happen once; production environments may use separate
-> resource groups per stage.
+> Azure naming conflicts. Also ask the skill/tool to grant or verify
+> `Cognitive Services OpenAI User` data-plane access for your signed-in user and
+> any Foundry/Azure AI managed identities that will call evaluator models. A
+> single shared resource group is easiest for demos because RBAC and cleanup
+> happen once; production environments may use separate resource groups per
+> stage.
 
 ## The cross-environment identity story (versioning callout)
 
@@ -312,11 +315,13 @@ what causes the eval to fail later with `PermissionDenied` on
 `Microsoft.CognitiveServices/accounts/OpenAI/deployments/chat/
 completions/action`.
 
-Run these assignments once per resource group that hosts a Foundry account
-you will evaluate against. Cloud evaluations run server-side and some agent
-or grader calls may authenticate as Foundry/Azure AI managed identities, not
-only as your signed-in user. Assigning the role only to your user can still
-leave graders failing with `AuthenticationError`.
+If your skill/tool already confirmed these role assignments, treat the commands
+below as a verification/fallback step. Otherwise, run these assignments once per
+resource group that hosts a Foundry account you will evaluate against. Cloud
+evaluations run server-side and some agent or grader calls may authenticate as
+Foundry/Azure AI managed identities, not only as your signed-in user. Assigning
+the role only to your user can still leave graders failing with
+`AuthenticationError`.
 
 ```powershell
 $subscriptionId = az account show --query id -o tsv

--- a/docs/tutorial-hosted-agent-quickstart.md
+++ b/docs/tutorial-hosted-agent-quickstart.md
@@ -151,9 +151,12 @@ spans.
 > Replace `<your-alias>` with a short unique suffix when multiple people share
 > the same subscription. Resource group names are unique within a subscription;
 > Foundry / AI Services resource names should also be unique enough to avoid
-> Azure naming conflicts. For a recorded tutorial, one shared resource group is
-> easiest because RBAC and cleanup happen in one place; production teams may
-> split resource groups by environment.
+> Azure naming conflicts. Also ask the skill/tool to grant or verify
+> `Cognitive Services OpenAI User` data-plane access for your signed-in user and
+> any Foundry/Azure AI managed identities that will call evaluator models. For a
+> recorded tutorial, one shared resource group is easiest because RBAC and
+> cleanup happen in one place; production teams may split resource groups by
+> environment.
 
 ## 1. Create a clean workspace and install dependencies
 
@@ -334,11 +337,13 @@ but `dataActions: []`. Skipping this once causes the eval to fail with
 `PermissionDenied` on `Microsoft.CognitiveServices/accounts/OpenAI/
 deployments/chat/completions/action`.
 
-Run these assignments once per resource group hosting a Foundry account
-you will evaluate against. Local AI-assisted evaluators use your identity,
-while Foundry-hosted/server-side eval paths may use Azure AI managed
-identities from the same resource group. Assigning only the user can still
-leave server-side graders failing with `AuthenticationError`.
+If your skill/tool already confirmed these role assignments, treat the commands
+below as a verification/fallback step. Otherwise, run these assignments once per
+resource group hosting a Foundry account you will evaluate against. Local
+AI-assisted evaluators use your identity, while Foundry-hosted/server-side eval
+paths may use Azure AI managed identities from the same resource group.
+Assigning only the user can still leave server-side graders failing with
+`AuthenticationError`.
 
 ```powershell
 $subscriptionId = az account show --query id -o tsv

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -243,6 +243,9 @@ For each project, please:
   uses a single bootstrap model value for every environment.
 - Attach or create an Application Insights resource for telemetry,
   starting with the dev project.
+- Grant or verify `Cognitive Services OpenAI User` data-plane access for my
+  signed-in user and for the Foundry/Azure AI managed identities that will
+  call the model deployment during server-side evaluations.
 
 Show me the planned changes and the resulting endpoints before applying.
 ```
@@ -276,11 +279,14 @@ Skipping this step is what causes the eval grader to fail later with::
     data action `Microsoft.CognitiveServices/accounts/OpenAI/deployments/
     chat/completions/action` to perform `POST /openai/deployments/...`
 
-Run these assignments once per resource group that hosts a Foundry account
-you will evaluate against. Cloud evaluations run server-side: the agent call
-and graders may authenticate as Foundry/Azure AI managed identities, not only
-as your signed-in user. Assigning the role only to your user can still leave
-some graders failing with `AuthenticationError`.
+If you used Path B and the `microsoft-foundry` skill confirmed these role
+assignments, treat the commands below as a verification/fallback step. If you
+used the portal, or if the skill only created the projects and deployments, run
+these assignments once per resource group that hosts a Foundry account you will
+evaluate against. Cloud evaluations run server-side: the agent call and graders
+may authenticate as Foundry/Azure AI managed identities, not only as your
+signed-in user. Assigning the role only to your user can still leave some
+graders failing with `AuthenticationError`.
 
 ```powershell
 $subscriptionId = az account show --query id -o tsv


### PR DESCRIPTION
## Summary
- Tell the `microsoft-foundry` skill prompt to grant or verify Cognitive Services OpenAI User data-plane access
- Clarify RBAC commands are fallback/verification when a skill or tool already applied the assignments
- Keep prompt-agent, hosted-agent, and end-to-end tutorials consistent

## Tests
- Not run (docs-only change)