### PR TITLE
fix: declare click as an explicit runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   ([#214](https://github.com/Azure/agentops/issues/214))
 
 ### Fixed
+- **Clean installs now include the pager dependency used by explain commands.**
+  `agentops explain`, `agentops init explain`, and `agentops doctor explain`
+  import Click directly to render long manual output, so `click>=8.1,<9` is now
+  declared as a runtime dependency instead of relying on transitive installs.
+
 - **`agentops eval init` now works with both old and new `azure.ai.agents` azd
   extensions.** Version 0.1.40 of the extension renamed the eval subcommand from
   `azd ai agent eval init` to `azd ai agent eval generate`, which made

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "typer>=0.12,<1.0",
+  "click>=8.1,<9",
   "pydantic>=2,<3",
   "ruamel.yaml>=0.18,<1.0",
   "azure-ai-projects>=2.0.1,<3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ name = "agentops-accelerator"
 source = { editable = "." }
 dependencies = [
     { name = "azure-ai-projects" },
+    { name = "click" },
     { name = "pydantic" },
     { name = "ruamel-yaml" },
     { name = "typer" },
@@ -66,6 +67,7 @@ requires-dist = [
     { name = "azure-monitor-opentelemetry", marker = "extra == 'agent'", specifier = ">=1.6,<2.0" },
     { name = "azure-monitor-opentelemetry", marker = "extra == 'foundry'", specifier = ">=1.6,<2.0" },
     { name = "azure-monitor-query", marker = "extra == 'agent'", specifier = ">=1.3,<3.0" },
+    { name = "click", specifier = ">=8.1,<9" },
     { name = "cryptography", marker = "extra == 'agent'", specifier = ">=42" },
     { name = "fastapi", marker = "extra == 'agent'", specifier = ">=0.110,<1.0" },
     { name = "httpx", marker = "extra == 'agent'", specifier = ">=0.27,<1.0" },


### PR DESCRIPTION
## Summary
Declares `click` as an explicit runtime dependency so a clean `pip install agentops-accelerator` no longer crashes on the `explain` / manual commands.

## Problem
The CLI imports `click` directly for its pager and manual output paths (`app.py` `_emit_manual_output` / `_emit_doctor_explain`). `click` was only available transitively via Typer, but **Typer 0.26+ no longer depends on `click`**. As a result, a fresh install of the published `agentops-accelerator` (0.3.11) crashes:

\\\
\$ agentops explain
ModuleNotFoundError: No module named 'click'
\\\

This affects `agentops explain`, `agentops init explain`, and `agentops doctor explain` (all formats/flags). It was masked in dev/editable installs and when the `[foundry]` extra is installed (which pulls `click` transitively), but the base install is broken.

## Fix
Add `click>=8.1,<9` to `[project].dependencies` in `pyproject.toml`.

## Verification
Found via a full E2E test of the published 0.3.11 package in a fresh venv (44-case command/parameter matrix). Fix verified by building the wheel from this branch and installing it into a **brand-new clean venv**: `click` is pulled automatically and both `agentops explain` and `agentops doctor explain` exit `0`.

No version bump (setuptools-scm owns versioning). Changelog updated under `[Unreleased] > Fixed`.