### PR TITLE
docs: use current Foundry User role name

### DIFF
--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -70,13 +70,14 @@ hosted endpoint itself is the per-environment artifact.
 > Replace `<your-alias>` with a short unique suffix when multiple people share
 > the same subscription. Resource group names are unique within a subscription;
 > Foundry / AI Services resource names should also be unique enough to avoid
-> Azure naming conflicts. Also ask the skill/tool to grant or verify `Azure AI
-> User` access for your signed-in user and `Cognitive Services OpenAI User`
-> data-plane access for your signed-in user plus any Foundry/Azure AI managed
-> identities that will call evaluator models. A single shared resource group is
-> easiest for demos because RBAC and cleanup happen once; production environments
-> may use separate resource groups per stage. For a fuller Azure baseline with
-> networking, identity, security, and operations patterns, see
+> Azure naming conflicts. Also ask the skill/tool to grant or verify `Foundry
+> User` access for your signed-in user (some portal screens still call this
+> `Azure AI User`) and `Cognitive Services OpenAI User` data-plane access for
+> your signed-in user plus any Foundry/Azure AI managed identities that will
+> call evaluator models. A single shared resource group is easiest for demos
+> because RBAC and cleanup happen once; production environments may use separate
+> resource groups per stage. For a fuller Azure baseline with networking,
+> identity, security, and operations patterns, see
 > [Azure AI Landing Zone](https://aka.ms/ailz).
 
 ## The cross-environment identity story (versioning callout)
@@ -311,8 +312,9 @@ account behind your Foundry project — either through Foundry's cloud
 graders or through the local AI-assisted evaluators. Creating a project
 through the portal assigns you `Foundry User` **only at the project
 scope**. Creating/building agents in the Foundry UI can also require
-`Azure AI User` on the Foundry / AI Services resource. `Foundry User` does not
-cover OpenAI data-plane actions on the parent account. Subscription `Owner` is
+`Foundry User` on the parent Foundry / AI Services resource; some portal screens
+still use the previous role name, `Azure AI User`. `Foundry User` does not cover
+OpenAI data-plane actions on the parent account. Subscription `Owner` is
 also insufficient: its built-in role definition has `actions: ["*"]` but
 `dataActions: []`. Skipping the OpenAI role is what causes the eval to fail
 later with `PermissionDenied` on
@@ -336,7 +338,7 @@ $userObjectId = az ad signed-in-user show --query id -o tsv
 
 az role assignment create `
   --assignee $userObjectId `
-  --role "Azure AI User" `
+  --role "Foundry User" `
   --scope $scope
 
 az role assignment create `

--- a/docs/tutorial-hosted-agent-quickstart.md
+++ b/docs/tutorial-hosted-agent-quickstart.md
@@ -151,13 +151,14 @@ spans.
 > Replace `<your-alias>` with a short unique suffix when multiple people share
 > the same subscription. Resource group names are unique within a subscription;
 > Foundry / AI Services resource names should also be unique enough to avoid
-> Azure naming conflicts. Also ask the skill/tool to grant or verify `Azure AI
-> User` access for your signed-in user and `Cognitive Services OpenAI User`
-> data-plane access for your signed-in user plus any Foundry/Azure AI managed
-> identities that will call evaluator models. For a recorded tutorial, one
-> shared resource group is easiest because RBAC and cleanup happen in one place;
-> production teams may split resource groups by environment. For a fuller Azure
-> baseline with networking, identity, security, and operations patterns, see
+> Azure naming conflicts. Also ask the skill/tool to grant or verify `Foundry
+> User` access for your signed-in user (some portal screens still call this
+> `Azure AI User`) and `Cognitive Services OpenAI User` data-plane access for
+> your signed-in user plus any Foundry/Azure AI managed identities that will
+> call evaluator models. For a recorded tutorial, one shared resource group is
+> easiest because RBAC and cleanup happen in one place; production teams may
+> split resource groups by environment. For a fuller Azure baseline with
+> networking, identity, security, and operations patterns, see
 > [Azure AI Landing Zone](https://aka.ms/ailz).
 
 ## 1. Create a clean workspace and install dependencies
@@ -333,8 +334,9 @@ The local AI-assisted evaluators that AgentOps runs in step 8 call
 chat-completions on the AI Services account that backs your Foundry
 project. Creating a project through the portal only assigns you
 `Foundry User` **at the project scope**. Creating/building agents in the
-Foundry UI can also require `Azure AI User` on the Foundry / AI Services
-resource. `Foundry User` also does not cover the OpenAI data-plane action on
+Foundry UI can also require `Foundry User` on the parent Foundry / AI Services
+resource; some portal screens still use the previous role name,
+`Azure AI User`. `Foundry User` also does not cover the OpenAI data-plane action on
 the parent account. Even subscription `Owner` is insufficient: the built-in
 `Owner` role has `actions: ["*"]` but `dataActions: []`. Skipping the OpenAI
 role causes the eval to fail with `PermissionDenied` on
@@ -357,7 +359,7 @@ $userObjectId = az ad signed-in-user show --query id -o tsv
 
 az role assignment create `
   --assignee $userObjectId `
-  --role "Azure AI User" `
+  --role "Foundry User" `
   --scope $scope
 
 az role assignment create `

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -213,8 +213,10 @@ names so the rest of the tutorial reads naturally:
 
 Creating a project through the portal only assigns you `Foundry User` **at
 the project scope**. In the Foundry UI, creating/building agents can also
-require `Azure AI User` on the Foundry / AI Services resource. If that role is
-missing, the portal blocks step 4 with:
+require `Foundry User` on the parent Foundry / AI Services resource. Some
+portal screens still use the previous role name, `Azure AI User`, while the
+Azure RBAC role name is now `Foundry User`. If that role is missing, the portal
+blocks step 4 with:
 
 ```text
 You don't have permission to build agents in this project.
@@ -251,7 +253,7 @@ $userObjectId = az ad signed-in-user show --query id -o tsv
 # User building agents in Foundry and running local commands / cloud evals.
 az role assignment create `
   --assignee $userObjectId `
-  --role "Azure AI User" `
+  --role "Foundry User" `
   --scope $scope
 
 az role assignment create `
@@ -329,8 +331,9 @@ For each project, please:
   uses a single bootstrap model value for every environment.
 - Attach or create an Application Insights resource for telemetry,
   starting with the dev project.
-- Grant or verify `Azure AI User` access for my signed-in user so I can build
-  agents in the Foundry UI.
+- Grant or verify `Foundry User` access for my signed-in user at the Foundry /
+  AI Services resource or resource-group scope so I can build agents in the
+  Foundry UI. Some portal screens still call this role `Azure AI User`.
 - Grant or verify `Cognitive Services OpenAI User` data-plane access for my
   signed-in user and for the Foundry/Azure AI managed identities that will call
   the model deployment during server-side evaluations.
@@ -350,10 +353,11 @@ easiest because RBAC and cleanup happen in one place; production teams may split
 resource groups by environment.
 
 Before continuing, check that the skill's plan/output explicitly lists
-`Azure AI User` for your signed-in user and `Cognitive Services OpenAI User` for
-your signed-in user plus the Foundry/Azure AI managed identities. If it only
-created the projects and model deployments, ask the skill to add or verify those
-role assignments before you move to step 4.
+`Foundry User` (or the previous portal label, `Azure AI User`) for your signed-in
+user and `Cognitive Services OpenAI User` for your signed-in user plus the
+Foundry/Azure AI managed identities. If it only created the projects and model
+deployments, ask the skill to add or verify those role assignments before you
+move to step 4.
 
 ## 4. Seed `travel-agent` in the sandbox project
 


### PR DESCRIPTION
## Summary
- Replace Azure AI User CLI role references with the current Foundry User RBAC role name
- Note that some portal screens still show the previous Azure AI User label
- Keep prompt-agent, hosted-agent, and end-to-end tutorial RBAC guidance consistent

## Tests
- Not run (docs-only change)