### PR TITLE
fix: make prompt tutorial use azd eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.10] - 2026-06-08
+
+### Fixed
+- **Prompt-agent tutorial now uses `azd ai agent eval` as the standard eval
+  path.** Step 10 creates the minimal azd service context, records Foundry
+  project metadata in the active `.azure/<env>/.env`, runs `agentops eval init`,
+  and verifies the native azd eval backend with `agentops eval run`.
+- **`agentops eval init` now prepares azd-compatible inputs for prompt-agent
+  datasets.** The wrapper writes an azd JSONL copy with `query` values derived
+  from AgentOps `input`, passes absolute paths for azd service-project
+  resolution, uses stable built-in evaluators by default, and decodes azd output
+  safely on Windows.
+- **AgentOps now normalizes the current azd preview eval output.** The azd
+  runner reads text run IDs, exports details with `azd ai agent eval show
+  --out-file`, and converts per-criteria pass counts into aggregate metrics for
+  the AgentOps threshold gate.
+
 ## [0.3.9] - 2026-06-08
 
 ### Added

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -769,34 +769,121 @@ Recommendation
 
 This confirms the deployment side is configured correctly: the PR workflow
 turns changes in `prompt_file` into a reviewable prompt-agent candidate, and
-the deploy workflow records which candidate is now running in dev. For this
-quickstart, keep the eval runner on the AgentOps cloud path that
-`workflow analyze` reports. Foundry runs the evaluator server-side, while
-AgentOps owns the release gate: it normalizes the results into `results.json`,
-applies thresholds, runs Doctor, and writes release evidence.
+the deploy workflow records which candidate is now running in dev. Next, add the
+minimal azd project context that `azd ai agent eval` needs. AgentOps will still
+own the release gate and evidence, but azd/Foundry will own the native eval run.
 
-Now follow the **Next** section from `workflow analyze`: set
-`AZURE_OPENAI_DEPLOYMENT` to the chat-capable deployment that should judge
-responses, then run `agentops eval run` in step 12 after the workflows are
-generated and the dev environment is ready.
+Create the azd service descriptor for this prompt agent:
 
-> **Advanced azd eval recipe path.** Use `agentops eval init` only when your
-> workspace is already a full azd AI agent project with `azure.yaml` and azd
-> project context. In that project shape, azd can generate and run an
-> `eval.yaml` recipe, and AgentOps can wrap it with:
->
-> ```yaml
-> execution: azd
-> eval_recipe: eval.yaml
-> thresholds:
->   booking_accuracy: ">=0.8"
->   avg_latency_seconds: "<=30"
-> ```
->
-> Do not run `agentops eval init` in this quickstart workspace just to satisfy
-> step 10. Without a full azd project context, current `azd ai agent eval run`
-> cannot resolve the Foundry project even if AgentOps passes the project endpoint
-> during initialization.
+```powershell
+New-Item -ItemType Directory -Force src\travel-agent | Out-Null
+@'
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+requiredVersions:
+  extensions:
+    azure.ai.agents: ">=0.1.38-preview"
+name: agentops-prompt-quickstart
+services:
+  travel-agent:
+    project: src/travel-agent
+    host: azure.ai.agent
+    language: none
+    config:
+      deployments:
+        - name: gpt-4o-mini
+          model:
+            format: OpenAI
+            name: gpt-4o-mini
+          sku:
+            name: GlobalStandard
+            capacity: 10
+'@ | Set-Content -Encoding utf8 azure.yaml
+
+@'
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/AgentSchema/refs/heads/main/schemas/v1.0/ContainerAgent.yaml
+
+kind: hosted
+name: travel-agent
+description: Helps plan short trips and explains tradeoffs.
+protocols:
+  - protocol: responses
+    version: 1.0.0
+environment_variables:
+  - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+    value: gpt-4o-mini
+'@ | Set-Content -Encoding utf8 src\travel-agent\agent.yaml
+```
+
+Make sure the active azd environment has the Foundry project metadata that azd
+uses to resolve the native eval resource. Replace the resource group and project
+names if you used a different suffix in step 3:
+
+```powershell
+$envName = "sandbox"
+$resourceGroup = "rg-agentops-travel-<your-alias>"
+$accountName = "foundry-agentops-travel-<your-alias>"
+$projectName = "travel-agent-sandbox"
+$projectEndpoint = "https://$accountName.services.ai.azure.com/api/projects/$projectName"
+$projectId = az resource show `
+  --resource-group $resourceGroup `
+  --resource-type Microsoft.CognitiveServices/accounts/projects `
+  --name "$accountName/$projectName" `
+  --query id -o tsv
+$subscriptionId = az account show --query id -o tsv
+
+$envFile = ".azure\$envName\.env"
+$updates = [ordered]@{
+  AZURE_AI_FOUNDRY_PROJECT_ENDPOINT = $projectEndpoint
+  FOUNDRY_PROJECT_ENDPOINT = $projectEndpoint
+  AZURE_AI_PROJECT_ID = $projectId
+  AZURE_AI_PROJECT_NAME = $projectName
+  AZURE_AI_ACCOUNT_NAME = $accountName
+  AZURE_RESOURCE_GROUP = $resourceGroup
+  AZURE_SUBSCRIPTION_ID = $subscriptionId
+  AZURE_LOCATION = "eastus2"
+  AZURE_AI_DEPLOYMENTS_LOCATION = "eastus2"
+  AZURE_OPENAI_ENDPOINT = "https://$accountName.openai.azure.com/"
+  AZURE_AI_MODEL_DEPLOYMENT_NAME = "gpt-4o-mini"
+  USE_EXISTING_AI_PROJECT = "true"
+}
+$content = if (Test-Path $envFile) { Get-Content $envFile } else { @() }
+foreach ($key in $updates.Keys) {
+  $line = "$key=`"$($updates[$key])`""
+  if ($content -match "^$key=") {
+    $content = $content | ForEach-Object { if ($_ -match "^$key=") { $line } else { $_ } }
+  } else {
+    $content += $line
+  }
+}
+Set-Content -Encoding utf8 $envFile $content
+```
+
+Now generate the azd eval recipe through AgentOps:
+
+```powershell
+agentops eval init --force
+```
+
+AgentOps passes the existing Travel dataset to azd after creating an azd-friendly
+copy with the `query` field that azd expects. It also pins stable built-in
+evaluators (`builtin.coherence`, `builtin.fluency`) and records the generated
+recipe in `agentops.yaml`:
+
+```yaml
+execution: azd
+eval_recipe: src/travel-agent/eval.yaml
+```
+
+Run the gate once locally:
+
+```powershell
+agentops eval run
+```
+
+You should see `execution: azd` and `Threshold status: PASSED`. The raw azd run
+details are kept under `.agentops/results/latest/` alongside AgentOps'
+normalized `results.json` and `report.md`.
 
 ## 11. Generate the PR + dev deploy workflows
 

--- a/src/agentops/pipeline/azd_runner.py
+++ b/src/agentops/pipeline/azd_runner.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
+import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -122,31 +124,39 @@ def run_azd_eval(
         raise AzdBackendError(_format_command_failure("azd ai agent eval run", completed))
 
     run_payload = _parse_json_object(completed.stdout)
-    run_id = _extract_run_id(run_payload)
+    run_id = _extract_run_id(run_payload) or _extract_labeled_id(completed.stdout, "Run")
+    eval_id = _extract_eval_id(run_payload) or _extract_labeled_id(completed.stdout, "Eval")
     show_payload: Dict[str, Any] = {}
     show_stdout = ""
     show_stderr = ""
-    if run_id:
-        show = _run_command(
-            [
-                "azd",
-                "ai",
-                "agent",
-                "eval",
-                "show",
-                "--eval-id",
-                run_id,
-                "--output",
-                "json",
-            ],
-            cwd=workspace,
-            timeout_seconds=timeout_seconds,
-        )
-        show_stdout = show.stdout
-        show_stderr = show.stderr
-        if show.returncode != 0:
-            raise AzdBackendError(_format_command_failure("azd ai agent eval show", show))
-        show_payload = _parse_json_object(show.stdout)
+    if run_id and eval_id:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            details_path = Path(temp_dir) / "azd-eval-run.json"
+            show = _run_command(
+                [
+                    "azd",
+                    "ai",
+                    "agent",
+                    "eval",
+                    "show",
+                    eval_id,
+                    "--eval-run-id",
+                    run_id,
+                    "--out-file",
+                    str(details_path),
+                ],
+                cwd=workspace,
+                timeout_seconds=timeout_seconds,
+            )
+            show_stdout = show.stdout
+            show_stderr = show.stderr
+            if show.returncode != 0:
+                raise AzdBackendError(_format_command_failure("azd ai agent eval show", show))
+            if details_path.exists():
+                show_stdout = "\n".join(
+                    part for part in (show_stdout, details_path.read_text(encoding="utf-8")) if part
+                )
+                show_payload = _parse_json_object(details_path.read_text(encoding="utf-8"))
 
     payload = show_payload or run_payload
     if not payload:
@@ -297,6 +307,8 @@ def _run_command(
             command,
             cwd=str(cwd),
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             timeout=timeout_seconds,
             check=False,
@@ -338,6 +350,19 @@ def _extract_run_id(payload: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _extract_eval_id(payload: Dict[str, Any]) -> Optional[str]:
+    for key in ("eval_id", "evalId"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _extract_labeled_id(text: str, label: str) -> Optional[str]:
+    match = re.search(rf"(?m)^\s*{re.escape(label)}:\s*(\S+)\s*$", text)
+    return match.group(1).strip() if match else None
+
+
 def _extract_status(payload: Dict[str, Any]) -> str:
     for key in ("status", "state", "result"):
         value = payload.get(key)
@@ -360,6 +385,24 @@ def _extract_item_count(payload: Dict[str, Any]) -> int:
 
 def _extract_numeric_metrics(payload: Dict[str, Any]) -> Dict[str, float]:
     metrics: Dict[str, float] = {}
+    criteria = payload.get("per_testing_criteria_results")
+    if isinstance(criteria, list):
+        for item in criteria:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("testing_criteria")
+            passed = item.get("passed")
+            failed = item.get("failed")
+            errored = item.get("errored")
+            if (
+                isinstance(name, str)
+                and isinstance(passed, int)
+                and isinstance(failed, int)
+                and isinstance(errored, int)
+            ):
+                total = passed + failed + errored
+                if total:
+                    metrics[name] = passed / total
     for key in ("metrics", "aggregate_metrics", "scores", "results", "evaluators", "dimensions"):
         value = payload.get(key)
         _collect_metrics(value, metrics)

--- a/src/agentops/services/azd_eval_init.py
+++ b/src/agentops/services/azd_eval_init.py
@@ -62,6 +62,14 @@ def run_azd_eval_init(
             command_ran=False,
         )
 
+    if not (root / "azure.yaml").exists():
+        raise AzdBackendError(
+            "`agentops eval init` requires a full azd AI agent project with "
+            "`azure.yaml`. This workspace can still use AgentOps cloud eval: "
+            "run `agentops workflow analyze --format text`, set "
+            "`AZURE_OPENAI_DEPLOYMENT`, then run `agentops eval run`."
+        )
+
     if not azd_available(cwd=root):
         raise AzdBackendError(
             "azd AI agent evaluation is not available. Install azd and the "

--- a/src/agentops/services/azd_eval_init.py
+++ b/src/agentops/services/azd_eval_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +17,28 @@ from agentops.pipeline.azd_runner import (
     azd_available,
 )
 from agentops.utils.yaml import load_yaml, save_yaml
+
+_DEFAULT_AZD_EVALUATORS = (
+    "builtin.coherence",
+    "builtin.fluency",
+)
+
+_EVALUATOR_NAME_TO_AZD = {
+    "CoherenceEvaluator": "builtin.coherence",
+    "FluencyEvaluator": "builtin.fluency",
+    "SimilarityEvaluator": "builtin.text_similarity",
+    "F1ScoreEvaluator": "builtin.f1_score",
+    "GroundednessEvaluator": "builtin.groundedness",
+    "RelevanceEvaluator": "builtin.relevance",
+    "RetrievalEvaluator": "builtin.retrieval",
+    "ResponseCompletenessEvaluator": "builtin.response_completeness",
+    "ToolCallAccuracyEvaluator": "builtin.tool_call_accuracy",
+    "IntentResolutionEvaluator": "builtin.intent_resolution",
+    "TaskAdherenceEvaluator": "builtin.task_adherence",
+    "ToolSelectionEvaluator": "builtin.tool_selection",
+    "ToolInputAccuracyEvaluator": "builtin.tool_input_accuracy",
+    "TaskCompletionEvaluator": "builtin.task_completion",
+}
 
 
 @dataclass(frozen=True)
@@ -65,9 +88,10 @@ def run_azd_eval_init(
     if not (root / "azure.yaml").exists():
         raise AzdBackendError(
             "`agentops eval init` requires a full azd AI agent project with "
-            "`azure.yaml`. This workspace can still use AgentOps cloud eval: "
-            "run `agentops workflow analyze --format text`, set "
-            "`AZURE_OPENAI_DEPLOYMENT`, then run `agentops eval run`."
+            "`azure.yaml`. Add the azd service descriptor and Foundry project "
+            "metadata from the prompt-agent tutorial step 10, or run "
+            "`azd ai agent init` for a hosted-agent project, then rerun "
+            "`agentops eval init`."
         )
 
     if not azd_available(cwd=root):
@@ -84,8 +108,9 @@ def run_azd_eval_init(
     agent_name = _agent_name_from_config(resolved_config)
     if agent_name:
         command.extend(["--agent", agent_name])
+    effective_dataset = dataset or _dataset_from_config(resolved_config)
     instruction_file = _prompt_file_from_config(resolved_config)
-    if instruction_file is not None:
+    if effective_dataset is None and instruction_file is not None:
         command.extend(
             [
                 "--gen-instruction-file",
@@ -95,17 +120,24 @@ def run_azd_eval_init(
     eval_model = _eval_model_from_config(resolved_config)
     if eval_model:
         command.extend(["--eval-model", eval_model])
-    effective_dataset = dataset or _dataset_from_config(resolved_config)
     if effective_dataset is not None:
+        effective_dataset = _azd_dataset_from_agentops_dataset(
+            effective_dataset,
+            workspace=root,
+        )
         command.extend(
             ["--dataset", _command_path(effective_dataset, workspace=root)]
         )
+        for evaluator in _azd_evaluators_from_config(resolved_config):
+            command.extend(["--evaluator", evaluator])
 
     try:
         completed = subprocess.run(
             command,
             cwd=str(root),
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             timeout=timeout_seconds,
             check=False,
@@ -234,6 +266,44 @@ def _eval_model_from_config(config_path: Path) -> Optional[str]:
     return None
 
 
+def _azd_evaluators_from_config(config_path: Path) -> tuple[str, ...]:
+    data = load_yaml(config_path)
+    raw_evaluators = data.get("evaluators")
+    names: list[str] = []
+    if isinstance(raw_evaluators, list):
+        for item in raw_evaluators:
+            raw_name = item.get("name") if isinstance(item, dict) else item
+            if not isinstance(raw_name, str) or not raw_name.strip():
+                continue
+            name = raw_name.strip()
+            mapped = name if name.startswith("builtin.") else _EVALUATOR_NAME_TO_AZD.get(name)
+            if mapped and mapped not in names:
+                names.append(mapped)
+    return tuple(names) if names else _DEFAULT_AZD_EVALUATORS
+
+
+def _azd_dataset_from_agentops_dataset(dataset: Path, *, workspace: Path) -> Path:
+    target_dir = workspace / ".agentops" / "azd"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / f"{dataset.stem}.azd.jsonl"
+
+    converted: list[str] = []
+    changed = False
+    for line in dataset.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if isinstance(row, dict) and "query" not in row and "input" in row:
+            row = {**row, "query": row["input"]}
+            changed = True
+        converted.append(json.dumps(row, ensure_ascii=False))
+
+    if changed:
+        target.write_text("\n".join(converted) + "\n", encoding="utf-8")
+        return target
+    return dataset
+
+
 def _persist_recipe(
     *,
     config_path: Path,
@@ -270,7 +340,4 @@ def _relative_config_path(path: Path, root: Path) -> str:
 
 
 def _command_path(path: Path, *, workspace: Path) -> str:
-    try:
-        return str(path.resolve().relative_to(workspace.resolve()))
-    except ValueError:
-        return str(path.resolve())
+    return str(path.resolve())

--- a/tests/unit/test_azd_eval_init.py
+++ b/tests/unit/test_azd_eval_init.py
@@ -47,7 +47,9 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
 
     monkeypatch.setattr(azd_eval_init, "azd_available", lambda *, cwd=None: True)
 
-    def fake_run(command, *, cwd, text, capture_output, timeout, check):
+    def fake_run(command, *, cwd, text, encoding, errors, capture_output, timeout, check):
+        assert encoding == "utf-8"
+        assert errors == "replace"
         assert command == [
             "azd",
             "--no-prompt",
@@ -59,12 +61,14 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
             "https://contoso.services.ai.azure.com/api/projects/travel",
             "--agent",
             "travel-agent",
-            "--gen-instruction-file",
-            str(Path(".agentops") / "prompts" / "travel.md"),
             "--eval-model",
             "gpt-4o-mini",
             "--dataset",
-            str(Path(".agentops") / "data" / "smoke.jsonl"),
+            str((tmp_path / ".agentops" / "azd" / "smoke.azd.jsonl").resolve()),
+            "--evaluator",
+            "builtin.coherence",
+            "--evaluator",
+            "builtin.fluency",
         ]
         recipe = Path(cwd) / "src" / "travel-agent" / "eval.yaml"
         recipe.parent.mkdir(parents=True, exist_ok=True)
@@ -80,6 +84,8 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
 
     assert result.command_ran is True
     assert result.config_updated is True
+    converted = tmp_path / ".agentops" / "azd" / "smoke.azd.jsonl"
+    assert '"query": "hello"' in converted.read_text(encoding="utf-8")
     updated = config_path.read_text(encoding="utf-8")
     assert "eval_recipe: src/travel-agent/eval.yaml" in updated
     assert "execution: azd" in updated
@@ -100,7 +106,9 @@ def test_run_azd_eval_init_explicit_dataset_wins(
 
     monkeypatch.setattr(azd_eval_init, "azd_available", lambda *, cwd=None: True)
 
-    def fake_run(command, *, cwd, text, capture_output, timeout, check):
+    def fake_run(command, *, cwd, text, encoding, errors, capture_output, timeout, check):
+        assert encoding == "utf-8"
+        assert errors == "replace"
         assert command == [
             "azd",
             "--no-prompt",
@@ -112,12 +120,14 @@ def test_run_azd_eval_init_explicit_dataset_wins(
             "https://contoso.services.ai.azure.com/api/projects/travel",
             "--agent",
             "travel-agent",
-            "--gen-instruction-file",
-            str(Path(".agentops") / "prompts" / "travel.md"),
             "--eval-model",
             "gpt-4o-mini",
             "--dataset",
-            "golden.jsonl",
+            str((tmp_path / ".agentops" / "azd" / "golden.azd.jsonl").resolve()),
+            "--evaluator",
+            "builtin.coherence",
+            "--evaluator",
+            "builtin.fluency",
         ]
         recipe = Path(cwd) / "eval.yaml"
         recipe.write_text("name: travel-agent-eval\n", encoding="utf-8")
@@ -150,7 +160,7 @@ def test_run_azd_eval_init_requires_azd_project_when_generating_recipe(
         )
     except azd_eval_init.AzdBackendError as exc:
         assert "requires a full azd AI agent project" in str(exc)
-        assert "agentops eval run" in str(exc)
+        assert "prompt-agent tutorial step 10" in str(exc)
     else:  # pragma: no cover - assertion helper
         raise AssertionError("expected AzdBackendError")
 

--- a/tests/unit/test_azd_eval_init.py
+++ b/tests/unit/test_azd_eval_init.py
@@ -37,6 +37,7 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
 ) -> None:
     config_path = tmp_path / "agentops.yaml"
     _write_config(config_path)
+    (tmp_path / "azure.yaml").write_text("name: travel-agent\n", encoding="utf-8")
     dataset = tmp_path / ".agentops" / "data" / "smoke.jsonl"
     dataset.parent.mkdir(parents=True)
     dataset.write_text('{"input":"hello"}\n', encoding="utf-8")
@@ -90,6 +91,7 @@ def test_run_azd_eval_init_explicit_dataset_wins(
 ) -> None:
     config_path = tmp_path / "agentops.yaml"
     _write_config(config_path)
+    (tmp_path / "azure.yaml").write_text("name: travel-agent\n", encoding="utf-8")
     dataset = tmp_path / "golden.jsonl"
     dataset.write_text('{"input":"hello"}\n', encoding="utf-8")
     prompt_file = tmp_path / ".agentops" / "prompts" / "travel.md"
@@ -130,6 +132,29 @@ def test_run_azd_eval_init_explicit_dataset_wins(
     )
 
     assert result.command_ran is True
+
+
+def test_run_azd_eval_init_requires_azd_project_when_generating_recipe(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "agentops.yaml"
+    _write_config(config_path)
+    run_mock = mock.Mock()
+    monkeypatch.setattr(subprocess, "run", run_mock)
+
+    try:
+        azd_eval_init.run_azd_eval_init(
+            workspace=tmp_path,
+            config_path=config_path,
+        )
+    except azd_eval_init.AzdBackendError as exc:
+        assert "requires a full azd AI agent project" in str(exc)
+        assert "agentops eval run" in str(exc)
+    else:  # pragma: no cover - assertion helper
+        raise AssertionError("expected AzdBackendError")
+
+    run_mock.assert_not_called()
 
 
 def test_run_azd_eval_init_reuses_existing_recipe_without_running_azd(

--- a/tests/unit/test_azd_runner.py
+++ b/tests/unit/test_azd_runner.py
@@ -44,6 +44,63 @@ evaluators:
     )
 
 
+def test_run_azd_eval_reads_show_out_file_when_run_outputs_text(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    recipe_path = tmp_path / "eval.yaml"
+    _write_recipe(recipe_path)
+    calls: list[list[str]] = []
+
+    def fake_run(command, *, cwd, text, encoding, errors, capture_output, timeout, check):
+        calls.append(command)
+        assert encoding == "utf-8"
+        assert errors == "replace"
+        if command[:5] == ["azd", "ai", "agent", "eval", "run"]:
+            return mock.Mock(
+                returncode=0,
+                stdout=(
+                    "Eval:       eval_123\n"
+                    "Run:        evalrun_456\n"
+                    "Status:     Completed\n"
+                ),
+                stderr="",
+            )
+        if command[:5] == ["azd", "ai", "agent", "eval", "show"]:
+            out_file = Path(command[command.index("--out-file") + 1])
+            out_file.write_text(
+                json.dumps(
+                    {
+                        "id": "evalrun_456",
+                        "eval_id": "eval_123",
+                        "status": "completed",
+                        "result_counts": {"total": 3},
+                        "per_testing_criteria_results": [
+                            {
+                                "testing_criteria": "coherence",
+                                "passed": 3,
+                                "failed": 0,
+                                "errored": 0,
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return mock.Mock(returncode=0, stdout="exported", stderr="")
+        raise AssertionError(command)
+
+    monkeypatch.setattr(azd_runner.subprocess, "run", fake_run)
+    monkeypatch.setattr(azd_runner, "azd_available", lambda *, cwd=None: True)
+
+    result = azd_runner.run_azd_eval(recipe_path, workspace=tmp_path)
+
+    assert result.run_id == "evalrun_456"
+    assert result.payload["eval_id"] == "eval_123"
+    assert azd_runner._extract_numeric_metrics(result.payload) == {"coherence": 1.0}
+    assert calls[1][:6] == ["azd", "ai", "agent", "eval", "show", "eval_123"]
+
+
 def test_normalize_to_results_binds_azd_metrics_and_thresholds(tmp_path: Path) -> None:
     recipe_path = tmp_path / "eval.yaml"
     _write_recipe(recipe_path)


### PR DESCRIPTION
## Summary
- make prompt quickstart step 10 use azd ai agent eval as the standard path
- add azd eval init safeguards and azd-friendly dataset conversion
- normalize current azd preview text/show --out-file output into AgentOps results

## Tests
- uv run ruff check src/ tests/
- python -m pytest tests/ -x -q
- agentops eval init --force in tutorial workspace
- agentops eval run in tutorial workspace