### PR TITLE
fix: persist eval recipe paths portably

### DIFF
--- a/src/agentops/services/azd_eval_init.py
+++ b/src/agentops/services/azd_eval_init.py
@@ -256,9 +256,9 @@ def _persist_recipe(
 
 def _relative_config_path(path: Path, root: Path) -> str:
     try:
-        return str(path.resolve().relative_to(root.resolve()))
+        return path.resolve().relative_to(root.resolve()).as_posix()
     except ValueError:
-        return str(path.resolve())
+        return path.resolve().as_posix()
 
 
 def _command_path(path: Path, *, workspace: Path) -> str:

--- a/tests/unit/test_azd_eval_init.py
+++ b/tests/unit/test_azd_eval_init.py
@@ -80,7 +80,7 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
     assert result.command_ran is True
     assert result.config_updated is True
     updated = config_path.read_text(encoding="utf-8")
-    assert "eval_recipe: src\\travel-agent\\eval.yaml" in updated
+    assert "eval_recipe: src/travel-agent/eval.yaml" in updated
     assert "execution: azd" in updated
 
 


### PR DESCRIPTION
## Summary
- persist eval_recipe paths with POSIX separators so generated agentops.yaml is portable across Windows and Linux
- update eval init regression test accordingly

## Tests
- uv run ruff check src/ tests/
- python -m pytest tests/ -x -q