### PR TITLE
fix: recommend eval init before azd eval run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   generates the azd eval recipe. The prompt-agent quickstart now keeps the main
   path to `agentops eval init` followed by `agentops eval run`, while still using
   `azd ai agent eval` under the hood.
+- **`agentops workflow analyze` now tells azd eval users to run
+  `agentops eval init` first.** When an azd eval recipe is selected, the
+  recommended commands and next steps now explicitly create or reuse the recipe
+  before telling users to run the local eval gate.
 
 ## [0.3.10] - 2026-06-08
 

--- a/src/agentops/services/workflow_analysis.py
+++ b/src/agentops/services/workflow_analysis.py
@@ -339,6 +339,8 @@ def analyze_workflow_project(directory: Path) -> WorkflowAnalysis:
         recommended_commands.insert(1, "pwsh ./scripts/Invoke-PreflightChecks.ps1 -Strict")
     if requires_copilot and not skills_installed:
         recommended_commands.insert(1, "agentops skills install --platform copilot")
+    if recommended_eval_runner == AZD_EVAL_RUNNER:
+        recommended_commands.insert(1, "agentops eval init")
     if has_azd:
         recommended_commands.append("azd provision")
         recommended_commands.append("azd deploy")
@@ -1139,7 +1141,8 @@ def _next_steps(
     eval_step = "Run `agentops eval run` locally and commit agentops.yaml plus datasets."
     if eval_runner == AZD_EVAL_RUNNER:
         eval_step = (
-            "Run `agentops eval run` locally and commit agentops.yaml, eval.yaml, "
+            "Run `agentops eval init` to create or reuse the azd eval recipe, then "
+            "`agentops eval run` locally and commit agentops.yaml, eval.yaml, "
             "generated evaluator/rubric assets, and datasets."
         )
     steps = [

--- a/tests/unit/test_workflow_analysis.py
+++ b/tests/unit/test_workflow_analysis.py
@@ -150,7 +150,9 @@ evaluators:
     assert "booking_accuracy" in analysis.official_evaluators
     assert any(signal.key == "azd_ai_agent_eval" for signal in analysis.signals)
     assert "azd AI agent eval" in rendered
-    assert analysis.next_steps[0].startswith("Run `agentops eval run` locally")
+    assert "agentops eval init" in analysis.recommended_commands
+    assert analysis.next_steps[0].startswith("Run `agentops eval init`")
+    assert "`agentops eval run` locally" in analysis.next_steps[0]
     assert "eval.yaml" in analysis.next_steps[0]
     assert "generated evaluator/rubric assets" in analysis.next_steps[0]
 


### PR DESCRIPTION
## Summary
- add agentops eval init to workflow analyze commands for azd eval recipes
- update next steps to say init creates/reuses the recipe before eval run
- update changelog and tests

## Validation
- uv run ruff check src/ tests/
- python -m pytest tests/ -x -q
- verified workflow analyze output in the prompt quickstart workspace