### PR TITLE
Support reasoning models (o-series, GPT-5) as evaluator graders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Added
+- **Reasoning models (OpenAI o-series, GPT-5) are now supported as evaluator
+  graders.** AI-assisted evaluators previously failed with
+  `BadRequestError: 'max_tokens' is not supported with this model` when the
+  grader deployment (`AZURE_OPENAI_DEPLOYMENT`) was a reasoning model. AgentOps
+  now passes `is_reasoning_model=True` to the `azure-ai-evaluation` evaluators so
+  the SDK sends `max_completion_tokens` instead. Resolution is automatic from the
+  deployment name and can be forced with the `AGENTOPS_EVALUATOR_REASONING`
+  environment variable (`auto` default, or `true`/`false`).
+
 ## [0.3.8] - 2026-06-04
 
 ### Fixed

--- a/src/agentops/pipeline/runtime.py
+++ b/src/agentops/pipeline/runtime.py
@@ -12,6 +12,7 @@ import importlib
 import inspect
 import json
 import os
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -61,7 +62,9 @@ class EvaluatorRuntime:
 def _credential() -> Any:
     from azure.identity import DefaultAzureCredential  # noqa: WPS433
 
-    return DefaultAzureCredential(exclude_developer_cli_credential=True, process_timeout=30)
+    return DefaultAzureCredential(
+        exclude_developer_cli_credential=True, process_timeout=30
+    )
 
 
 def _model_config() -> Dict[str, str]:
@@ -118,6 +121,37 @@ def _model_config() -> Dict[str, str]:
     return config
 
 
+# Model families whose Azure OpenAI deployments reject the classic
+# ``max_tokens`` parameter and require ``max_completion_tokens`` instead
+# (OpenAI o-series reasoning models and GPT-5). ``azure-ai-evaluation``
+# only rewrites the request when the evaluator is constructed with
+# ``is_reasoning_model=True``; it never auto-detects.
+_REASONING_DEPLOYMENT_RE = re.compile(
+    r"(?:^|[^a-z0-9])(?:o[1-9][0-9]*|gpt-?5)(?:[^a-z0-9]|$)",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_reasoning_model(deployment: str) -> bool:
+    return bool(_REASONING_DEPLOYMENT_RE.search(deployment or ""))
+
+
+def _evaluator_reasoning_enabled(deployment: str) -> bool:
+    """Resolve whether AI-assisted evaluators target a reasoning grader.
+
+    Controlled by ``AGENTOPS_EVALUATOR_REASONING`` (``auto`` default,
+    ``true``/``false`` override). ``auto`` infers from the deployment name
+    because Azure deployment names are user-chosen and need not match the
+    underlying model.
+    """
+    raw = (os.getenv("AGENTOPS_EVALUATOR_REASONING") or "auto").strip().lower()
+    if raw in {"true", "1", "yes", "on"}:
+        return True
+    if raw in {"false", "0", "no", "off"}:
+        return False
+    return _looks_like_reasoning_model(deployment)
+
+
 def _project_endpoint() -> str:
     endpoint = os.getenv("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT")
     if not endpoint:
@@ -152,7 +186,10 @@ def load_evaluator(preset: EvaluatorPreset) -> EvaluatorRuntime:
 
     init_kwargs: Dict[str, Any] = {}
     if preset.class_name in _AI_ASSISTED:
-        init_kwargs["model_config"] = _model_config()
+        config = _model_config()
+        init_kwargs["model_config"] = config
+        if _evaluator_reasoning_enabled(config.get("azure_deployment", "")):
+            init_kwargs["is_reasoning_model"] = True
     if preset.class_name in _SAFETY:
         init_kwargs["azure_ai_project"] = _project_endpoint()
         init_kwargs["credential"] = _credential()
@@ -227,7 +264,9 @@ def _build_conversation_messages(
             # Normalise across the OpenAI ``function_call`` shape and the
             # nested ``function`` envelope produced by some Foundry payloads.
             raw_function = call.get("function")
-            function: Dict[str, Any] = raw_function if isinstance(raw_function, dict) else {}
+            function: Dict[str, Any] = (
+                raw_function if isinstance(raw_function, dict) else {}
+            )
             name = call.get("name") or function.get("name")
             if not name:
                 continue
@@ -242,29 +281,37 @@ def _build_conversation_messages(
                     pass
             tool_call_id = call.get("tool_call_id") or call.get("id") or f"call_{index}"
 
-            response_messages.append({
-                "role": "assistant",
-                "content": [{
-                    "type": "tool_call",
-                    "tool_call_id": tool_call_id,
-                    "name": name,
-                    "arguments": arguments if arguments is not None else {},
-                }],
-            })
+            response_messages.append(
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": tool_call_id,
+                            "name": name,
+                            "arguments": arguments if arguments is not None else {},
+                        }
+                    ],
+                }
+            )
 
             result = call.get("result")
             if isinstance(result, str) and result:
-                response_messages.append({
-                    "role": "tool",
-                    "tool_call_id": tool_call_id,
-                    "content": [{"type": "tool_result", "tool_result": result}],
-                })
+                response_messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call_id,
+                        "content": [{"type": "tool_result", "tool_result": result}],
+                    }
+                )
 
     if response_text:
-        response_messages.append({
-            "role": "assistant",
-            "content": [{"type": "text", "text": response_text}],
-        })
+        response_messages.append(
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": response_text}],
+            }
+        )
 
     if not response_messages:
         return None
@@ -353,7 +400,9 @@ def run_evaluator(
     #     score it as 0.0 instead of crashing the row.
     if preset.class_name == "ToolCallAccuracyEvaluator":
         has_actual = isinstance(actual_tool_calls, list) and len(actual_tool_calls) > 0
-        has_dataset = isinstance(row.get("tool_calls"), list) and len(row["tool_calls"]) > 0
+        has_dataset = (
+            isinstance(row.get("tool_calls"), list) and len(row["tool_calls"]) > 0
+        )
         if not has_actual:
             if has_dataset:
                 return RowMetric(

--- a/tests/unit/test_runtime_reasoning_model.py
+++ b/tests/unit/test_runtime_reasoning_model.py
@@ -1,0 +1,139 @@
+"""Tests for reasoning-model grader support in the evaluator runtime.
+
+``azure-ai-evaluation`` requires ``is_reasoning_model=True`` to rewrite the
+chat-completions request (``max_tokens`` -> ``max_completion_tokens``) for
+OpenAI o-series and GPT-5 graders. AgentOps resolves the flag from the grader
+deployment via :func:`_evaluator_reasoning_enabled` and forwards it to
+AI-assisted evaluators in :func:`load_evaluator`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from agentops.core.evaluators import EvaluatorPreset
+from agentops.pipeline import runtime
+from agentops.pipeline.runtime import (
+    _evaluator_reasoning_enabled,
+    _looks_like_reasoning_model,
+    load_evaluator,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "AGENTOPS_EVALUATOR_REASONING",
+        "AZURE_OPENAI_ENDPOINT",
+        "AZURE_OPENAI_DEPLOYMENT",
+        "AZURE_AI_MODEL_DEPLOYMENT_NAME",
+        "AZURE_AI_FOUNDRY_PROJECT_ENDPOINT",
+        "AZURE_OPENAI_API_VERSION",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.mark.parametrize(
+    "deployment",
+    [
+        "o1",
+        "o1-mini",
+        "o3",
+        "o3-mini",
+        "o4-mini",
+        "gpt-5",
+        "gpt5",
+        "gpt-5-mini",
+        "my-o3-grader",
+    ],
+)
+def test_reasoning_names_detected(deployment: str) -> None:
+    assert _looks_like_reasoning_model(deployment) is True
+
+
+@pytest.mark.parametrize(
+    "deployment",
+    [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-4.1",
+        "gpt-4-turbo",
+        "gpt-35-turbo",
+        "my-grader",
+        "",
+    ],
+)
+def test_classic_names_not_detected(deployment: str) -> None:
+    assert _looks_like_reasoning_model(deployment) is False
+
+
+def test_env_true_overrides_classic_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOPS_EVALUATOR_REASONING", "true")
+    assert _evaluator_reasoning_enabled("gpt-4o") is True
+
+
+def test_env_false_overrides_reasoning_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOPS_EVALUATOR_REASONING", "false")
+    assert _evaluator_reasoning_enabled("o3-mini") is False
+
+
+def test_env_auto_falls_back_to_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOPS_EVALUATOR_REASONING", "auto")
+    assert _evaluator_reasoning_enabled("o3-mini") is True
+    assert _evaluator_reasoning_enabled("gpt-4o") is False
+
+
+class _FakeEvaluator:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    def __call__(self, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover
+        return {}
+
+
+def _install_fake_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    import types
+
+    fake_module = types.SimpleNamespace(CoherenceEvaluator=_FakeEvaluator)
+    monkeypatch.setattr(
+        runtime.importlib,
+        "import_module",
+        lambda name: fake_module,
+    )
+
+
+def _preset() -> EvaluatorPreset:
+    return EvaluatorPreset(
+        name="coherence",
+        class_name="CoherenceEvaluator",
+        score_key="coherence",
+        input_mapping={"response": "$prediction"},
+    )
+
+
+def test_load_evaluator_passes_flag_for_reasoning_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://x.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "o3-mini")
+    _install_fake_sdk(monkeypatch)
+
+    rt = load_evaluator(_preset())
+
+    assert rt.callable.kwargs.get("is_reasoning_model") is True
+    assert rt.callable.kwargs["model_config"]["azure_deployment"] == "o3-mini"
+
+
+def test_load_evaluator_omits_flag_for_classic_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://x.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")
+    _install_fake_sdk(monkeypatch)
+
+    rt = load_evaluator(_preset())
+
+    assert "is_reasoning_model" not in rt.callable.kwargs
+    assert rt.callable.kwargs["model_config"]["azure_deployment"] == "gpt-4o-mini"


### PR DESCRIPTION
## Problem

AI-assisted evaluators fail with a 400 when the grader deployment (`AZURE_OPENAI_DEPLOYMENT`) is a reasoning model:

```
BadRequestError: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

The parameter is set inside `azure-ai-evaluation`, which only rewrites `max_tokens` -> `max_completion_tokens` when the evaluator is constructed with `is_reasoning_model=True`. It never auto-detects, and AgentOps never passed it.

## Change

- `runtime.load_evaluator` now forwards `is_reasoning_model` to AI-assisted evaluators.
- Resolution is automatic from the grader deployment name (`o1`/`o3`/`o4`/`gpt-5`) and overridable via `AGENTOPS_EVALUATOR_REASONING` (`auto` default, `true`/`false`).
- Verified all evaluators in `_AI_ASSISTED` subclass `PromptyEvaluatorBase` and accept the kwarg via `**kwargs` (no `TypeError` risk).

## Tests

- New `tests/unit/test_runtime_reasoning_model.py`: name detection, env override (true/false/auto), and `load_evaluator` kwarg propagation (Azure SDK mocked).
- Full unit suite: 856 passed, 1 skipped. `mypy` clean on the changed module.

Closes the `max_tokens` grader incompatibility.
