### PR TITLE
fix: bootstrap azd eval init context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.11] - 2026-06-08
+
+### Fixed
+- **`agentops eval init` now bootstraps the minimal azd prompt-agent context.**
+  For Foundry prompt-agent configs, the command creates missing `azure.yaml` and
+  `src/<agent>/agent.yaml` files, enriches the active `.azure/<env>/.env` with
+  Foundry project metadata when it can resolve the project resource, and then
+  generates the azd eval recipe. The prompt-agent quickstart now keeps the main
+  path to `agentops eval init` followed by `agentops eval run`, while still using
+  `azd ai agent eval` under the hood.
+
 ## [0.3.10] - 2026-06-08
 
 ### Fixed

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -755,9 +755,9 @@ project:
 agentops workflow analyze --format text
 ```
 
-For `agent: name:version` plus `prompt_file`, AgentOps should at least detect
-the prompt-agent deploy mode. Before you wire the azd recipe below, the eval
-recommendation may still show AgentOps cloud eval in Foundry:
+For `agent: name:version` plus `prompt_file`, AgentOps should detect the
+prompt-agent deploy mode. Before you initialize the azd eval recipe below, the
+eval recommendation may still show AgentOps cloud eval in Foundry:
 
 ```text
 Recommendation
@@ -769,111 +769,29 @@ Recommendation
 
 This confirms the deployment side is configured correctly: the PR workflow
 turns changes in `prompt_file` into a reviewable prompt-agent candidate, and
-the deploy workflow records which candidate is now running in dev. Next, add the
-minimal azd project context that `azd ai agent eval` needs. AgentOps will still
-own the release gate and evidence, but azd/Foundry will own the native eval run.
-
-Create the azd service descriptor for this prompt agent:
+the deploy workflow records which candidate is now running in dev. Next, let
+AgentOps initialize the native azd eval recipe:
 
 ```powershell
-New-Item -ItemType Directory -Force src\travel-agent | Out-Null
-@'
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
-
-requiredVersions:
-  extensions:
-    azure.ai.agents: ">=0.1.38-preview"
-name: agentops-prompt-quickstart
-services:
-  travel-agent:
-    project: src/travel-agent
-    host: azure.ai.agent
-    language: none
-    config:
-      deployments:
-        - name: gpt-4o-mini
-          model:
-            format: OpenAI
-            name: gpt-4o-mini
-          sku:
-            name: GlobalStandard
-            capacity: 10
-'@ | Set-Content -Encoding utf8 azure.yaml
-
-@'
-# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/AgentSchema/refs/heads/main/schemas/v1.0/ContainerAgent.yaml
-
-kind: hosted
-name: travel-agent
-description: Helps plan short trips and explains tradeoffs.
-protocols:
-  - protocol: responses
-    version: 1.0.0
-environment_variables:
-  - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
-    value: gpt-4o-mini
-'@ | Set-Content -Encoding utf8 src\travel-agent\agent.yaml
+agentops eval init
 ```
 
-Make sure the active azd environment has the Foundry project metadata that azd
-uses to resolve the native eval resource. Replace the resource group and project
-names if you used a different suffix in step 3:
-
-```powershell
-$envName = "sandbox"
-$resourceGroup = "rg-agentops-travel-<your-alias>"
-$accountName = "foundry-agentops-travel-<your-alias>"
-$projectName = "travel-agent-sandbox"
-$projectEndpoint = "https://$accountName.services.ai.azure.com/api/projects/$projectName"
-$projectId = az resource show `
-  --resource-group $resourceGroup `
-  --resource-type Microsoft.CognitiveServices/accounts/projects `
-  --name "$accountName/$projectName" `
-  --query id -o tsv
-$subscriptionId = az account show --query id -o tsv
-
-$envFile = ".azure\$envName\.env"
-$updates = [ordered]@{
-  AZURE_AI_FOUNDRY_PROJECT_ENDPOINT = $projectEndpoint
-  FOUNDRY_PROJECT_ENDPOINT = $projectEndpoint
-  AZURE_AI_PROJECT_ID = $projectId
-  AZURE_AI_PROJECT_NAME = $projectName
-  AZURE_AI_ACCOUNT_NAME = $accountName
-  AZURE_RESOURCE_GROUP = $resourceGroup
-  AZURE_SUBSCRIPTION_ID = $subscriptionId
-  AZURE_LOCATION = "eastus2"
-  AZURE_AI_DEPLOYMENTS_LOCATION = "eastus2"
-  AZURE_OPENAI_ENDPOINT = "https://$accountName.openai.azure.com/"
-  AZURE_AI_MODEL_DEPLOYMENT_NAME = "gpt-4o-mini"
-  USE_EXISTING_AI_PROJECT = "true"
-}
-$content = if (Test-Path $envFile) { Get-Content $envFile } else { @() }
-foreach ($key in $updates.Keys) {
-  $line = "$key=`"$($updates[$key])`""
-  if ($content -match "^$key=") {
-    $content = $content | ForEach-Object { if ($_ -match "^$key=") { $line } else { $_ } }
-  } else {
-    $content += $line
-  }
-}
-Set-Content -Encoding utf8 $envFile $content
-```
-
-Now generate the azd eval recipe through AgentOps:
-
-```powershell
-agentops eval init --force
-```
-
-AgentOps passes the existing Travel dataset to azd after creating an azd-friendly
-copy with the `query` field that azd expects. It also pins stable built-in
-evaluators (`builtin.coherence`, `builtin.fluency`) and records the generated
-recipe in `agentops.yaml`:
+AgentOps prepares the small amount of azd context that
+`azd ai agent eval` needs: it creates `azure.yaml` and
+`src/travel-agent/agent.yaml` if they are missing, enriches the active
+`.azure/sandbox/.env` with the Foundry project metadata azd expects, and writes
+an azd-friendly dataset copy with the `query` field derived from your
+AgentOps `input` values. It then asks azd to generate the eval recipe and records
+that recipe in `agentops.yaml`:
 
 ```yaml
 execution: azd
 eval_recipe: src/travel-agent/eval.yaml
 ```
+
+Use `agentops eval init --force` only when you intentionally want to regenerate
+and replace an existing `eval.yaml`. For the normal quickstart flow, run it
+without `--force`.
 
 Run the gate once locally:
 

--- a/src/agentops/services/azd_eval_init.py
+++ b/src/agentops/services/azd_eval_init.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from agentops.core.agentops_config import classify_agent
 from agentops.core.azd_eval import AzdEvalRecipeError, find_eval_yaml
@@ -85,14 +86,7 @@ def run_azd_eval_init(
             command_ran=False,
         )
 
-    if not (root / "azure.yaml").exists():
-        raise AzdBackendError(
-            "`agentops eval init` requires a full azd AI agent project with "
-            "`azure.yaml`. Add the azd service descriptor and Foundry project "
-            "metadata from the prompt-agent tutorial step 10, or run "
-            "`azd ai agent init` for a hosted-agent project, then rerun "
-            "`agentops eval init`."
-        )
+    _ensure_prompt_agent_azd_context(root, resolved_config)
 
     if not azd_available(cwd=root):
         raise AzdBackendError(
@@ -227,6 +221,211 @@ def _project_endpoint_from_config_or_env(config_path: Path) -> Optional[str]:
     except Exception:  # noqa: BLE001
         pass
 
+    return None
+
+
+def _ensure_prompt_agent_azd_context(workspace: Path, config_path: Path) -> None:
+    data = load_yaml(config_path)
+    raw_agent = data.get("agent")
+    if not isinstance(raw_agent, str) or not raw_agent.strip():
+        return
+    try:
+        target = classify_agent(raw_agent)
+    except ValueError:
+        return
+    if target.kind != "foundry_prompt" or not target.name:
+        return
+
+    model = _eval_model_from_config(config_path) or "gpt-4o-mini"
+    description = _agent_description_from_config(config_path)
+    service_dir = workspace / "src" / target.name
+    azure_yaml = workspace / "azure.yaml"
+    agent_yaml = service_dir / "agent.yaml"
+
+    if not azure_yaml.exists():
+        azure_yaml.write_text(
+            _minimal_azure_yaml(
+                project_name=workspace.name,
+                service_name=target.name,
+                model=model,
+            ),
+            encoding="utf-8",
+        )
+    if not agent_yaml.exists():
+        service_dir.mkdir(parents=True, exist_ok=True)
+        agent_yaml.write_text(
+            _minimal_agent_yaml(
+                agent_name=target.name,
+                description=description,
+                model=model,
+            ),
+            encoding="utf-8",
+        )
+
+    _ensure_azd_project_env_metadata(workspace, config_path, model=model)
+
+
+def _agent_description_from_config(config_path: Path) -> str:
+    data = load_yaml(config_path)
+    raw_bootstrap = data.get("prompt_agent_bootstrap")
+    if isinstance(raw_bootstrap, dict):
+        raw_description = raw_bootstrap.get("description")
+        if isinstance(raw_description, str) and raw_description.strip():
+            return raw_description.strip()
+    return "Foundry prompt agent evaluated by AgentOps."
+
+
+def _minimal_azure_yaml(*, project_name: str, service_name: str, model: str) -> str:
+    return f"""# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+requiredVersions:
+  extensions:
+    azure.ai.agents: ">=0.1.38-preview"
+name: {project_name}
+services:
+  {service_name}:
+    project: src/{service_name}
+    host: azure.ai.agent
+    language: none
+    config:
+      deployments:
+        - name: {model}
+          model:
+            format: OpenAI
+            name: {model}
+          sku:
+            name: GlobalStandard
+            capacity: 10
+"""
+
+
+def _minimal_agent_yaml(*, agent_name: str, description: str, model: str) -> str:
+    return f"""# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/AgentSchema/refs/heads/main/schemas/v1.0/ContainerAgent.yaml
+
+kind: hosted
+name: {agent_name}
+description: {description}
+protocols:
+  - protocol: responses
+    version: 1.0.0
+environment_variables:
+  - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+    value: {model}
+"""
+
+
+def _ensure_azd_project_env_metadata(
+    workspace: Path,
+    config_path: Path,
+    *,
+    model: str,
+) -> None:
+    endpoint = _project_endpoint_from_config_or_env(config_path)
+    if not endpoint:
+        return
+    parsed = _parse_project_endpoint(endpoint)
+    if parsed is None:
+        return
+
+    from agentops.utils.azd_env import (  # noqa: PLC0415
+        discover_azd_env,
+        ensure_azd_env,
+        set_env_values,
+    )
+
+    location = discover_azd_env(workspace)
+    if not location.found or location.env_path is None:
+        location = ensure_azd_env(workspace, "sandbox")
+    env_path = location.env_path
+    updates = {
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT": endpoint,
+        "FOUNDRY_PROJECT_ENDPOINT": endpoint,
+        "AZURE_AI_PROJECT_NAME": parsed["project_name"],
+        "AZURE_AI_ACCOUNT_NAME": parsed["account_name"],
+        "AZURE_AI_MODEL_DEPLOYMENT_NAME": model,
+        "USE_EXISTING_AI_PROJECT": "true",
+    }
+
+    resource = _resolve_project_resource(parsed)
+    if resource:
+        updates.update(resource)
+    set_env_values(env_path, updates)
+
+
+def _parse_project_endpoint(endpoint: str) -> Optional[dict[str, str]]:
+    match = re.match(
+        r"^https://(?P<account>[^./]+)\.services\.ai\.azure\.com/api/projects/(?P<project>[^/?#]+)",
+        endpoint.rstrip("/"),
+    )
+    if not match:
+        return None
+    return {
+        "account_name": match.group("account"),
+        "project_name": match.group("project"),
+    }
+
+
+def _resolve_project_resource(parsed: dict[str, str]) -> dict[str, str]:
+    try:
+        listed = subprocess.run(
+            [
+                "az",
+                "resource",
+                "list",
+                "--resource-type",
+                "Microsoft.CognitiveServices/accounts/projects",
+                "--query",
+                (
+                    "[?name=='"
+                    f"{parsed['account_name']}/{parsed['project_name']}"
+                    "'].{id:id,resourceGroup:resourceGroup,location:location}"
+                ),
+                "-o",
+                "json",
+            ],
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return {}
+    if listed.returncode != 0:
+        return {}
+    try:
+        payload: Any = json.loads(listed.stdout)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(payload, list) or not payload or not isinstance(payload[0], dict):
+        return {}
+    item = payload[0]
+    project_id = item.get("id")
+    resource_group = item.get("resourceGroup")
+    location = item.get("location")
+    if not isinstance(project_id, str) or not isinstance(resource_group, str):
+        return {}
+
+    subscription_id = _subscription_id_from_resource_id(project_id)
+    updates = {
+        "AZURE_AI_PROJECT_ID": project_id,
+        "AZURE_RESOURCE_GROUP": resource_group,
+        "AZURE_OPENAI_ENDPOINT": f"https://{parsed['account_name']}.openai.azure.com/",
+    }
+    if isinstance(location, str) and location:
+        updates["AZURE_LOCATION"] = location
+        updates["AZURE_AI_DEPLOYMENTS_LOCATION"] = location
+    if subscription_id:
+        updates["AZURE_SUBSCRIPTION_ID"] = subscription_id
+    return updates
+
+
+def _subscription_id_from_resource_id(resource_id: str) -> Optional[str]:
+    parts = resource_id.strip("/").split("/")
+    for index, part in enumerate(parts):
+        if part.lower() == "subscriptions" and index + 1 < len(parts):
+            return parts[index + 1]
     return None
 
 

--- a/tests/unit/test_azd_eval_init.py
+++ b/tests/unit/test_azd_eval_init.py
@@ -26,6 +26,7 @@ project_endpoint: https://contoso.services.ai.azure.com/api/projects/travel
 prompt_file: .agentops/prompts/travel.md
 prompt_agent_bootstrap:
   model: gpt-4o-mini
+  description: Helps plan short trips and explains tradeoffs.
 """.lstrip(),
         encoding="utf-8",
     )
@@ -37,7 +38,6 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
 ) -> None:
     config_path = tmp_path / "agentops.yaml"
     _write_config(config_path)
-    (tmp_path / "azure.yaml").write_text("name: travel-agent\n", encoding="utf-8")
     dataset = tmp_path / ".agentops" / "data" / "smoke.jsonl"
     dataset.parent.mkdir(parents=True)
     dataset.write_text('{"input":"hello"}\n', encoding="utf-8")
@@ -47,9 +47,20 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
 
     monkeypatch.setattr(azd_eval_init, "azd_available", lambda *, cwd=None: True)
 
-    def fake_run(command, *, cwd, text, encoding, errors, capture_output, timeout, check):
-        assert encoding == "utf-8"
-        assert errors == "replace"
+    def fake_run(command, **kwargs):
+        if command[:3] == ["az", "resource", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    '[{"id":"/subscriptions/sub-1/resourceGroups/rg-test/'
+                    'providers/Microsoft.CognitiveServices/accounts/contoso/'
+                    'projects/travel","resourceGroup":"rg-test","location":"eastus2"}]'
+                ),
+                stderr="",
+            )
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
         assert command == [
             "azd",
             "--no-prompt",
@@ -70,7 +81,7 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
             "--evaluator",
             "builtin.fluency",
         ]
-        recipe = Path(cwd) / "src" / "travel-agent" / "eval.yaml"
+        recipe = Path(kwargs["cwd"]) / "src" / "travel-agent" / "eval.yaml"
         recipe.parent.mkdir(parents=True, exist_ok=True)
         recipe.write_text("name: travel-agent-eval\n", encoding="utf-8")
         return subprocess.CompletedProcess(command, 0, stdout="created", stderr="")
@@ -86,6 +97,13 @@ def test_run_azd_eval_init_delegates_to_azd_and_persists_recipe(
     assert result.config_updated is True
     converted = tmp_path / ".agentops" / "azd" / "smoke.azd.jsonl"
     assert '"query": "hello"' in converted.read_text(encoding="utf-8")
+    assert (tmp_path / "azure.yaml").exists()
+    agent_yaml = tmp_path / "src" / "travel-agent" / "agent.yaml"
+    assert "Helps plan short trips" in agent_yaml.read_text(encoding="utf-8")
+    env_text = (tmp_path / ".azure" / "sandbox" / ".env").read_text(encoding="utf-8")
+    assert "AZURE_AI_PROJECT_ID=" in env_text
+    assert "AZURE_RESOURCE_GROUP=rg-test" in env_text
+    assert "FOUNDRY_PROJECT_ENDPOINT=" in env_text
     updated = config_path.read_text(encoding="utf-8")
     assert "eval_recipe: src/travel-agent/eval.yaml" in updated
     assert "execution: azd" in updated
@@ -106,9 +124,9 @@ def test_run_azd_eval_init_explicit_dataset_wins(
 
     monkeypatch.setattr(azd_eval_init, "azd_available", lambda *, cwd=None: True)
 
-    def fake_run(command, *, cwd, text, encoding, errors, capture_output, timeout, check):
-        assert encoding == "utf-8"
-        assert errors == "replace"
+    def fake_run(command, **kwargs):
+        if command[:3] == ["az", "resource", "list"]:
+            return subprocess.CompletedProcess(command, 0, stdout="[]", stderr="")
         assert command == [
             "azd",
             "--no-prompt",
@@ -129,7 +147,7 @@ def test_run_azd_eval_init_explicit_dataset_wins(
             "--evaluator",
             "builtin.fluency",
         ]
-        recipe = Path(cwd) / "eval.yaml"
+        recipe = Path(kwargs["cwd"]) / "eval.yaml"
         recipe.write_text("name: travel-agent-eval\n", encoding="utf-8")
         return subprocess.CompletedProcess(command, 0, stdout="created", stderr="")
 
@@ -144,27 +162,67 @@ def test_run_azd_eval_init_explicit_dataset_wins(
     assert result.command_ran is True
 
 
-def test_run_azd_eval_init_requires_azd_project_when_generating_recipe(
+def test_run_azd_eval_init_bootstraps_before_azd_availability_check(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     config_path = tmp_path / "agentops.yaml"
     _write_config(config_path)
-    run_mock = mock.Mock()
-    monkeypatch.setattr(subprocess, "run", run_mock)
+    dataset = tmp_path / ".agentops" / "data" / "smoke.jsonl"
+    dataset.parent.mkdir(parents=True)
+    dataset.write_text('{"input":"hello"}\n', encoding="utf-8")
+    monkeypatch.setattr(azd_eval_init, "azd_available", lambda *, cwd=None: False)
 
-    try:
-        azd_eval_init.run_azd_eval_init(
-            workspace=tmp_path,
-            config_path=config_path,
-        )
-    except azd_eval_init.AzdBackendError as exc:
-        assert "requires a full azd AI agent project" in str(exc)
-        assert "prompt-agent tutorial step 10" in str(exc)
-    else:  # pragma: no cover - assertion helper
-        raise AssertionError("expected AzdBackendError")
+    with mock.patch.object(subprocess, "run") as run_mock:
+        run_mock.return_value = subprocess.CompletedProcess([], 0, stdout="[]", stderr="")
+        try:
+            azd_eval_init.run_azd_eval_init(
+                workspace=tmp_path,
+                config_path=config_path,
+            )
+        except azd_eval_init.AzdBackendError as exc:
+            assert "azd AI agent evaluation is not available" in str(exc)
+        else:  # pragma: no cover - assertion helper
+            raise AssertionError("expected AzdBackendError")
 
-    run_mock.assert_not_called()
+    assert (tmp_path / "azure.yaml").exists()
+    assert (tmp_path / "src" / "travel-agent" / "agent.yaml").exists()
+
+
+def test_run_azd_eval_init_bootstraps_without_project_endpoint(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "agentops.yaml"
+    config_path.write_text(
+        """
+version: 1
+agent: travel-agent:1
+dataset: .agentops/data/smoke.jsonl
+prompt_agent_bootstrap:
+  model: gpt-4o-mini
+""".lstrip(),
+        encoding="utf-8",
+    )
+    dataset = tmp_path / ".agentops" / "data" / "smoke.jsonl"
+    dataset.parent.mkdir(parents=True)
+    dataset.write_text('{"input":"hello"}\n', encoding="utf-8")
+    monkeypatch.setattr(azd_eval_init, "azd_available", lambda *, cwd=None: True)
+
+    def fake_run(command, **kwargs):
+        assert "--project-endpoint" not in command
+        recipe = Path(kwargs["cwd"]) / "eval.yaml"
+        recipe.write_text("name: travel-agent-eval\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="created", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = azd_eval_init.run_azd_eval_init(
+        workspace=tmp_path,
+        config_path=config_path,
+    )
+
+    assert result.command_ran is True
 
 
 def test_run_azd_eval_init_reuses_existing_recipe_without_running_azd(

--- a/uv.lock
+++ b/uv.lock
@@ -54,31 +54,31 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "azure-ai-evaluation", marker = "extra == 'foundry'", specifier = ">=1.0" },
-    { name = "azure-ai-projects", specifier = ">=2.0.1" },
-    { name = "azure-identity", marker = "extra == 'agent'", specifier = ">=1.17" },
-    { name = "azure-identity", marker = "extra == 'foundry'", specifier = ">=1.17" },
-    { name = "azure-mgmt-cognitiveservices", marker = "extra == 'agent'", specifier = ">=13.5" },
-    { name = "azure-mgmt-monitor", marker = "extra == 'agent'", specifier = ">=6.0" },
-    { name = "azure-monitor-opentelemetry", marker = "extra == 'agent'", specifier = ">=1.6" },
-    { name = "azure-monitor-opentelemetry", marker = "extra == 'foundry'", specifier = ">=1.6" },
-    { name = "azure-monitor-query", marker = "extra == 'agent'", specifier = ">=1.3" },
+    { name = "azure-ai-evaluation", marker = "extra == 'foundry'", specifier = ">=1.0,<2.0" },
+    { name = "azure-ai-projects", specifier = ">=2.0.1,<3.0" },
+    { name = "azure-identity", marker = "extra == 'agent'", specifier = ">=1.17,<2.0" },
+    { name = "azure-identity", marker = "extra == 'foundry'", specifier = ">=1.17,<2.0" },
+    { name = "azure-mgmt-cognitiveservices", marker = "extra == 'agent'", specifier = ">=13.5,<14.0" },
+    { name = "azure-mgmt-monitor", marker = "extra == 'agent'", specifier = ">=6.0,<7.0" },
+    { name = "azure-monitor-opentelemetry", marker = "extra == 'agent'", specifier = ">=1.6,<2.0" },
+    { name = "azure-monitor-opentelemetry", marker = "extra == 'foundry'", specifier = ">=1.6,<2.0" },
+    { name = "azure-monitor-query", marker = "extra == 'agent'", specifier = ">=1.3,<2.0" },
     { name = "cryptography", marker = "extra == 'agent'", specifier = ">=42" },
-    { name = "fastapi", marker = "extra == 'agent'", specifier = ">=0.110" },
-    { name = "httpx", marker = "extra == 'agent'", specifier = ">=0.27" },
-    { name = "markdown", marker = "extra == 'agent'", specifier = ">=3.6" },
+    { name = "fastapi", marker = "extra == 'agent'", specifier = ">=0.110,<1.0" },
+    { name = "httpx", marker = "extra == 'agent'", specifier = ">=0.27,<1.0" },
+    { name = "markdown", marker = "extra == 'agent'", specifier = ">=3.6,<4.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0,<2" },
-    { name = "pandas", marker = "extra == 'foundry'", specifier = ">=2.0" },
+    { name = "pandas", marker = "extra == 'foundry'", specifier = ">=2.0,<3.0" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "ruamel-yaml", specifier = ">=0.18,<1.0" },
     { name = "typer", specifier = ">=0.12,<1.0" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'agent'", specifier = ">=0.30" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'agent'", specifier = ">=0.30,<1.0" },
 ]
 provides-extras = ["mcp", "foundry", "agent"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "azure-ai-evaluation", specifier = ">=1.0" },
+    { name = "azure-ai-evaluation", specifier = ">=1.0,<2.0" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
@@ -353,16 +353,17 @@ wheels = [
 
 [[package]]
 name = "azure-mgmt-cognitiveservices"
-version = "14.1.0"
+version = "13.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "azure-common" },
     { name = "azure-mgmt-core" },
-    { name = "msrest" },
+    { name = "isodate" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/8e/9fcfdd507413a2536c5458b40942705ea8d74fe4e17f05fd1c32bb0225a9/azure_mgmt_cognitiveservices-14.1.0.tar.gz", hash = "sha256:915191374d0adb443863c20aaea2c9f3b9d558a849ac2b78f152249262fdcaf8", size = 184444, upload-time = "2025-10-24T07:28:14.229Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/4b/428c41c3aacad9506e65bd67055cc8ea950857ce4161b6bd895ed44e37f2/azure_mgmt_cognitiveservices-13.7.0.tar.gz", hash = "sha256:48a5a44c15c6768bad238011aaac83a806ceb8ace1b51b8043e35b39a9167a19", size = 174735, upload-time = "2025-07-21T06:24:49.537Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/25/ed6bbc01a03991255dd22aa41091360d225f1be20c88710af0f4a6c27459/azure_mgmt_cognitiveservices-14.1.0-py3-none-any.whl", hash = "sha256:3c0eecc00d183842a11d754f4f5c3328ff86f2d6c0a2b81b28dd7e073680258e", size = 290096, upload-time = "2025-10-24T07:28:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/72/0bccfe59ac552ff2434d2e69ea595d69b47bda81b507cbde2372363dc8a4/azure_mgmt_cognitiveservices-13.7.0-py3-none-any.whl", hash = "sha256:9683c436781b8294fe85410da4d22323128c3d68bc141196addbdf07b048dfb4", size = 271603, upload-time = "2025-07-21T06:24:50.951Z" },
 ]
 
 [[package]]
@@ -379,17 +380,16 @@ wheels = [
 
 [[package]]
 name = "azure-mgmt-monitor"
-version = "7.0.0"
+version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-common" },
     { name = "azure-mgmt-core" },
     { name = "isodate" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/12/25874f6b894e972646244f570a23298969b58f57cfb7a188e2740017b43a/azure_mgmt_monitor-7.0.0.tar.gz", hash = "sha256:b75f536441d430f69ff873a1646e5f5dbcb3080a10768a59d0adc01541623816", size = 195496, upload-time = "2025-07-28T07:46:17.031Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/31/ebabafe0be1a177428880a8ec0fc44d681ac9dc1ae66a70d859cb5c7fbc3/azure-mgmt-monitor-6.0.2.tar.gz", hash = "sha256:5ffbf500e499ab7912b1ba6d26cef26480d9ae411532019bb78d72562196e07b", size = 760481, upload-time = "2023-08-22T08:31:30.722Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/d1/f6ea4731edfa02c14756770d7c3d5202b40c5c72744f15142c0d89b6d957/azure_mgmt_monitor-7.0.0-py3-none-any.whl", hash = "sha256:ad63b5d187e21d2d34366271ade6abbeea1fcf76e313ff0f83d394d9c124aa1b", size = 245243, upload-time = "2025-07-28T07:46:18.594Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/47/82ccbdb757da87c3c00d9ca0a7b7a28ab95f8dab040d1877bb15bf1c1e38/azure_mgmt_monitor-6.0.2-py3-none-any.whl", hash = "sha256:fe4cf41e6680b74a228f81451dc5522656d599c6f343ecf702fc790fda9a357b", size = 1305191, upload-time = "2023-08-22T08:31:35.989Z" },
 ]
 
 [[package]]
@@ -435,16 +435,16 @@ wheels = [
 
 [[package]]
 name = "azure-monitor-query"
-version = "2.0.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "isodate" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/c0/e5c760f38224575f1eba35c319842f2be30fab599854ba9bd0b19d39c261/azure_monitor_query-2.0.0.tar.gz", hash = "sha256:7b05f2fcac4fb67fc9f77a7d4c5d98a0f3099fb73b57c69ec1b080773994671b", size = 86658, upload-time = "2025-07-30T22:23:41.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/c5/26eee462559e254ec69b1a8585528aa0d2bfb814c31a8640af872a151e7a/azure_monitor_query-1.4.1.tar.gz", hash = "sha256:71824e2b577d25df0d3bebbbb054c06a1ae3ebcb91831a9bac0bb344d0addf68", size = 162946, upload-time = "2025-01-14T23:00:47.263Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/0c/6b08a5a1e5f0bd97cefa13c53bf47f281a9a11732d19a94a86709acbc6bd/azure_monitor_query-2.0.0-py3-none-any.whl", hash = "sha256:8f52d581271d785e12f49cd5aaa144b8910fb843db2373855a7ef94c7fc462ea", size = 71102, upload-time = "2025-07-30T22:23:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/71/bdf03aef699d9a17d80bcaa8255c20e596ed591daa8a42a21854ddc4277d/azure_monitor_query-1.4.1-py3-none-any.whl", hash = "sha256:192c5d8efec48b434f803aa3850ce73b869975507a12b3a823012fc100056ac0", size = 157978, upload-time = "2025-01-14T23:00:50.661Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bootstrap minimal azd prompt-agent context during agentops eval init
- simplify prompt-agent quickstart step 10 to agentops eval init + agentops eval run
- update tests and changelog for the 0.3.11 patch

## Validation
- uv run ruff check src/ tests/
- python -m pytest tests/ -x -q
- agentops eval init / agentops eval run in the prompt quickstart workspace
- clean temp quickstart bootstrap without azure.yaml, agent.yaml, or eval.yaml