### PR TITLE
fix: clean azd eval lint issues

### DIFF
--- a/src/agentops/core/azd_eval.py
+++ b/src/agentops/core/azd_eval.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, Sequence
+from typing import Any, Dict, Iterable, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 

--- a/src/agentops/pipeline/azd_runner.py
+++ b/src/agentops/pipeline/azd_runner.py
@@ -15,7 +15,6 @@ from agentops.core.azd_eval import (
     EvalRecipe,
     bind_threshold_metrics,
     find_eval_yaml,
-    load_eval_recipe,
 )
 from agentops.core.results import RunResult, RunSummary, TargetInfo
 from agentops.pipeline import thresholds

--- a/src/agentops/pipeline/orchestrator.py
+++ b/src/agentops/pipeline/orchestrator.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from agentops.core.agentops_config import AgentOpsConfig, Threshold, classify_agent
+from agentops.core.azd_eval import load_eval_recipe
 from agentops.core.evaluators import (
     detect_dataset_shape,
     merge_thresholds,
@@ -529,7 +530,7 @@ def _run_evaluation_azd(
     from agentops.pipeline import azd_runner
 
     recipe_path = azd_runner.resolve_eval_recipe(workspace, config)
-    recipe = azd_runner.load_eval_recipe(recipe_path)
+    recipe = load_eval_recipe(recipe_path)
     progress(
         f"execution: {style('azd', 'bold')} - delegating to "
         f"{style('azd ai agent eval', 'cyan')} with recipe "


### PR DESCRIPTION
## Summary
- remove unused azd eval imports flagged by release lint
- import eval recipe loading directly where the orchestrator uses it

## Tests
- uv run ruff check src/ tests/
- python -m pytest tests/ -x -q