### PR TITLE
docs: verify prompt tutorial dataset path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   payload generation.
 
 ### Fixed
+- **Prompt-agent tutorial now explicitly verifies the Travel Agent dataset path
+  after `agentops init`.** Step 7 now tells users to confirm
+  `agentops.yaml` points at `.agentops/data/travel-smoke.jsonl` and provides a
+  repair command if the wizard left the starter `.agentops/data/smoke.jsonl`.
 - **`agentops eval init` now reuses the configured dataset and avoids hidden azd
   prompts.** When `--dataset` is omitted, the command passes the existing
   `agentops.yaml` dataset to `azd ai agent eval init`, reducing first-run

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -498,6 +498,28 @@ If the wizard offers starter defaults such as `Agent [my-agent:1]` or
 `Dataset path [.agentops/data/smoke.jsonl]`, replace them with the
 Travel Agent values above.
 
+Before continuing, verify the saved dataset path. This must point to the
+Travel Agent dataset you created in step 6, not the starter
+`.agentops/data/smoke.jsonl` file:
+
+```powershell
+Select-String -Path agentops.yaml -Pattern '^dataset:'
+```
+
+Expected output:
+
+```text
+dataset: .agentops/data/travel-smoke.jsonl
+```
+
+If it still says `.agentops/data/smoke.jsonl`, fix it now:
+
+```powershell
+(Get-Content agentops.yaml) `
+  -replace '^dataset:.*$', 'dataset: .agentops/data/travel-smoke.jsonl' |
+  Set-Content -Encoding utf8 agentops.yaml
+```
+
 The interactive path is intentional: you see what each value means, and
 each answer is saved as soon as it validates. Because you passed
 `--azd-env sandbox`, the wizard writes the local Azure values to


### PR DESCRIPTION
## Summary
- Make step 7 explicitly verify that agentops.yaml points to .agentops/data/travel-smoke.jsonl
- Add a repair command for workspaces that still point to the starter smoke.jsonl
- Update the changelog for 0.3.9

## Validation
- git diff --check