### PR TITLE
fix: align workflow analyze guidance with azd eval init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   payload generation.
 
 ### Fixed
+- **`agentops workflow analyze` now points prompt-agent users at `eval init`
+  before `eval run` when no azd recipe is wired yet.** This keeps the CLI's
+  next-step guidance aligned with the prompt-agent tutorial's standard
+  Foundry-native `eval.yaml` flow.
 - **`agentops eval init` now prints safely on Windows terminals without Unicode
   support.** The CLI falls back to an ASCII updated marker instead of raising a
   `UnicodeEncodeError` on cp1252 consoles after it wires `execution: azd` and

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -751,6 +751,10 @@ the deploy workflow records which candidate is now running in dev. Next,
 standardize the eval side on an azd recipe so the same Foundry-native eval
 definition is used locally and in CI.
 
+The **Next** section printed by `workflow analyze` is a generic handoff. If it
+still says to run `agentops eval run` first, do not jump there yet for this
+tutorial. First create and wire the azd eval recipe:
+
 For this tutorial, use an azd eval recipe as the default Foundry-native eval
 handoff:
 

--- a/src/agentops/services/workflow_analysis.py
+++ b/src/agentops/services/workflow_analysis.py
@@ -1136,19 +1136,40 @@ def _next_steps(
     skills_installed: bool,
     ailz_preflight: bool,
 ) -> List[str]:
+    eval_step = "Run `agentops eval run` locally and commit agentops.yaml plus datasets."
+    if mode == "prompt-agent" and eval_runner == AGENTOPS_CLOUD_RUNNER:
+        eval_step = (
+            "Run `agentops eval init` first if you want the Foundry-native azd "
+            "eval.yaml path; then run `agentops eval run` and commit agentops.yaml, "
+            "eval.yaml, and datasets."
+        )
+    elif eval_runner == AZD_EVAL_RUNNER:
+        eval_step = (
+            "Run `agentops eval run` locally and commit agentops.yaml, eval.yaml, "
+            "generated evaluator/rubric assets, and datasets."
+        )
     steps = [
-        "Run `agentops eval run` locally and commit agentops.yaml plus datasets.",
+        eval_step,
         f"Generate workflows with `agentops workflow generate --deploy-mode {mode}`.",
     ]
     if eval_runner == AGENTOPS_CLOUD_RUNNER:
+        cloud_eval_step = (
+            "Set AZURE_OPENAI_DEPLOYMENT so Foundry cloud eval can judge responses, "
+            "then review AgentOps results.json/report.md after the run."
+        )
+        if mode == "prompt-agent":
+            cloud_eval_step = (
+                "If you skip `agentops eval init` and stay on AgentOps cloud eval, "
+                "set AZURE_OPENAI_DEPLOYMENT so Foundry can judge responses."
+            )
         steps.insert(
             1,
-            "Set AZURE_OPENAI_DEPLOYMENT so Foundry cloud eval can judge responses, then review AgentOps results.json/report.md after the run.",
+            cloud_eval_step,
         )
     elif eval_runner == AZD_EVAL_RUNNER:
         steps.insert(
             1,
-            "Keep eval.yaml and generated evaluator/rubric assets committed; CI installs a pinned azure.ai.agents extension before running the azd backend.",
+            "CI installs a pinned azure.ai.agents extension before running the azd backend.",
         )
     elif eval_runner == OFFICIAL_EVAL_RUNNER:
         steps.insert(

--- a/tests/unit/test_workflow_analysis.py
+++ b/tests/unit/test_workflow_analysis.py
@@ -109,6 +109,10 @@ def test_analysis_recommends_cloud_eval_for_supported_prompt_agent(tmp_path: Pat
     assert "Copilot skills" in rendered
     assert "not needed - no Copilot handoff for this project shape" in rendered
     assert "Foundry eval" in rendered
+    assert "Run `agentops eval init` first" in rendered
+    assert "If you skip `agentops eval init`" in rendered
+    assert analysis.next_steps[0].startswith("Run `agentops eval init` first")
+    assert analysis.next_steps[1].startswith("If you skip `agentops eval init`")
     assert "- [x]" not in rendered
     assert "builtin." not in rendered
     assert "| Check" not in rendered
@@ -146,6 +150,9 @@ evaluators:
     assert "booking_accuracy" in analysis.official_evaluators
     assert any(signal.key == "azd_ai_agent_eval" for signal in analysis.signals)
     assert "azd AI agent eval" in rendered
+    assert analysis.next_steps[0].startswith("Run `agentops eval run` locally")
+    assert "eval.yaml" in analysis.next_steps[0]
+    assert "generated evaluator/rubric assets" in analysis.next_steps[0]
 
 
 def test_analysis_uses_placeholder_for_generic_repo(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Update workflow analyze next steps so prompt-agent users are pointed to agentops eval init before eval run when no azd recipe is wired yet
- Clarify AZURE_OPENAI_DEPLOYMENT is only needed if users skip eval init and stay on AgentOps cloud eval
- Update prompt-agent tutorial step 10 and changelog

## Validation
- python -m pytest tests\\unit\\test_workflow_analysis.py tests\\unit\\test_cicd.py::test_prompt_agent_config_with_eval_yaml_uses_azd_eval_runner -q
- Smoke: workflow analyze before eval init recommends eval init first
- Smoke: workflow analyze after execution: azd/eval_recipe recommends azd AI agent eval