### PR TITLE
docs: mark full multi-turn evaluation optional

### DIFF
--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -871,7 +871,7 @@ multi-turn dataset kind, and the threshold results emitted by azd.
 > conversation-aware. For true end-to-end full conversation evaluation, continue
 > with the Foundry portal flow below.
 
-### Run full multi-turn evaluation in Foundry
+### Optional: Run full multi-turn evaluation in Foundry
 
 The CLI / azd gate above is the repo-controlled release gate. It uses
 synthetic conversation-context rows: the agent receives the relevant


### PR DESCRIPTION
Clarifies that the Foundry portal Full conversations multi-turn evaluation path is optional in the prompt-agent quickstart.