### PR TITLE
fix: correct prompt tutorial eval guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,15 +26,17 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   after `agentops init`.** Step 7 now tells users to confirm
   `agentops.yaml` points at `.agentops/data/travel-smoke.jsonl` and provides a
   repair command if the wizard left the starter `.agentops/data/smoke.jsonl`.
-- **`agentops eval init` now reuses the configured dataset and avoids hidden azd
-  prompts.** When `--dataset` is omitted, the command passes the existing
-  `agentops.yaml` dataset to `azd ai agent eval init`, reducing first-run
-  generation time for tutorial workspaces. It also runs azd with `--no-prompt`
-  and prints a progress line before the potentially long Foundry initialization.
-- **`agentops workflow analyze` now points prompt-agent users at `eval init`
-  before `eval run` when no azd recipe is wired yet.** This keeps the CLI's
-  next-step guidance aligned with the prompt-agent tutorial's standard
-  Foundry-native `eval.yaml` flow.
+- **`agentops eval init` now reuses configured prompt-agent inputs and avoids
+  hidden azd prompts.** When `--dataset` is omitted, the command passes the
+  existing `agentops.yaml` dataset to `azd ai agent eval init`. It also runs azd
+  with `--no-prompt`, passes the configured Foundry project endpoint, agent
+  name, prompt file, and bootstrap model, and prints a progress line before the
+  potentially long Foundry initialization.
+- **Prompt-agent tutorial guidance now keeps azd eval recipes advanced-only.**
+  Step 10 now follows `workflow analyze` for the quickstart's AgentOps cloud
+  eval path and explains that `agentops eval init` requires a full azd AI agent
+  project context before `azd ai agent eval run` can resolve the Foundry
+  project.
 - **`agentops eval init` now prints safely on Windows terminals without Unicode
   support.** The CLI falls back to an ASCII updated marker instead of raising a
   `UnicodeEncodeError` on cp1252 consoles after it wires `execution: azd` and

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -769,42 +769,34 @@ Recommendation
 
 This confirms the deployment side is configured correctly: the PR workflow
 turns changes in `prompt_file` into a reviewable prompt-agent candidate, and
-the deploy workflow records which candidate is now running in dev. Next,
-standardize the eval side on an azd recipe so the same Foundry-native eval
-definition is used locally and in CI.
+the deploy workflow records which candidate is now running in dev. For this
+quickstart, keep the eval runner on the AgentOps cloud path that
+`workflow analyze` reports. Foundry runs the evaluator server-side, while
+AgentOps owns the release gate: it normalizes the results into `results.json`,
+applies thresholds, runs Doctor, and writes release evidence.
 
-The **Next** section printed by `workflow analyze` is a generic handoff. If it
-still says to run `agentops eval run` first, do not jump there yet for this
-tutorial. First create and wire the azd eval recipe:
+Now follow the **Next** section from `workflow analyze`: set
+`AZURE_OPENAI_DEPLOYMENT` to the chat-capable deployment that should judge
+responses, then run `agentops eval run` in step 12 after the workflows are
+generated and the dev environment is ready.
 
-For this tutorial, use an azd eval recipe as the default Foundry-native eval
-handoff:
-
-```powershell
-agentops eval init
-```
-
-That command lets azd generate `eval.yaml`. AgentOps passes the dataset already
-configured in `agentops.yaml` to azd, so azd does not need to invent a new smoke
-dataset for this tutorial. The first run can still take a few minutes because
-Foundry creates the eval assets server-side before `eval.yaml` is written. Keep
-the recipe wired in `agentops.yaml`:
-
-```yaml
-execution: azd
-eval_recipe: eval.yaml
-thresholds:
-  booking_accuracy: ">=0.8"
-  avg_latency_seconds: "<=30"
-```
-
-In this mode, azd owns the actual Foundry eval run through
-`azd ai agent eval`. AgentOps owns the release gate around that run: it calls
-azd from the generated workflow, normalizes the emitted metrics into
-`results.json`, applies the thresholds, runs Doctor, and writes the release
-evidence. If a threshold references a metric that azd did not emit, AgentOps
-fails closed instead of silently passing. Rubric evaluator dimensions can be
-used as literal threshold names, such as `booking_accuracy`.
+> **Advanced azd eval recipe path.** Use `agentops eval init` only when your
+> workspace is already a full azd AI agent project with `azure.yaml` and azd
+> project context. In that project shape, azd can generate and run an
+> `eval.yaml` recipe, and AgentOps can wrap it with:
+>
+> ```yaml
+> execution: azd
+> eval_recipe: eval.yaml
+> thresholds:
+>   booking_accuracy: ">=0.8"
+>   avg_latency_seconds: "<=30"
+> ```
+>
+> Do not run `agentops eval init` in this quickstart workspace just to satisfy
+> step 10. Without a full azd project context, current `azd ai agent eval run`
+> cannot resolve the Foundry project even if AgentOps passes the project endpoint
+> during initialization.
 
 ## 11. Generate the PR + dev deploy workflows
 

--- a/src/agentops/services/azd_eval_init.py
+++ b/src/agentops/services/azd_eval_init.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from agentops.core.agentops_config import classify_agent
 from agentops.core.azd_eval import AzdEvalRecipeError, find_eval_yaml
 from agentops.pipeline.azd_runner import (
     AZD_EVAL_TIMEOUT_SECONDS,
@@ -69,6 +70,23 @@ def run_azd_eval_init(
         )
 
     command = ["azd", "--no-prompt", "ai", "agent", "eval", "init"]
+    project_endpoint = _project_endpoint_from_config_or_env(resolved_config)
+    if project_endpoint:
+        command.extend(["--project-endpoint", project_endpoint])
+    agent_name = _agent_name_from_config(resolved_config)
+    if agent_name:
+        command.extend(["--agent", agent_name])
+    instruction_file = _prompt_file_from_config(resolved_config)
+    if instruction_file is not None:
+        command.extend(
+            [
+                "--gen-instruction-file",
+                _command_path(instruction_file, workspace=root),
+            ]
+        )
+    eval_model = _eval_model_from_config(resolved_config)
+    if eval_model:
+        command.extend(["--eval-model", eval_model])
     effective_dataset = dataset or _dataset_from_config(resolved_config)
     if effective_dataset is not None:
         command.extend(
@@ -134,6 +152,78 @@ def _dataset_from_config(config_path: Path) -> Optional[Path]:
     if not dataset.exists():
         return None
     return dataset
+
+
+def _project_endpoint_from_config_or_env(config_path: Path) -> Optional[str]:
+    data = load_yaml(config_path)
+    raw_endpoint = data.get("project_endpoint")
+    if isinstance(raw_endpoint, str) and raw_endpoint.strip():
+        return raw_endpoint.strip()
+
+    try:
+        from agentops.utils.azd_env import discover_azd_env  # noqa: PLC0415
+        from agentops.utils.dotenv_loader import parse_env_file  # noqa: PLC0415
+
+        location = discover_azd_env(config_path.parent)
+        if location.found and location.env_path is not None:
+            endpoint = parse_env_file(location.env_path).get(
+                "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT"
+            )
+            if endpoint:
+                return endpoint
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        from agentops.utils.dotenv_loader import parse_env_file  # noqa: PLC0415
+
+        for path in (
+            config_path.parent / ".agentops" / ".env",
+            config_path.parent / ".env",
+        ):
+            endpoint = parse_env_file(path).get("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT")
+            if endpoint:
+                return endpoint
+    except Exception:  # noqa: BLE001
+        pass
+
+    return None
+
+
+def _agent_name_from_config(config_path: Path) -> Optional[str]:
+    data = load_yaml(config_path)
+    raw_agent = data.get("agent")
+    if not isinstance(raw_agent, str) or not raw_agent.strip():
+        return None
+    try:
+        parsed = classify_agent(raw_agent)
+    except ValueError:
+        return None
+    return parsed.name
+
+
+def _prompt_file_from_config(config_path: Path) -> Optional[Path]:
+    data = load_yaml(config_path)
+    raw_prompt_file = data.get("prompt_file")
+    if not raw_prompt_file:
+        return None
+    prompt_file = Path(str(raw_prompt_file))
+    if not prompt_file.is_absolute():
+        prompt_file = config_path.parent / prompt_file
+    if not prompt_file.exists():
+        return None
+    return prompt_file
+
+
+def _eval_model_from_config(config_path: Path) -> Optional[str]:
+    data = load_yaml(config_path)
+    raw_bootstrap = data.get("prompt_agent_bootstrap")
+    if not isinstance(raw_bootstrap, dict):
+        return None
+    raw_model = raw_bootstrap.get("model")
+    if isinstance(raw_model, str) and raw_model.strip():
+        return raw_model.strip()
+    return None
 
 
 def _persist_recipe(

--- a/src/agentops/services/workflow_analysis.py
+++ b/src/agentops/services/workflow_analysis.py
@@ -1137,13 +1137,7 @@ def _next_steps(
     ailz_preflight: bool,
 ) -> List[str]:
     eval_step = "Run `agentops eval run` locally and commit agentops.yaml plus datasets."
-    if mode == "prompt-agent" and eval_runner == AGENTOPS_CLOUD_RUNNER:
-        eval_step = (
-            "Run `agentops eval init` first if you want the Foundry-native azd "
-            "eval.yaml path; then run `agentops eval run` and commit agentops.yaml, "
-            "eval.yaml, and datasets."
-        )
-    elif eval_runner == AZD_EVAL_RUNNER:
+    if eval_runner == AZD_EVAL_RUNNER:
         eval_step = (
             "Run `agentops eval run` locally and commit agentops.yaml, eval.yaml, "
             "generated evaluator/rubric assets, and datasets."
@@ -1157,11 +1151,6 @@ def _next_steps(
             "Set AZURE_OPENAI_DEPLOYMENT so Foundry cloud eval can judge responses, "
             "then review AgentOps results.json/report.md after the run."
         )
-        if mode == "prompt-agent":
-            cloud_eval_step = (
-                "If you skip `agentops eval init` and stay on AgentOps cloud eval, "
-                "set AZURE_OPENAI_DEPLOYMENT so Foundry can judge responses."
-            )
         steps.insert(
             1,
             cloud_eval_step,

--- a/tests/unit/test_azd_eval_init.py
+++ b/tests/unit/test_azd_eval_init.py
@@ -22,6 +22,10 @@ def _write_config(path: Path) -> None:
 version: 1
 agent: travel-agent:1
 dataset: .agentops/data/smoke.jsonl
+project_endpoint: https://contoso.services.ai.azure.com/api/projects/travel
+prompt_file: .agentops/prompts/travel.md
+prompt_agent_bootstrap:
+  model: gpt-4o-mini
 """.lstrip(),
         encoding="utf-8",
     )
@@ -36,6 +40,9 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
     dataset = tmp_path / ".agentops" / "data" / "smoke.jsonl"
     dataset.parent.mkdir(parents=True)
     dataset.write_text('{"input":"hello"}\n', encoding="utf-8")
+    prompt_file = tmp_path / ".agentops" / "prompts" / "travel.md"
+    prompt_file.parent.mkdir(parents=True)
+    prompt_file.write_text("You are a travel planner.", encoding="utf-8")
 
     monkeypatch.setattr(azd_eval_init, "azd_available", lambda *, cwd=None: True)
 
@@ -47,6 +54,14 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
             "agent",
             "eval",
             "init",
+            "--project-endpoint",
+            "https://contoso.services.ai.azure.com/api/projects/travel",
+            "--agent",
+            "travel-agent",
+            "--gen-instruction-file",
+            str(Path(".agentops") / "prompts" / "travel.md"),
+            "--eval-model",
+            "gpt-4o-mini",
             "--dataset",
             str(Path(".agentops") / "data" / "smoke.jsonl"),
         ]
@@ -77,6 +92,9 @@ def test_run_azd_eval_init_explicit_dataset_wins(
     _write_config(config_path)
     dataset = tmp_path / "golden.jsonl"
     dataset.write_text('{"input":"hello"}\n', encoding="utf-8")
+    prompt_file = tmp_path / ".agentops" / "prompts" / "travel.md"
+    prompt_file.parent.mkdir(parents=True)
+    prompt_file.write_text("You are a travel planner.", encoding="utf-8")
 
     monkeypatch.setattr(azd_eval_init, "azd_available", lambda *, cwd=None: True)
 
@@ -88,6 +106,14 @@ def test_run_azd_eval_init_explicit_dataset_wins(
             "agent",
             "eval",
             "init",
+            "--project-endpoint",
+            "https://contoso.services.ai.azure.com/api/projects/travel",
+            "--agent",
+            "travel-agent",
+            "--gen-instruction-file",
+            str(Path(".agentops") / "prompts" / "travel.md"),
+            "--eval-model",
+            "gpt-4o-mini",
             "--dataset",
             "golden.jsonl",
         ]

--- a/tests/unit/test_workflow_analysis.py
+++ b/tests/unit/test_workflow_analysis.py
@@ -109,10 +109,10 @@ def test_analysis_recommends_cloud_eval_for_supported_prompt_agent(tmp_path: Pat
     assert "Copilot skills" in rendered
     assert "not needed - no Copilot handoff for this project shape" in rendered
     assert "Foundry eval" in rendered
-    assert "Run `agentops eval init` first" in rendered
-    assert "If you skip `agentops eval init`" in rendered
-    assert analysis.next_steps[0].startswith("Run `agentops eval init` first")
-    assert analysis.next_steps[1].startswith("If you skip `agentops eval init`")
+    assert "Run `agentops eval run` locally" in rendered
+    assert "Set AZURE_OPENAI_DEPLOYMENT" in rendered
+    assert analysis.next_steps[0].startswith("Run `agentops eval run` locally")
+    assert analysis.next_steps[1].startswith("Set AZURE_OPENAI_DEPLOYMENT")
     assert "- [x]" not in rendered
     assert "builtin." not in rendered
     assert "| Check" not in rendered


### PR DESCRIPTION
## Summary
- keep prompt quickstart on the AgentOps cloud eval path instead of requiring azd eval init
- clarify that azd eval recipes require a full azd AI agent project context
- pass configured prompt-agent inputs to azd eval init for projects that do use that advanced path

## Tests
- python -m pytest tests\\unit\\test_azd_eval_init.py tests\\unit\\test_workflow_analysis.py -q