### PR TITLE
docs: mention AI Landing Zone in tutorials

### DIFF
--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -75,7 +75,8 @@ hosted endpoint itself is the per-environment artifact.
 > any Foundry/Azure AI managed identities that will call evaluator models. A
 > single shared resource group is easiest for demos because RBAC and cleanup
 > happen once; production environments may use separate resource groups per
-> stage.
+> stage. For a fuller Azure baseline with networking, identity, security, and
+> operations patterns, see [Azure AI Landing Zone](https://aka.ms/ailz).
 
 ## The cross-environment identity story (versioning callout)
 

--- a/docs/tutorial-hosted-agent-quickstart.md
+++ b/docs/tutorial-hosted-agent-quickstart.md
@@ -156,7 +156,8 @@ spans.
 > any Foundry/Azure AI managed identities that will call evaluator models. For a
 > recorded tutorial, one shared resource group is easiest because RBAC and
 > cleanup happen in one place; production teams may split resource groups by
-> environment.
+> environment. For a fuller Azure baseline with networking, identity, security,
+> and operations patterns, see [Azure AI Landing Zone](https://aka.ms/ailz).
 
 ## 1. Create a clean workspace and install dependencies
 

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -183,6 +183,11 @@ names so the rest of the tutorial reads naturally:
 > projects exist; only the dev / qa / prod chain is what CI promotes
 > through.
 
+> **Enterprise provisioning option.** This quickstart creates only the Foundry
+> resources needed for the video path. For a fuller Azure baseline with
+> networking, identity, security, and operations patterns, see
+> [Azure AI Landing Zone](https://aka.ms/ailz).
+
 ### Path A — Foundry portal (always available)
 
 1. Open the [Azure AI Foundry portal](https://ai.azure.com).


### PR DESCRIPTION
## Summary
- Add a short AI Landing Zone reference to the prompt-agent tutorial provisioning step
- Keep hosted-agent and end-to-end tutorials consistent with the same link

## Tests
- Not run (docs-only change)