### PR TITLE
docs: clarify resource group placeholder in tutorials

### DIFF
--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -321,7 +321,8 @@ resource group that hosts a Foundry account you will evaluate against. Cloud
 evaluations run server-side and some agent or grader calls may authenticate as
 Foundry/Azure AI managed identities, not only as your signed-in user. Assigning
 the role only to your user can still leave graders failing with
-`AuthenticationError`.
+`AuthenticationError`. Replace `<resource-group>` with the resource group you
+chose above, for example `rg-agentops-travel-<your-alias>`.
 
 ```powershell
 $subscriptionId = az account show --query id -o tsv

--- a/docs/tutorial-hosted-agent-quickstart.md
+++ b/docs/tutorial-hosted-agent-quickstart.md
@@ -343,7 +343,8 @@ resource group hosting a Foundry account you will evaluate against. Local
 AI-assisted evaluators use your identity, while Foundry-hosted/server-side eval
 paths may use Azure AI managed identities from the same resource group.
 Assigning only the user can still leave server-side graders failing with
-`AuthenticationError`.
+`AuthenticationError`. Replace `<resource-group>` with the resource group you
+chose above, for example `rg-agentops-travel-<your-alias>`.
 
 ```powershell
 $subscriptionId = az account show --query id -o tsv

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -224,7 +224,9 @@ Run these assignments once per resource group that hosts a Foundry account
 you will evaluate against. Cloud evaluations run server-side: the agent call
 and graders may authenticate as Foundry/Azure AI managed identities, not only
 as your signed-in user. Assigning the role only to your user can still leave
-some graders failing with `AuthenticationError`.
+some graders failing with `AuthenticationError`. Replace `<resource-group>`
+with the resource group you chose above, for example
+`rg-agentops-travel-<your-alias>`.
 
 ```powershell
 $subscriptionId = az account show --query id -o tsv


### PR DESCRIPTION
## Summary
- Clarify that `<resource-group>` must be replaced before running RBAC commands
- Apply the same wording to prompt-agent, hosted-agent, and end-to-end tutorials

## Tests
- Not run (docs-only change)