### PR TITLE
fix: avoid unicode failure in eval init output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   payload generation.
 
 ### Fixed
+- **`agentops eval init` now prints safely on Windows terminals without Unicode
+  support.** The CLI falls back to an ASCII updated marker instead of raising a
+  `UnicodeEncodeError` on cp1252 consoles after it wires `execution: azd` and
+  `eval_recipe`.
 - **Foundry RBAC preflight now prevents the portal build-agent permission
   block.** The prompt-agent, hosted-agent, and end-to-end tutorials plus the
   packaged `agentops-eval` skill now grant `Foundry User` and `Cognitive

--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -107,7 +107,8 @@ def _cli_created(path: Path | str) -> str:
 
 
 def _cli_updated(path: Path | str) -> str:
-    return f" {_cli_ok('✓')} {_cli_ok('updated')} {_cli_path(path)}"
+    marker = "✓" if _terminal_unicode_enabled() else "*"
+    return f" {_cli_ok(marker)} {_cli_ok('updated')} {_cli_path(path)}"
 
 
 def _cli_overwritten(path: Path | str) -> str:

--- a/tests/unit/test_azd_eval_init.py
+++ b/tests/unit/test_azd_eval_init.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 from typer.testing import CliRunner
 
+import agentops.cli.app as cli_app
 from agentops.cli.app import app
 from agentops.services import azd_eval_init
 
@@ -102,3 +103,33 @@ def test_cli_eval_init_prints_result(tmp_path: Path, monkeypatch) -> None:
     assert result.exit_code == 0
     assert "azd eval init" in result.output
     assert "agentops eval run" in result.output
+
+
+def test_cli_eval_init_uses_ascii_updated_marker_when_unicode_disabled(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config_path = tmp_path / "agentops.yaml"
+    _write_config(config_path)
+    recipe_path = tmp_path / "eval.yaml"
+
+    def fake_init(**kwargs):
+        return azd_eval_init.AzdEvalInitResult(
+            recipe_path=recipe_path,
+            config_path=config_path,
+            config_updated=True,
+            command_ran=False,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(azd_eval_init, "run_azd_eval_init", fake_init)
+    monkeypatch.setattr(cli_app, "_terminal_unicode_enabled", lambda: False)
+
+    result = runner.invoke(
+        app,
+        ["eval", "init", "--dir", str(tmp_path), "--config", str(config_path)],
+    )
+
+    assert result.exit_code == 0
+    assert " * updated" in result.output
+    assert "✓" not in result.output


### PR DESCRIPTION
## Summary
- Fall back to an ASCII updated marker when the terminal does not support Unicode
- Add regression coverage for gentops eval init output on non-Unicode terminals
- Update the changelog

## Validation
- python -m pytest tests\\unit\\test_agentops_config.py tests\\unit\\test_azd_eval.py tests\\unit\\test_azd_eval_init.py tests\\unit\\test_azd_runner.py tests\\unit\\test_cicd.py::test_prompt_agent_config_with_eval_yaml_uses_azd_eval_runner tests\\unit\\test_workflow_analysis.py::test_analysis_recommends_azd_eval_when_eval_yaml_exists -q
- Smoke: temp workspace with existing eval.yaml, python -m agentops eval init --dir <tmp> --config <tmp>\\agentops.yaml