### PR TITLE
fix: reuse configured dataset during azd eval init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   payload generation.
 
 ### Fixed
+- **`agentops eval init` now reuses the configured dataset and avoids hidden azd
+  prompts.** When `--dataset` is omitted, the command passes the existing
+  `agentops.yaml` dataset to `azd ai agent eval init`, reducing first-run
+  generation time for tutorial workspaces. It also runs azd with `--no-prompt`
+  and prints a progress line before the potentially long Foundry initialization.
 - **`agentops workflow analyze` now points prompt-agent users at `eval init`
   before `eval run` when no azd recipe is wired yet.** This keeps the CLI's
   next-step guidance aligned with the prompt-agent tutorial's standard

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -762,8 +762,11 @@ handoff:
 agentops eval init
 ```
 
-That command lets azd generate `eval.yaml`. Keep the recipe wired in
-`agentops.yaml`:
+That command lets azd generate `eval.yaml`. AgentOps passes the dataset already
+configured in `agentops.yaml` to azd, so azd does not need to invent a new smoke
+dataset for this tutorial. The first run can still take a few minutes because
+Foundry creates the eval assets server-side before `eval.yaml` is written. Keep
+the recipe wired in `agentops.yaml`:
 
 ```yaml
 execution: azd

--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -1939,6 +1939,10 @@ def cmd_eval_init(
         config_path = workspace / config_path
 
     try:
+        typer.echo(
+            f"{_cli_label('azd eval init')}: checking/generating eval.yaml "
+            "(this can take a few minutes on the first run)"
+        )
         result = run_azd_eval_init(
             workspace=workspace,
             config_path=config_path,

--- a/src/agentops/services/azd_eval_init.py
+++ b/src/agentops/services/azd_eval_init.py
@@ -68,9 +68,12 @@ def run_azd_eval_init(
             f"{AZD_EXTENSION_NAME}`), then rerun `agentops eval init`."
         )
 
-    command = ["azd", "ai", "agent", "eval", "init"]
-    if dataset is not None:
-        command.extend(["--dataset", str(dataset)])
+    command = ["azd", "--no-prompt", "ai", "agent", "eval", "init"]
+    effective_dataset = dataset or _dataset_from_config(resolved_config)
+    if effective_dataset is not None:
+        command.extend(
+            ["--dataset", _command_path(effective_dataset, workspace=root)]
+        )
 
     try:
         completed = subprocess.run(
@@ -120,6 +123,19 @@ def _find_recipe_if_unambiguous(workspace: Path) -> Optional[Path]:
         return None
 
 
+def _dataset_from_config(config_path: Path) -> Optional[Path]:
+    data = load_yaml(config_path)
+    raw_dataset = data.get("dataset")
+    if not raw_dataset:
+        return None
+    dataset = Path(str(raw_dataset))
+    if not dataset.is_absolute():
+        dataset = config_path.parent / dataset
+    if not dataset.exists():
+        return None
+    return dataset
+
+
 def _persist_recipe(
     *,
     config_path: Path,
@@ -151,5 +167,12 @@ def _persist_recipe(
 def _relative_config_path(path: Path, root: Path) -> str:
     try:
         return str(path.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(path.resolve())
+
+
+def _command_path(path: Path, *, workspace: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(workspace.resolve()))
     except ValueError:
         return str(path.resolve())

--- a/tests/unit/test_azd_eval_init.py
+++ b/tests/unit/test_azd_eval_init.py
@@ -33,11 +33,23 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
 ) -> None:
     config_path = tmp_path / "agentops.yaml"
     _write_config(config_path)
+    dataset = tmp_path / ".agentops" / "data" / "smoke.jsonl"
+    dataset.parent.mkdir(parents=True)
+    dataset.write_text('{"input":"hello"}\n', encoding="utf-8")
 
     monkeypatch.setattr(azd_eval_init, "azd_available", lambda *, cwd=None: True)
 
     def fake_run(command, *, cwd, text, capture_output, timeout, check):
-        assert command == ["azd", "ai", "agent", "eval", "init"]
+        assert command == [
+            "azd",
+            "--no-prompt",
+            "ai",
+            "agent",
+            "eval",
+            "init",
+            "--dataset",
+            str(Path(".agentops") / "data" / "smoke.jsonl"),
+        ]
         recipe = Path(cwd) / "src" / "travel-agent" / "eval.yaml"
         recipe.parent.mkdir(parents=True, exist_ok=True)
         recipe.write_text("name: travel-agent-eval\n", encoding="utf-8")
@@ -55,6 +67,43 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
     updated = config_path.read_text(encoding="utf-8")
     assert "eval_recipe: src\\travel-agent\\eval.yaml" in updated
     assert "execution: azd" in updated
+
+
+def test_run_azd_eval_init_explicit_dataset_wins(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "agentops.yaml"
+    _write_config(config_path)
+    dataset = tmp_path / "golden.jsonl"
+    dataset.write_text('{"input":"hello"}\n', encoding="utf-8")
+
+    monkeypatch.setattr(azd_eval_init, "azd_available", lambda *, cwd=None: True)
+
+    def fake_run(command, *, cwd, text, capture_output, timeout, check):
+        assert command == [
+            "azd",
+            "--no-prompt",
+            "ai",
+            "agent",
+            "eval",
+            "init",
+            "--dataset",
+            "golden.jsonl",
+        ]
+        recipe = Path(cwd) / "eval.yaml"
+        recipe.write_text("name: travel-agent-eval\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="created", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = azd_eval_init.run_azd_eval_init(
+        workspace=tmp_path,
+        config_path=config_path,
+        dataset=dataset,
+    )
+
+    assert result.command_ran is True
 
 
 def test_run_azd_eval_init_reuses_existing_recipe_without_running_azd(


### PR DESCRIPTION
## Summary
- Pass the configured agentops.yaml dataset to azd eval init when --dataset is omitted
- Run azd with --no-prompt and print a progress message before first-run initialization
- Update prompt-agent tutorial and changelog

## Validation
- python -m pytest tests\\unit\\test_azd_eval_init.py tests\\unit\\test_workflow_analysis.py -q
- Smoke: existing eval.yaml reuse updates agentops.yaml and prints progress