### PR TITLE
fix: show heartbeat during azd eval runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   `agentops eval init` first.** When an azd eval recipe is selected, the
   recommended commands and next steps now explicitly create or reuse the recipe
   before telling users to run the local eval gate.
+- **`agentops eval run` now prints heartbeat feedback while azd is running.**
+  Long `azd ai agent eval run` calls now show an immediate waiting message and
+  periodic elapsed-time updates instead of leaving the terminal silent while
+  Foundry completes the native evaluation.
 
 ## [0.3.10] - 2026-06-08
 

--- a/src/agentops/pipeline/azd_runner.py
+++ b/src/agentops/pipeline/azd_runner.py
@@ -25,6 +25,7 @@ from agentops.pipeline import thresholds
 AZD_EXTENSION_NAME = "azure.ai.agents"
 AZD_AVAILABILITY_TIMEOUT_SECONDS = 10.0
 AZD_EVAL_TIMEOUT_SECONDS = 1800.0
+AZD_PROGRESS_INTERVAL_SECONDS = 30.0
 
 
 class AzdBackendError(RuntimeError):
@@ -118,7 +119,13 @@ def run_azd_eval(
     notify(f"Running azd backend: {' '.join(command)}")
 
     started = time.perf_counter()
-    completed = _run_command(command, cwd=workspace, timeout_seconds=timeout_seconds)
+    completed = _run_command(
+        command,
+        cwd=workspace,
+        timeout_seconds=timeout_seconds,
+        progress=progress,
+        progress_label="azd eval run",
+    )
     duration = time.perf_counter() - started
     if completed.returncode != 0:
         raise AzdBackendError(_format_command_failure("azd ai agent eval run", completed))
@@ -301,7 +308,17 @@ def _run_command(
     *,
     cwd: Path,
     timeout_seconds: float,
+    progress: Optional[Callable[[str], None]] = None,
+    progress_label: str = "command",
 ) -> subprocess.CompletedProcess[str]:
+    if progress is not None:
+        return _run_command_with_progress(
+            command,
+            cwd=cwd,
+            timeout_seconds=timeout_seconds,
+            progress=progress,
+            progress_label=progress_label,
+        )
     try:
         return subprocess.run(
             command,
@@ -321,6 +338,69 @@ def _run_command(
     except subprocess.TimeoutExpired as exc:
         raise AzdBackendError(
             f"{' '.join(command)} timed out after {timeout_seconds:g}s."
+        ) from exc
+
+
+def _run_command_with_progress(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: float,
+    progress: Callable[[str], None],
+    progress_label: str,
+) -> subprocess.CompletedProcess[str]:
+    started = time.monotonic()
+    next_update = started + AZD_PROGRESS_INTERVAL_SECONDS
+    progress(
+        f"{progress_label}: waiting for azd/Foundry to finish "
+        f"(timeout {timeout_seconds / 60:.0f} min)."
+    )
+    try:
+        with tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace") as stdout_file:
+            with tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace") as stderr_file:
+                process = subprocess.Popen(
+                    command,
+                    cwd=str(cwd),
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                )
+                while True:
+                    returncode = process.poll()
+                    now = time.monotonic()
+                    if returncode is not None:
+                        break
+                    elapsed = now - started
+                    if elapsed > timeout_seconds:
+                        process.kill()
+                        process.wait()
+                        raise AzdBackendError(
+                            f"{' '.join(command)} timed out after {timeout_seconds:g}s."
+                        )
+                    if now >= next_update:
+                        progress(
+                            f"{progress_label}: still running "
+                            f"({elapsed / 60:.1f} min elapsed)."
+                        )
+                        next_update = now + AZD_PROGRESS_INTERVAL_SECONDS
+                    time.sleep(1.0)
+
+                stdout_file.seek(0)
+                stderr_file.seek(0)
+                stdout = stdout_file.read()
+                stderr = stderr_file.read()
+                return subprocess.CompletedProcess(
+                    command,
+                    returncode,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+    except FileNotFoundError as exc:
+        raise AzdBackendError(
+            "azd was not found on PATH. Install the Azure Developer CLI and the "
+            f"`{AZD_EXTENSION_NAME}` extension, then rerun `agentops eval run`."
         ) from exc
 
 

--- a/tests/unit/test_azd_runner.py
+++ b/tests/unit/test_azd_runner.py
@@ -101,6 +101,50 @@ def test_run_azd_eval_reads_show_out_file_when_run_outputs_text(
     assert calls[1][:6] == ["azd", "ai", "agent", "eval", "show", "eval_123"]
 
 
+def test_run_command_with_progress_emits_heartbeat(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    messages: list[str] = []
+    ticks = iter([0.0, 31.0, 32.0])
+
+    class FakeProcess:
+        returncode = 0
+
+        def __init__(self, *, stdout, stderr) -> None:
+            self._polls = 0
+            stdout.write("Eval: eval_123\n")
+            stderr.write("diagnostic\n")
+
+        def poll(self) -> int | None:
+            self._polls += 1
+            return None if self._polls == 1 else self.returncode
+
+    def fake_popen(command, **kwargs):
+        assert command == ["azd", "ai", "agent", "eval", "run"]
+        return FakeProcess(stdout=kwargs["stdout"], stderr=kwargs["stderr"])
+
+    monkeypatch.setattr(azd_runner.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(azd_runner.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(azd_runner.time, "sleep", lambda _seconds: None)
+
+    completed = azd_runner._run_command(
+        ["azd", "ai", "agent", "eval", "run"],
+        cwd=tmp_path,
+        timeout_seconds=120,
+        progress=messages.append,
+        progress_label="azd eval run",
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout == "Eval: eval_123\n"
+    assert completed.stderr == "diagnostic\n"
+    assert messages == [
+        "azd eval run: waiting for azd/Foundry to finish (timeout 2 min).",
+        "azd eval run: still running (0.5 min elapsed).",
+    ]
+
+
 def test_normalize_to_results_binds_azd_metrics_and_thresholds(tmp_path: Path) -> None:
     recipe_path = tmp_path / "eval.yaml"
     _write_recipe(recipe_path)


### PR DESCRIPTION
## Summary
- show an immediate waiting message while azd ai agent eval run is active
- print periodic elapsed-time heartbeat updates for long Foundry eval runs
- keep stdout/stderr captured for raw artifacts and failure messages

## Validation
- uv run ruff check src/ tests/
- python -m pytest tests/ -x -q