### PR TITLE
docs: scope Foundry RBAC to AI Services account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   notes, and red-team readiness plans while explicitly refusing offensive
   payload generation.
 
+### Fixed
+- **Foundry RBAC preflight now prevents the portal build-agent permission
+  block.** The prompt-agent, hosted-agent, and end-to-end tutorials plus the
+  packaged `agentops-eval` skill now grant `Foundry User` and `Cognitive
+  Services OpenAI User` on the parent AI Services account using stable role IDs.
+  This covers the Foundry UI's "You don't have permission to build agents"
+  failure as well as the evaluator chat-completions data-plane failure, while
+  still assigning the OpenAI role to Foundry/Azure AI managed identities used by
+  server-side graders.
+
 ## [0.3.8] - 2026-06-04
 
 ### Fixed

--- a/docs/tutorial-end-to-end.md
+++ b/docs/tutorial-end-to-end.md
@@ -323,28 +323,33 @@ completions/action`.
 
 If your skill/tool already confirmed these role assignments, treat the commands
 below as a verification/fallback step. Otherwise, run these assignments once per
-resource group that hosts a Foundry account you will evaluate against. Cloud
+AI Services account that hosts a Foundry project you will evaluate against. Cloud
 evaluations run server-side and some agent or grader calls may authenticate as
 Foundry/Azure AI managed identities, not only as your signed-in user. Assigning
 the role only to your user can still leave graders failing with
 `AuthenticationError`. Replace `<resource-group>` with the resource group you
-chose above, for example `rg-agentops-travel-<your-alias>`.
+chose above, for example `rg-agentops-travel-<your-alias>`, and
+`<account-name>` with the parent Foundry / AI Services account name.
 
 ```powershell
 $subscriptionId = az account show --query id -o tsv
 $resourceGroup = "<resource-group>"
-$scope = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroup"
+$accountName = "<account-name>"
+$accountScope = az cognitiveservices account show `
+  --resource-group $resourceGroup `
+  --name $accountName `
+  --query id -o tsv
 $userObjectId = az ad signed-in-user show --query id -o tsv
 
 az role assignment create `
   --assignee $userObjectId `
-  --role "Foundry User" `
-  --scope $scope
+  --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" `
+  --scope $accountScope
 
 az role assignment create `
   --assignee $userObjectId `
-  --role "Cognitive Services OpenAI User" `
-  --scope $scope
+  --role "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" `
+  --scope $accountScope
 
 az resource list -g $resourceGroup `
   --query "[?identity.principalId!=null].identity.principalId" -o tsv |
@@ -352,8 +357,8 @@ az resource list -g $resourceGroup `
     az role assignment create `
       --assignee-object-id $_ `
       --assignee-principal-type ServicePrincipal `
-      --role "Cognitive Services OpenAI User" `
-      --scope $scope
+      --role "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" `
+      --scope $accountScope
   }
 ```
 

--- a/docs/tutorial-hosted-agent-quickstart.md
+++ b/docs/tutorial-hosted-agent-quickstart.md
@@ -344,28 +344,33 @@ role causes the eval to fail with `PermissionDenied` on
 
 If your skill/tool already confirmed these role assignments, treat the commands
 below as a verification/fallback step. Otherwise, run these assignments once per
-resource group hosting a Foundry account you will evaluate against. Local
+AI Services account hosting a Foundry project you will evaluate against. Local
 AI-assisted evaluators use your identity, while Foundry-hosted/server-side eval
 paths may use Azure AI managed identities from the same resource group.
 Assigning only the user can still leave server-side graders failing with
 `AuthenticationError`. Replace `<resource-group>` with the resource group you
-chose above, for example `rg-agentops-travel-<your-alias>`.
+chose above, for example `rg-agentops-travel-<your-alias>`, and
+`<account-name>` with the parent Foundry / AI Services account name.
 
 ```powershell
 $subscriptionId = az account show --query id -o tsv
 $resourceGroup = "<resource-group>"
-$scope = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroup"
+$accountName = "<account-name>"
+$accountScope = az cognitiveservices account show `
+  --resource-group $resourceGroup `
+  --name $accountName `
+  --query id -o tsv
 $userObjectId = az ad signed-in-user show --query id -o tsv
 
 az role assignment create `
   --assignee $userObjectId `
-  --role "Foundry User" `
-  --scope $scope
+  --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" `
+  --scope $accountScope
 
 az role assignment create `
   --assignee $userObjectId `
-  --role "Cognitive Services OpenAI User" `
-  --scope $scope
+  --role "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" `
+  --scope $accountScope
 
 az resource list -g $resourceGroup `
   --query "[?identity.principalId!=null].identity.principalId" -o tsv |
@@ -373,8 +378,8 @@ az resource list -g $resourceGroup `
     az role assignment create `
       --assignee-object-id $_ `
       --assignee-principal-type ServicePrincipal `
-      --role "Cognitive Services OpenAI User" `
-      --scope $scope
+      --role "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" `
+      --scope $accountScope
   }
 ```
 

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -236,30 +236,35 @@ Skipping the OpenAI role is what causes the eval grader to fail later with::
     data action `Microsoft.CognitiveServices/accounts/OpenAI/deployments/
     chat/completions/action` to perform `POST /openai/deployments/...`
 
-Run these assignments once per resource group that hosts a Foundry account you
+Run these assignments once per AI Services account that hosts a Foundry project you
 will build in or evaluate against. Cloud evaluations run server-side: the agent
 call and graders may authenticate as Foundry/Azure AI managed identities, not
 only as your signed-in user. Assigning the OpenAI role only to your user can
 still leave some graders failing with `AuthenticationError`. Replace
 `<resource-group>` with the resource group you chose above, for example
-`rg-agentops-travel-<your-alias>`.
+`rg-agentops-travel-<your-alias>`, and `<account-name>` with the parent Foundry /
+AI Services account name.
 
 ```powershell
 $subscriptionId = az account show --query id -o tsv
 $resourceGroup = "<resource-group>"
-$scope = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroup"
+$accountName = "<account-name>"
+$accountScope = az cognitiveservices account show `
+  --resource-group $resourceGroup `
+  --name $accountName `
+  --query id -o tsv
 $userObjectId = az ad signed-in-user show --query id -o tsv
 
 # User building agents in Foundry and running local commands / cloud evals.
 az role assignment create `
   --assignee $userObjectId `
-  --role "Foundry User" `
-  --scope $scope
+  --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" `
+  --scope $accountScope
 
 az role assignment create `
   --assignee $userObjectId `
-  --role "Cognitive Services OpenAI User" `
-  --scope $scope
+  --role "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" `
+  --scope $accountScope
 
 # Foundry/Azure AI managed identities used by server-side agent/evaluator calls.
 az resource list -g $resourceGroup `
@@ -268,8 +273,8 @@ az resource list -g $resourceGroup `
     az role assignment create `
       --assignee-object-id $_ `
       --assignee-principal-type ServicePrincipal `
-      --role "Cognitive Services OpenAI User" `
-      --scope $scope
+      --role "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" `
+      --scope $accountScope
   }
 ```
 
@@ -331,8 +336,8 @@ For each project, please:
   uses a single bootstrap model value for every environment.
 - Attach or create an Application Insights resource for telemetry,
   starting with the dev project.
-- Grant or verify `Foundry User` access for my signed-in user at the Foundry /
-  AI Services resource or resource-group scope so I can build agents in the
+- Grant or verify `Foundry User` access for my signed-in user on the parent
+  Foundry / AI Services account so I can build agents in the
   Foundry UI. Some portal screens still call this role `Azure AI User`.
 - Grant or verify `Cognitive Services OpenAI User` data-plane access for my
   signed-in user and for the Foundry/Azure AI managed identities that will call
@@ -519,6 +524,10 @@ agent: travel-agent:2
 dataset: .agentops/data/travel-smoke.jsonl
 ```
 
+> **Why `version: 1`?** This is the AgentOps configuration schema version, not
+> the Foundry agent version. Keep it as `1`; the agent version is the suffix in
+> `agent: travel-agent:2`.
+>
 > **App Insights — should already be wired from step 3.** Step 3
 > (both Path A and Path B) instructs you to attach an Application
 > Insights resource to the **dev** Foundry project when you create it,

--- a/plugins/agentops/skills/agentops-eval/SKILL.md
+++ b/plugins/agentops/skills/agentops-eval/SKILL.md
@@ -25,28 +25,36 @@ with a `name:version` or URL.
    (`--project-endpoint`, `--agent`, `--dataset`, …) for non-interactive
    runs. Run `agentops init show` later to inspect the resolved config.
 
-## Step 0.5 - Ensure data-plane RBAC on the AI Services account
+## Step 0.5 - Ensure agent-build and data-plane RBAC on the AI Services account
 
 AgentOps eval (cloud graders **and** local AI-assisted evaluators) calls
 `/openai/deployments/.../chat/completions` on the AI Services account
 that backs the Foundry project. Creating a project through the Foundry
 portal only assigns the user `Foundry User` at the *project* scope,
-which does **not** cover OpenAI data-plane actions on the parent
-account. Subscription `Owner` is also insufficient because the built-in
+which does **not** cover the parent account. The Foundry UI may then block
+agent creation with "You don't have permission to build agents in this
+project" and ask for the old portal label, `Azure AI User`; the current Azure
+RBAC role is `Foundry User` (`53ca6127-db72-4b80-b1b0-d745d6d5456d`).
+
+You also need `Cognitive Services OpenAI User`
+(`5e0bd9bd-7b93-4f28-af87-19fc36ad61bd`) for OpenAI data-plane actions on
+the parent account. Subscription `Owner` is insufficient because the built-in
 `Owner` role has `actions: ["*"]` but `dataActions: []`. The first
-`agentops eval run` against a fresh workspace will otherwise fail with:
+`agentops eval run` against a fresh workspace otherwise fails with:
 
 ```
 PermissionDenied … lacks the required data action
 'Microsoft.CognitiveServices/accounts/OpenAI/deployments/chat/completions/action'
 ```
 
-Run this preflight before Step 1. It must grant the role to the signed-in
-user **and** to the Foundry/Azure AI managed identities in the resource
-group. Cloud evaluations run server-side and some graders authenticate as
-those managed identities, so assigning only the user can still produce
-intermittent `AuthenticationError` grader failures. The commands are
-idempotent (`RoleAssignmentExists` means the role was already granted):
+Run this preflight before Step 1. It must grant `Foundry User` and
+`Cognitive Services OpenAI User` to the signed-in user on the AI Services
+account, plus the OpenAI data-plane role to any Foundry/Azure AI managed
+identities in the resource group. Cloud evaluations run server-side and some
+graders authenticate as those managed identities, so assigning only the user
+can still produce intermittent `AuthenticationError` grader failures. The
+commands are idempotent (`RoleAssignmentExists` means the role was already
+granted):
 
 ```bash
 # 1. Resolve the AI Services account from agentops.yaml / .azure/<env>/.env
@@ -54,16 +62,22 @@ PROJECT_ENDPOINT=$(grep -h '^AZURE_AI_FOUNDRY_PROJECT_ENDPOINT' .azure/*/.env .a
 ACCOUNT_HOST=$(echo "$PROJECT_ENDPOINT" | awk -F[/:] '{print $4}')
 ACCOUNT_NAME=$(echo "$ACCOUNT_HOST" | cut -d. -f1)
 
-# 2. Resolve subscription, resource group, and signed-in object ID
+# 2. Resolve subscription, resource group, account scope, and signed-in object ID
 SUB_ID=$(az account show --query id -o tsv)
 RG=$(az cognitiveservices account list --subscription "$SUB_ID" --query "[?name=='$ACCOUNT_NAME'].resourceGroup | [0]" -o tsv)
+ACCOUNT_ID=$(az cognitiveservices account show -g "$RG" -n "$ACCOUNT_NAME" --query id -o tsv)
 OBJ_ID=$(az ad signed-in-user show --query id -o tsv)
 
-# 3. Grant the user data-plane access at RG scope.
+# 3. Grant the user portal build access and data-plane access at account scope.
 az role assignment create \
   --assignee "$OBJ_ID" \
-  --role "Cognitive Services OpenAI User" \
-  --scope "/subscriptions/$SUB_ID/resourceGroups/$RG"
+  --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
+  --scope "$ACCOUNT_ID"
+
+az role assignment create \
+  --assignee "$OBJ_ID" \
+  --role "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" \
+  --scope "$ACCOUNT_ID"
 
 # 4. Grant the same data-plane role to Foundry/Azure AI managed identities.
 az resource list -g "$RG" \
@@ -73,8 +87,8 @@ while read -r PRINCIPAL_ID; do
   az role assignment create \
     --assignee-object-id "$PRINCIPAL_ID" \
     --assignee-principal-type ServicePrincipal \
-    --role "Cognitive Services OpenAI User" \
-    --scope "/subscriptions/$SUB_ID/resourceGroups/$RG"
+    --role "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" \
+    --scope "$ACCOUNT_ID"
 done
 ```
 
@@ -85,9 +99,10 @@ If the user has not run `az login` yet, do that first. If
 `az cognitiveservices account list` returns an empty RG, the AI Services
 account lives in a different subscription - ask the user which one.
 
-Skip this step only if the user explicitly says the role is already
-assigned, or if a previous `agentops eval run` succeeded against the
-same Foundry account.
+Skip this step only if the user explicitly says both roles are already
+assigned on the parent AI Services account, or if the user can already build
+agents in the Foundry UI and a previous `agentops eval run` succeeded against
+the same Foundry account.
 
 **Propagation:** data-plane role assignments do not take effect
 instantly — allow several minutes (occasionally up to ~15) before the

--- a/src/agentops/templates/skills/agentops-eval/SKILL.md
+++ b/src/agentops/templates/skills/agentops-eval/SKILL.md
@@ -25,28 +25,36 @@ with a `name:version` or URL.
    (`--project-endpoint`, `--agent`, `--dataset`, …) for non-interactive
    runs. Run `agentops init show` later to inspect the resolved config.
 
-## Step 0.5 - Ensure data-plane RBAC on the AI Services account
+## Step 0.5 - Ensure agent-build and data-plane RBAC on the AI Services account
 
 AgentOps eval (cloud graders **and** local AI-assisted evaluators) calls
 `/openai/deployments/.../chat/completions` on the AI Services account
 that backs the Foundry project. Creating a project through the Foundry
 portal only assigns the user `Foundry User` at the *project* scope,
-which does **not** cover OpenAI data-plane actions on the parent
-account. Subscription `Owner` is also insufficient because the built-in
+which does **not** cover the parent account. The Foundry UI may then block
+agent creation with "You don't have permission to build agents in this
+project" and ask for the old portal label, `Azure AI User`; the current Azure
+RBAC role is `Foundry User` (`53ca6127-db72-4b80-b1b0-d745d6d5456d`).
+
+You also need `Cognitive Services OpenAI User`
+(`5e0bd9bd-7b93-4f28-af87-19fc36ad61bd`) for OpenAI data-plane actions on
+the parent account. Subscription `Owner` is insufficient because the built-in
 `Owner` role has `actions: ["*"]` but `dataActions: []`. The first
-`agentops eval run` against a fresh workspace will otherwise fail with:
+`agentops eval run` against a fresh workspace otherwise fails with:
 
 ```
 PermissionDenied … lacks the required data action
 'Microsoft.CognitiveServices/accounts/OpenAI/deployments/chat/completions/action'
 ```
 
-Run this preflight before Step 1. It must grant the role to the signed-in
-user **and** to the Foundry/Azure AI managed identities in the resource
-group. Cloud evaluations run server-side and some graders authenticate as
-those managed identities, so assigning only the user can still produce
-intermittent `AuthenticationError` grader failures. The commands are
-idempotent (`RoleAssignmentExists` means the role was already granted):
+Run this preflight before Step 1. It must grant `Foundry User` and
+`Cognitive Services OpenAI User` to the signed-in user on the AI Services
+account, plus the OpenAI data-plane role to any Foundry/Azure AI managed
+identities in the resource group. Cloud evaluations run server-side and some
+graders authenticate as those managed identities, so assigning only the user
+can still produce intermittent `AuthenticationError` grader failures. The
+commands are idempotent (`RoleAssignmentExists` means the role was already
+granted):
 
 ```bash
 # 1. Resolve the AI Services account from agentops.yaml / .azure/<env>/.env
@@ -54,16 +62,22 @@ PROJECT_ENDPOINT=$(grep -h '^AZURE_AI_FOUNDRY_PROJECT_ENDPOINT' .azure/*/.env .a
 ACCOUNT_HOST=$(echo "$PROJECT_ENDPOINT" | awk -F[/:] '{print $4}')
 ACCOUNT_NAME=$(echo "$ACCOUNT_HOST" | cut -d. -f1)
 
-# 2. Resolve subscription, resource group, and signed-in object ID
+# 2. Resolve subscription, resource group, account scope, and signed-in object ID
 SUB_ID=$(az account show --query id -o tsv)
 RG=$(az cognitiveservices account list --subscription "$SUB_ID" --query "[?name=='$ACCOUNT_NAME'].resourceGroup | [0]" -o tsv)
+ACCOUNT_ID=$(az cognitiveservices account show -g "$RG" -n "$ACCOUNT_NAME" --query id -o tsv)
 OBJ_ID=$(az ad signed-in-user show --query id -o tsv)
 
-# 3. Grant the user data-plane access at RG scope.
+# 3. Grant the user portal build access and data-plane access at account scope.
 az role assignment create \
   --assignee "$OBJ_ID" \
-  --role "Cognitive Services OpenAI User" \
-  --scope "/subscriptions/$SUB_ID/resourceGroups/$RG"
+  --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
+  --scope "$ACCOUNT_ID"
+
+az role assignment create \
+  --assignee "$OBJ_ID" \
+  --role "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" \
+  --scope "$ACCOUNT_ID"
 
 # 4. Grant the same data-plane role to Foundry/Azure AI managed identities.
 az resource list -g "$RG" \
@@ -73,8 +87,8 @@ while read -r PRINCIPAL_ID; do
   az role assignment create \
     --assignee-object-id "$PRINCIPAL_ID" \
     --assignee-principal-type ServicePrincipal \
-    --role "Cognitive Services OpenAI User" \
-    --scope "/subscriptions/$SUB_ID/resourceGroups/$RG"
+    --role "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" \
+    --scope "$ACCOUNT_ID"
 done
 ```
 
@@ -85,9 +99,10 @@ If the user has not run `az login` yet, do that first. If
 `az cognitiveservices account list` returns an empty RG, the AI Services
 account lives in a different subscription - ask the user which one.
 
-Skip this step only if the user explicitly says the role is already
-assigned, or if a previous `agentops eval run` succeeded against the
-same Foundry account.
+Skip this step only if the user explicitly says both roles are already
+assigned on the parent AI Services account, or if the user can already build
+agents in the Foundry UI and a previous `agentops eval run` succeeded against
+the same Foundry account.
 
 **Propagation:** data-plane role assignments do not take effect
 instantly — allow several minutes (occasionally up to ~15) before the


### PR DESCRIPTION
## Summary
- Scope Foundry/User and OpenAI data-plane role assignments to the parent AI Services account instead of the resource group
- Update all three tutorials and the packaged agentops-eval skill/template with stable role IDs
- Add the ersion: 1 explanation in the prompt-agent tutorial and changelog entry

## Validation
- python -m pytest tests\\unit\\test_skills.py tests\\unit\\test_skills_sync.py -q