### PR TITLE
feat: agentops assert run + agentops redteam run as active CI gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Added
+- **`agentops assert run` orchestrates the open-source ASSERT framework.**
+  AgentOps now invokes the `assert-ai` CLI as an active CI step instead of only
+  consuming pre-generated artifacts via `assert_path:`. A new `assert:` block in
+  `agentops.yaml` (`config`, `results_dir`, `suite`, `run_id`,
+  `fail_on_violations`) drives subprocess invocation, locates the run output
+  under `<results_dir>/<suite>/<run>/`, parses `metrics.json` and
+  `scores.jsonl`, and writes a normalized summary at `.agentops/assert/latest.json`
+  that the release evidence pack ingests automatically. Exit code 2 when any
+  policy dimension reports violations.
+- **`agentops redteam run` orchestrates Foundry's AI Red Teaming agent (PyRIT).**
+  AgentOps now invokes `azure.ai.evaluation.red_team.RedTeam` against the
+  configured target (Azure OpenAI deployment, Foundry prompt agent, or HTTP
+  endpoint) and normalizes the per-category and per-strategy attack outcomes.
+  A new `redteam:` block in `agentops.yaml` (`target`, `risk_categories`,
+  `attack_strategies`, `num_objectives`, `fail_on_attack_success_rate`)
+  controls the scan; results land at `.agentops/redteam/latest.json` so the
+  evidence pack picks them up via `redteam_path:` automatically. Exit code 2
+  when attack-success-rate exceeds the configured threshold.
+
 ## [0.3.13] - 2026-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 <h1 align="center">AgentOps Accelerator</h1>
 
 <p align="center">
-Answer the release question for Microsoft Foundry agents: can we ship it, and where is the proof?
+<b>Open-source framework and CLI for continuous evaluation, safety testing, and release readiness of Microsoft Foundry agents.</b>
+<br/>
+Can we ship it, and where is the proof?
 </p>
 
 <p align="center">
@@ -19,25 +21,52 @@ Answer the release question for Microsoft Foundry agents: can we ship it, and wh
 
 ## Overview
 
-AgentOps Accelerator helps teams turn Foundry agent work into a clear release
-decision. Foundry is the agent control plane; AgentOps turns Foundry signals and
-repo checks into repeatable gates, Doctor readiness, release evidence, and
-trace-driven regression loops.
+**AgentOps Accelerator is an open-source framework and CLI that standardizes
+continuous evaluation, safety testing, and release readiness for enterprise AI
+agents — with Microsoft Foundry as the agent runtime.**
 
-The project enables:
+It is an *orchestrator*, not a reimplementation. AgentOps wires together the
+tools you already use — Foundry Evaluations, `azd ai agent eval`, the
+open-source ASSERT framework, the PyRIT-backed AI Red Teaming agent, Azure
+Monitor / Application Insights, and your CI/CD platform — into a single
+repeatable release loop:
 
-- Local and CI execution for release gates
-- Foundry prompt agent, Foundry hosted endpoint, HTTP/JSON agent, and raw model targets
-- Auto-selected evaluators for RAG, tools, and model quality
-- Stable `results.json` for automation
-- PR-friendly `report.md`
-- Baseline comparison for regression detection
-- Doctor checks for repo, CI/CD, telemetry, landing zones, and Foundry setup
-- Release evidence packs for promotion review
-- Optional `azd ai agent eval` execution with Rubric/custom metric binding
-- ASSERT, ACS, and red-team governance evidence references
-- Trace promotion into regression datasets
-- Cockpit navigation for AgentOps, Foundry, and Azure Monitor
+1. **Evaluate** the agent against datasets, rubrics, and policies — locally or
+   in the cloud — using auto-selected evaluators for RAG, tool use, model
+   quality, and safety.
+2. **Probe** the agent with adversarial inputs by orchestrating ASSERT
+   (`agentops assert run`) and the Foundry/PyRIT Red Teaming agent
+   (`agentops redteam run`) as active CI steps.
+3. **Diagnose** repo, telemetry, landing zone, and Foundry readiness with
+   `agentops doctor`.
+4. **Gate** the release with a deterministic exit-code contract that PRs and
+   pipelines can rely on.
+5. **Prove** the release with a stable evidence pack (`evidence.json` +
+   `evidence.md`) that bundles eval results, ASSERT verdicts, red-team
+   findings, telemetry readiness, and Doctor findings for promotion review.
+6. **Learn from production** by promoting reviewed traces into regression
+   datasets that feed the next eval cycle.
+
+The output is a clear answer to two questions reviewers actually ask:
+**can we ship it, and where is the proof?**
+
+### Core outputs
+
+| Artifact | Produced by | Audience |
+|---|---|---|
+| `results.json` | `agentops eval run` | CI / automation |
+| `report.md` | `agentops eval run` | PR reviewers |
+| `.agentops/assert/latest.json` | `agentops assert run` | Evidence pack, CI gate |
+| `.agentops/redteam/latest.json` | `agentops redteam run` | Evidence pack, CI gate |
+| `evidence.json` / `evidence.md` | `agentops doctor --evidence-pack` | Release approver |
+| Cockpit (localhost) | `agentops cockpit` | Engineer reviewing readiness |
+
+### Exit-code contract
+
+- `0` — execution succeeded and all gates passed
+- `2` — execution succeeded but a threshold, ASSERT violation, red-team rate,
+  or Doctor severity gate failed
+- `1` — runtime or configuration error
 
 ## AgentOps and Microsoft Foundry
 
@@ -50,25 +79,14 @@ ship/no-ship workflow.
 |---|---|---|
 | Build and version | Foundry portal, Foundry SDK/Toolkit, `microsoft-foundry` skill, azd | Pins the exact candidate in `agentops.yaml` and generates the PR/release gate around it |
 | Evaluate and compare | Foundry Evaluations, `azd ai agent eval`, Rubric evaluator, and official CI actions/extensions | Keeps datasets and thresholds in the repo, records evidence, normalizes azd/Rubric outputs, and provides local/fallback runs for non-prompt targets |
+| Probe safety | ASSERT framework, PyRIT-backed AI Red Teaming agent | Runs both as active CI steps via `agentops assert run` and `agentops redteam run`, normalizes verdicts, and gates the pipeline |
 | Observe and investigate | Foundry Monitor, Traces, Azure Monitor, App Insights | Surfaces deep links, telemetry readiness, Doctor findings, and Cockpit navigation |
 | Decide release | Branch protection, environments, approvals | Packages `evidence.json` / `evidence.md` for promotion review |
-| Govern controls | ASSERT, ACS, Foundry Guardrails, Foundry red-team scans | References reviewed artifacts by path/hash/status without executing or applying the external controls |
+| Govern controls | ACS, Foundry Guardrails | References reviewed artifacts by path/hash/status without executing or applying the external controls |
 | Improve from production | Production traces and Foundry datasets | Promotes reviewed trace learnings into regression candidates |
 
 The rhythm is simple: build and operate the agent in Foundry, keep the release
 contract in the repo, and let AgentOps connect the two into a clean review loop.
-
-Core outputs:
-
-- `results.json` (machine-readable)
-- `report.md` (human-readable)
-- `evidence.json` / `evidence.md` (from `agentops doctor --evidence-pack`)
-
-Exit code contract:
-
-- `0` execution succeeded and all thresholds passed
-- `2` execution succeeded but one or more thresholds failed
-- `1` runtime or configuration error
 
 ## Quickstart
 

--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -1019,47 +1019,127 @@ bind to an emitted metric. Open `.agentops/results/latest/results.json` to see
 which rubric metric names actually appeared in the azd output; that is the
 authoritative list of values you can put under `thresholds:`.
 
-### Add ASSERT evidence to the release proof
+### Add ASSERT and Red Team to the release gate
 
 The normal AgentOps flow proves the release with evaluation results, Doctor
-findings, workflow runs, and release evidence. ASSERT fits into that same release
-proof as a governed artifact: run ASSERT in the tool or process your team uses
-for policy checks, keep the reviewed policy or result summary in the repo or CI
-artifact store, and point AgentOps at it.
+findings, workflow runs, and release evidence. Two release-readiness signals
+deserve to run inside the same loop:
 
-AgentOps does not execute ASSERT. It records the artifact path, status, and
-SHA-256 hash so Doctor and the evidence pack can show reviewers which ASSERT
-evidence was used for the release. Store only approved metadata in the repo; keep
-raw adversarial prompts, secrets, customer data, and detailed scan payloads in
-the approved secure system.
+- **ASSERT** (open-source `assert-ai`) — turns natural-language policies into
+  executable behavior tests (prompt injection, jailbreak, hallucination, PII
+  leak, unauthorized tool use). Repo: <https://github.com/responsibleai/ASSERT>.
+- **AI Red Teaming** (Foundry agent, PyRIT-backed) — generates adversarial
+  prompts across risk categories (violence, hate, self-harm, sexual) and applies
+  attack strategies (base64, rot13, morse) to surface safety regressions before
+  users do. Docs:
+  <https://learn.microsoft.com/azure/ai-foundry/concepts/ai-red-teaming-agent>.
+
+AgentOps does NOT reimplement either. It orchestrates them as active CI steps,
+gates the pipeline on their results, and writes normalized JSON summaries that
+the evidence pack ingests automatically.
+
+#### 10a. Run ASSERT against the Travel Agent
+
+Install ASSERT and scaffold a minimal eval config:
 
 ```powershell
-New-Item -ItemType Directory -Force .agentops\governance | Out-Null
-@'
-# ASSERT evidence
+pip install assert-ai
 
-Status: reviewed
-Source: <link-to-approved-assert-run-or-policy>
-Scope: Travel Agent release readiness
-Notes: ASSERT execution remains in the owning ASSERT workflow; AgentOps records
-this artifact as release evidence only.
-'@ | Set-Content -Encoding utf8 .agentops\governance\assert-evidence.md
+New-Item -ItemType Directory -Force .\assert | Out-Null
+@'
+suite_id: travel-agent-v1
+run_id: ci-tutorial
+target:
+  type: azure_openai
+  deployment: gpt-4o-mini
+dimensions:
+  - prompt_injection
+  - pii_leak
+  - jailbreak
+num_cases_per_dimension: 5
+'@ | Set-Content -Encoding utf8 .\assert\eval_config.yaml
 ```
 
-Then reference it from `agentops.yaml`:
+Add the `assert:` block to `agentops.yaml`:
 
 ```yaml
-assert_path: .agentops/governance/assert-evidence.md
+assert:
+  config: ./assert/eval_config.yaml
+  fail_on_violations: true
 ```
 
-When you later run:
+Run it through AgentOps:
+
+```powershell
+agentops assert run
+```
+
+What AgentOps does for you:
+
+1. Verifies `assert-ai` is installed.
+2. Invokes `assert-ai run --config ./assert/eval_config.yaml`.
+3. Locates the run output under `artifacts/results/<suite>/<run>/`.
+4. Parses `metrics.json` and `scores.jsonl` for per-dimension verdicts.
+5. Writes a normalized summary at `.agentops/assert/latest.json`.
+6. Exits non-zero (code 2) when ASSERT reports any policy violation, unless
+   you pass `--no-gate` or set `assert.fail_on_violations: false`.
+
+#### 10b. Run the AI Red Teaming agent
+
+Install Foundry's Red Team SDK (it ships under an extra of `azure-ai-evaluation`):
+
+```powershell
+pip install "azure-ai-evaluation[redteam]"
+```
+
+Add the `redteam:` block to `agentops.yaml`:
+
+```yaml
+redteam:
+  target:
+    model_deployment: gpt-4o-mini
+  risk_categories: [violence, hate_unfairness, self_harm, sexual]
+  attack_strategies: [base64, rot13, morse]
+  num_objectives: 5
+  fail_on_attack_success_rate: 0.2  # fail if >20% of attacks succeed
+```
+
+Run it:
+
+```powershell
+agentops redteam run
+```
+
+What AgentOps does for you:
+
+1. Verifies the `RedTeam` Python API is importable.
+2. Resolves the target (deployment / agent / endpoint) from the YAML.
+3. Calls `RedTeam.scan(...)` with the configured risk categories, strategies,
+   and objective count.
+4. Aggregates per-category and per-strategy attack-success-rate.
+5. Writes a normalized summary at `.agentops/redteam/latest.json` plus the
+   raw SDK payload at `.agentops/redteam/raw_summary.json`.
+6. Exits non-zero (code 2) when overall attack-success-rate exceeds
+   `fail_on_attack_success_rate`, unless you pass `--no-gate`.
+
+> **Heads-up.** Both commands hit live Azure services. Run them against a
+> non-production deployment and budget for the cost of the configured
+> objective count.
+
+#### 10c. Pull both into the release evidence pack
+
+Both runners write to well-known paths the evidence pack already auto-discovers
+(via `assert_path` and `redteam_path` resolution). When you produce the
+evidence pack:
 
 ```powershell
 agentops doctor --workspace . --evidence-pack
 ```
 
-the release evidence includes the ASSERT path, status, and SHA-256 hash without
-claiming that AgentOps executed ASSERT.
+`evidence.json` and `evidence.md` now include the suite/run id, total cases,
+violation counts, attack-success-rate, and SHA-256 hashes for both artifacts —
+without claiming AgentOps invented the verdicts. The verdicts come from ASSERT
+and PyRIT; AgentOps owns orchestration, normalization, and gating.
 
 ## 11. Generate the PR + dev deploy workflows
 
@@ -1646,10 +1726,12 @@ You are done when:
 - `agentops doctor --evidence-pack` writes
   `.agentops/release/latest/evidence.md`, and the GitHub run summary
   shows its Doctor finding summary.
-- Optional governance artifacts are either absent (no Doctor noise) or wired as
-  evidence-only paths in `agentops.yaml` (`assert_path`, `acs_path`,
-  `redteam_path`) so the evidence pack can cite their hash/status without
-  claiming AgentOps executed ASSERT, applied ACS, or ran red-team scans.
+- Optional safety runners are either skipped (no Doctor noise) or wired in:
+  `assert:` to run `agentops assert run`, and `redteam:` to run
+  `agentops redteam run`. Both write normalized JSON under `.agentops/` that
+  the evidence pack ingests automatically. Pre-existing `assert_path`,
+  `acs_path`, `redteam_path` references for evidence-only hash/status are
+  still honored.
 - Cockpit opens and links the repo-side readiness view back to Foundry
   for both sandbox and dev.
 

--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -60,6 +60,21 @@ init_app = typer.Typer(
     invoke_without_command=True,
     no_args_is_help=False,
 )
+assert_app = typer.Typer(
+    help=(
+        "Run the open-source ASSERT (assert-ai) framework against this "
+        "workspace. Requires 'pip install assert-ai' and an 'assert:' block "
+        "in agentops.yaml. Use `agentops assert explain` for the manual."
+    )
+)
+redteam_app = typer.Typer(
+    help=(
+        "Run Foundry's AI Red Teaming agent (PyRIT-backed) against this "
+        "workspace's target. Requires 'pip install \"azure-ai-evaluation[redteam]\"' "
+        "and a 'redteam:' block in agentops.yaml. Use `agentops redteam explain` "
+        "for the manual."
+    )
+)
 app.add_typer(eval_app, name="eval")
 app.add_typer(report_app, name="report")
 app.add_typer(workflow_app, name="workflow")
@@ -68,6 +83,8 @@ app.add_typer(mcp_app, name="mcp")
 app.add_typer(agent_app, name="agent")
 app.add_typer(doctor_app, name="doctor")
 app.add_typer(init_app, name="init")
+app.add_typer(assert_app, name="assert")
+app.add_typer(redteam_app, name="redteam")
 
 log = get_logger(__name__)
 DEFAULT_REPORT_INPUT = Path(".agentops/results/latest/results.json")
@@ -468,7 +485,7 @@ EXPLAIN_PAGES: dict[tuple[str, ...], ExplainPage] = {
             "agentops explain eval run --open",
             "agentops explain cockpit --format markdown --out cockpit.md",
         ),
-        children=("init", "eval", "report", "workflow", "skills", "mcp", "agent", "doctor", "cockpit"),
+        children=("init", "eval", "report", "workflow", "skills", "mcp", "agent", "doctor", "cockpit", "assert", "redteam"),
     ),
     ("init",): ExplainPage(
         title="Initialize workspace and configure endpoints",
@@ -839,6 +856,127 @@ EXPLAIN_PAGES: dict[tuple[str, ...], ExplainPage] = {
         ),
         examples=("agentops cockpit", "agentops cockpit --port 8091", "agentops cockpit --no-preflight", "agentops cockpit explain"),
         see_also=("agentops explain doctor", "agentops explain eval run", "agentops explain workflow generate"),
+    ),
+    ("assert",): ExplainPage(
+        title="ASSERT runner",
+        command="agentops assert",
+        synopsis=(
+            "agentops assert run [--config PATH] [--assert-config PATH] "
+            "[--results-dir PATH] [--suite ID] [--run-id ID] [--no-gate]",
+            "agentops assert explain [--format text|markdown|html] [--out PATH] [--open]",
+        ),
+        summary=(
+            "Orchestrates the open-source ASSERT (assert-ai) framework "
+            "(https://github.com/responsibleai/ASSERT) from inside the "
+            "AgentOps release loop. ASSERT turns natural-language policies "
+            "into executable behavior tests for AI agents: prompt injection, "
+            "jailbreak, hallucination, PII leak, unauthorized tool use, and "
+            "other long-tail failure modes that generic helpfulness scorers "
+            "miss.",
+            "AgentOps does not reimplement ASSERT. It invokes the "
+            "`assert-ai` CLI as a subprocess, locates the run's output "
+            "directory under `<results_dir>/<suite>/<run>/`, parses "
+            "`metrics.json` and `scores.jsonl`, and writes a normalized "
+            "summary at `.agentops/assert/latest.json` so the release "
+            "evidence pack can ingest it automatically.",
+            "Use this command instead of the older flow that only "
+            "referenced pre-generated ASSERT artifacts via `assert_path:`. "
+            "With `agentops assert run`, ASSERT becomes an active step in "
+            "your CI/CD pipeline, gated by policy violations.",
+        ),
+        how_it_works=(
+            "Reads the `assert:` block in `agentops.yaml` (or `--assert-config`).",
+            "Verifies `assert-ai` is installed (`pip install assert-ai`).",
+            "Invokes `assert-ai run --config <eval_config.yaml>` as a subprocess.",
+            "Locates the run output directory under `<results_dir>/<suite>/<run>/`.",
+            "Reads `metrics.json` for aggregate totals and `scores.jsonl` for per-dimension verdicts.",
+            "Writes a normalized summary at `.agentops/assert/latest.json`.",
+            "Exits with code 2 when ASSERT reports policy violations (unless `--no-gate`).",
+        ),
+        inputs=(
+            "`assert.config` - path to the ASSERT eval_config.yaml that drives the run.",
+            "`assert.results_dir` - where ASSERT writes <suite>/<run>/ artifacts. Defaults to `artifacts/results`.",
+            "`assert.suite` / `assert.run_id` - optional overrides for output discovery.",
+            "`assert.fail_on_violations` - when true (default), violations exit code 2.",
+        ),
+        outputs=(
+            "`.agentops/assert/latest.json` - normalized summary consumed by the evidence pack.",
+            "ASSERT raw artifacts under `<results_dir>/<suite>/<run>/`: `taxonomy.json`, `test_set.jsonl`, `inference_set.jsonl`, `scores.jsonl`, `metrics.json`.",
+            "Terminal summary with per-dimension violation counts and overall pass rate.",
+        ),
+        examples=(
+            "agentops assert run",
+            "agentops assert run --assert-config assert/eval_config.yaml",
+            "agentops assert run --suite travel-agent-v1 --run-id ci-build-42",
+            "agentops assert run --no-gate  # record violations without failing",
+        ),
+        see_also=(
+            "agentops explain doctor",
+            "agentops explain workflow generate",
+            "https://github.com/responsibleai/ASSERT",
+        ),
+    ),
+    ("redteam",): ExplainPage(
+        title="Red Team runner (PyRIT / Foundry)",
+        command="agentops redteam",
+        synopsis=(
+            "agentops redteam run [--config PATH] [--target SPEC] "
+            "[--num-objectives N] [--output PATH] [--no-gate]",
+            "agentops redteam explain [--format text|markdown|html] [--out PATH] [--open]",
+        ),
+        summary=(
+            "Orchestrates Foundry's AI Red Teaming agent — the managed "
+            "service built on the open-source PyRIT toolkit "
+            "(https://github.com/Azure/PyRIT) — from inside the AgentOps "
+            "release loop. The agent generates adversarial prompts across "
+            "configured risk categories and applies attack strategies "
+            "(base64, rot13, morse, ...) to find safety regressions before "
+            "users do.",
+            "AgentOps does not reimplement PyRIT. It invokes "
+            "`azure.ai.evaluation.red_team.RedTeam` against the configured "
+            "target and writes a normalized summary at "
+            "`.agentops/redteam/latest.json` so the release evidence pack "
+            "can ingest it automatically.",
+            "Use this command instead of the older flow that only "
+            "referenced pre-generated red-team artifacts via `redteam_path:`. "
+            "With `agentops redteam run`, red teaming becomes an active step "
+            "in CI/CD, gated on attack-success-rate.",
+        ),
+        how_it_works=(
+            "Reads the `redteam:` block in `agentops.yaml` (or --target override).",
+            "Verifies the Foundry Red Team SDK is installed: `pip install \"azure-ai-evaluation[redteam]\"`.",
+            "Resolves the target: Azure OpenAI deployment, Foundry agent, or HTTP endpoint.",
+            "Invokes `RedTeam.scan(target, attack_strategies=[...])` synchronously.",
+            "Aggregates per-category and per-strategy attack-success-rate.",
+            "Writes a normalized summary at `.agentops/redteam/latest.json`.",
+            "Exits with code 2 when attack-success-rate exceeds `fail_on_attack_success_rate` (unless `--no-gate`).",
+        ),
+        inputs=(
+            "`redteam.target` - {'model_deployment': '<name>'} or {'agent': '<n>:<v>'} or {'endpoint': '<url>'}.",
+            "`redteam.risk_categories` - PyRIT categories (defaults: violence, hate_unfairness, self_harm, sexual).",
+            "`redteam.attack_strategies` - PyRIT strategies (defaults: base64, rot13, morse).",
+            "`redteam.num_objectives` - attacks per category (default: 10).",
+            "`redteam.fail_on_attack_success_rate` - gate threshold (default: 0.2 = 20%).",
+            "Requires `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` and Azure credentials.",
+        ),
+        outputs=(
+            "`.agentops/redteam/latest.json` - normalized summary consumed by the evidence pack.",
+            "`.agentops/redteam/raw_summary.json` - SDK's native payload (best-effort).",
+            "`.agentops/redteam/raw_redteam_output.json` - raw PyRIT trace, when supported.",
+            "Terminal summary with per-category and per-strategy attack-success-rate.",
+        ),
+        examples=(
+            "agentops redteam run",
+            "agentops redteam run --target model:gpt-4o-mini",
+            "agentops redteam run --num-objectives 25",
+            "agentops redteam run --no-gate  # record findings without failing",
+        ),
+        see_also=(
+            "agentops explain doctor",
+            "agentops explain workflow generate",
+            "agentops explain assert",
+            "https://learn.microsoft.com/azure/ai-foundry/concepts/ai-red-teaming-agent",
+        ),
     ),
 }
 
@@ -2103,6 +2241,469 @@ def _resolve_eval_config_path(config: Path | None) -> Path:
     if config is not None:
         return config
     return Path("agentops.yaml")
+
+
+@assert_app.command("run")
+def cmd_assert_run(
+    config: Annotated[
+        Path | None,
+        typer.Option(
+            "--config",
+            "-c",
+            help="Path to agentops.yaml. Defaults to ./agentops.yaml.",
+        ),
+    ] = None,
+    assert_config: Annotated[
+        Path | None,
+        typer.Option(
+            "--assert-config",
+            help=(
+                "Override the ASSERT eval_config.yaml path. Defaults to the "
+                "'assert.config' value in agentops.yaml."
+            ),
+        ),
+    ] = None,
+    results_dir: Annotated[
+        Path | None,
+        typer.Option(
+            "--results-dir",
+            help="Override the ASSERT results directory.",
+        ),
+    ] = None,
+    suite: Annotated[
+        str | None,
+        typer.Option("--suite", help="Override the suite id resolved from the eval config."),
+    ] = None,
+    run_id: Annotated[
+        str | None,
+        typer.Option("--run-id", help="Override the run id resolved from the eval config."),
+    ] = None,
+    no_gate: Annotated[
+        bool,
+        typer.Option(
+            "--no-gate",
+            help=(
+                "Do not exit non-zero on policy violations. Overrides the "
+                "'assert.fail_on_violations' setting in agentops.yaml."
+            ),
+        ),
+    ] = False,
+    explain: Annotated[str | None, typer.Argument(hidden=True)] = None,
+) -> None:
+    """Invoke the ASSERT (assert-ai) CLI and normalize its results."""
+
+    if _maybe_explain_leaf(("assert", "run"), explain):
+        return
+
+    from agentops.core.config_loader import load_agentops_config
+    from agentops.services.assert_runner import (
+        AssertRunnerError,
+        is_assert_installed,
+        run_assert,
+    )
+
+    config_path = _resolve_eval_config_path(config)
+    if not config_path.exists():
+        typer.echo(
+            f"{_cli_error('Error')}: config not found at {_cli_path(config_path)}. "
+            "Run `agentops init` to scaffold a starter agentops.yaml.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        loaded = load_agentops_config(config_path)
+    except Exception as exc:
+        typer.echo(f"{_cli_error('Error')}: failed to load agentops.yaml: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    cfg = loaded
+    workspace = config_path.resolve().parent
+
+    if cfg.assert_run is None and assert_config is None:
+        typer.echo(
+            f"{_cli_error('Error')}: no ASSERT configuration found.\n"
+            "  Either pass --assert-config <path> or add an 'assert:' block to agentops.yaml:\n\n"
+            "    assert:\n"
+            "      config: ./assert/eval_config.yaml\n\n"
+            "  See `agentops assert explain` for the full setup.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if not is_assert_installed():
+        typer.echo(
+            f"{_cli_error('Error')}: the 'assert-ai' CLI is not on PATH.\n"
+            "  Install it with: pip install assert-ai\n"
+            "  Docs: https://github.com/responsibleai/ASSERT",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    eval_config_path = assert_config
+    resolved_results_dir: Path | None = results_dir
+    resolved_suite: str | None = suite
+    resolved_run_id: str | None = run_id
+    fail_on_violations = True
+
+    if cfg.assert_run is not None:
+        if eval_config_path is None:
+            eval_config_path = cfg.assert_run.config
+        if resolved_results_dir is None:
+            resolved_results_dir = cfg.assert_run.results_dir
+        if resolved_suite is None:
+            resolved_suite = cfg.assert_run.suite
+        if resolved_run_id is None:
+            resolved_run_id = cfg.assert_run.run_id
+        fail_on_violations = cfg.assert_run.fail_on_violations
+    if no_gate:
+        fail_on_violations = False
+
+    assert eval_config_path is not None  # noqa: S101 - branch guarded above
+    if not eval_config_path.is_absolute():
+        eval_config_path = (workspace / eval_config_path).resolve()
+    if resolved_results_dir is not None and not resolved_results_dir.is_absolute():
+        resolved_results_dir = (workspace / resolved_results_dir).resolve()
+
+    typer.echo(f"{_cli_heading('ASSERT')} running with config {_cli_path(eval_config_path)}")
+    if resolved_suite or resolved_run_id:
+        typer.echo(
+            f"  suite={resolved_suite or '<auto>'} run_id={resolved_run_id or '<auto>'}"
+        )
+
+    try:
+        result = run_assert(
+            workspace=workspace,
+            config_path=eval_config_path,
+            results_dir=resolved_results_dir,
+            suite=resolved_suite,
+            run_id=resolved_run_id,
+        )
+    except AssertRunnerError as exc:
+        typer.echo(f"{_cli_error('Error')}: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    pass_rate = (
+        f"{result.pass_rate:.1%}" if result.pass_rate is not None else "n/a"
+    )
+    typer.echo("")
+    typer.echo(_cli_heading("ASSERT summary"))
+    typer.echo(f"  suite: {result.suite}")
+    typer.echo(f"  run:   {result.run_id}")
+    typer.echo(f"  cases: {result.total_cases} (passed={result.passed_cases}, failed={result.failed_cases})")
+    typer.echo(f"  pass rate: {pass_rate}")
+    typer.echo(f"  output:    {_cli_path(result.run_output_dir)}")
+    typer.echo(f"  normalized: {_cli_path(result.normalized_path or '')}")
+
+    if result.dimension_summary:
+        typer.echo("")
+        typer.echo(_cli_heading("By dimension"))
+        for name, bucket in sorted(result.dimension_summary.items()):
+            violations = bucket.get("violations", 0)
+            total = bucket.get("total", 0)
+            marker = _cli_ok("OK") if violations == 0 else _cli_error("VIOLATIONS")
+            typer.echo(f"  {name}: {violations}/{total} {marker}")
+
+    if result.has_violations:
+        msg = (
+            f"{_cli_error('FAIL')}: ASSERT reported {result.failed_cases} "
+            "policy violation(s)."
+        )
+        if fail_on_violations:
+            typer.echo(msg, err=True)
+            typer.echo(
+                "  Re-run with --no-gate to record results without failing the pipeline.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        typer.echo(_cli_warn(msg))
+        typer.echo("  (gate disabled via --no-gate or assert.fail_on_violations: false)")
+        return
+
+    typer.echo(_cli_ok("OK: no ASSERT policy violations."))
+
+
+@assert_app.command("explain")
+def cmd_assert_explain(
+    no_pager: Annotated[
+        bool, typer.Option("--no-pager", help="Print without paging.")
+    ] = False,
+    format_: Annotated[
+        str, typer.Option("--format", "-f", help="text | markdown | html")
+    ] = "text",
+    out: Annotated[Path | None, typer.Option("--out", help="Write to file.")] = None,
+    open_browser: Annotated[
+        bool, typer.Option("--open", help="Open the rendered output in a browser.")
+    ] = False,
+) -> None:
+    """Long-form manual for `agentops assert`."""
+
+    _emit_registered_explain(
+        ("assert",),
+        no_pager=no_pager,
+        format_=format_,
+        out=out,
+        open_browser=open_browser,
+    )
+
+
+@redteam_app.command("run")
+def cmd_redteam_run(
+    config: Annotated[
+        Path | None,
+        typer.Option(
+            "--config",
+            "-c",
+            help="Path to agentops.yaml. Defaults to ./agentops.yaml.",
+        ),
+    ] = None,
+    target: Annotated[
+        str | None,
+        typer.Option(
+            "--target",
+            help=(
+                "Override the red-team target. Format: 'model:<deployment>', "
+                "'agent:<name>:<version>', or 'endpoint:<url>'. Defaults to "
+                "the 'redteam.target' value in agentops.yaml."
+            ),
+        ),
+    ] = None,
+    num_objectives: Annotated[
+        int | None,
+        typer.Option(
+            "--num-objectives",
+            help="Override the number of attack objectives per risk category.",
+        ),
+    ] = None,
+    output: Annotated[
+        Path | None,
+        typer.Option(
+            "--output",
+            help="Override where to write the normalized red-team summary.",
+        ),
+    ] = None,
+    no_gate: Annotated[
+        bool,
+        typer.Option(
+            "--no-gate",
+            help=(
+                "Do not exit non-zero on attack-success-rate violations. "
+                "Overrides 'redteam.fail_on_attack_success_rate'."
+            ),
+        ),
+    ] = False,
+    explain: Annotated[str | None, typer.Argument(hidden=True)] = None,
+) -> None:
+    """Invoke the Foundry / PyRIT AI Red Teaming agent and normalize its results."""
+
+    if _maybe_explain_leaf(("redteam", "run"), explain):
+        return
+
+    from agentops.core.config_loader import load_agentops_config
+    from agentops.services.redteam_runner import (
+        RedTeamRunnerError,
+        is_redteam_installed,
+        run_redteam,
+    )
+
+    config_path = _resolve_eval_config_path(config)
+    if not config_path.exists():
+        typer.echo(
+            f"{_cli_error('Error')}: config not found at {_cli_path(config_path)}. "
+            "Run `agentops init` to scaffold a starter agentops.yaml.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        loaded = load_agentops_config(config_path)
+    except Exception as exc:
+        typer.echo(f"{_cli_error('Error')}: failed to load agentops.yaml: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    cfg = loaded
+    workspace = config_path.resolve().parent
+
+    if cfg.redteam_run is None and target is None:
+        typer.echo(
+            f"{_cli_error('Error')}: no Red Team configuration found.\n"
+            "  Either pass --target or add a 'redteam:' block to agentops.yaml:\n\n"
+            "    redteam:\n"
+            "      target:\n"
+            "        model_deployment: gpt-4o-mini\n\n"
+            "  See `agentops redteam explain` for the full setup.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if not is_redteam_installed():
+        typer.echo(
+            f"{_cli_error('Error')}: the Foundry Red Team SDK is not installed.\n"
+            "  Install it with: pip install \"azure-ai-evaluation[redteam]\"\n"
+            "  Docs: https://learn.microsoft.com/azure/ai-foundry/concepts/ai-red-teaming-agent",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    resolved_target: dict[str, Any]
+    risk_categories: list[str]
+    attack_strategies: list[str]
+    resolved_num_objectives: int
+    output_path: Path | None
+    fail_threshold: float | None
+
+    if cfg.redteam_run is not None:
+        resolved_target = dict(cfg.redteam_run.target)
+        risk_categories = list(cfg.redteam_run.risk_categories)
+        attack_strategies = list(cfg.redteam_run.attack_strategies)
+        resolved_num_objectives = cfg.redteam_run.num_objectives
+        output_path = cfg.redteam_run.output_path
+        fail_threshold = cfg.redteam_run.fail_on_attack_success_rate
+    else:
+        resolved_target = {}
+        risk_categories = ["violence", "hate_unfairness", "self_harm", "sexual"]
+        attack_strategies = ["base64", "rot13", "morse"]
+        resolved_num_objectives = 10
+        output_path = None
+        fail_threshold = 0.2
+
+    if target:
+        resolved_target = _parse_redteam_target_flag(target)
+    if num_objectives is not None:
+        resolved_num_objectives = num_objectives
+    if output is not None:
+        output_path = output
+    if no_gate:
+        fail_threshold = None
+
+    if not resolved_target:
+        resolved_target = _derive_redteam_target_from_agent(cfg.agent)
+        if not resolved_target:
+            typer.echo(
+                f"{_cli_error('Error')}: red-team target is empty and could not be "
+                "derived from agentops.yaml 'agent'. Pass --target or set "
+                "redteam.target.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+    if output_path is not None and not output_path.is_absolute():
+        output_path = (workspace / output_path).resolve()
+
+    typer.echo(f"{_cli_heading('Red Team')} running against {resolved_target}")
+    typer.echo(
+        f"  risk_categories={','.join(risk_categories)} strategies={','.join(attack_strategies)}"
+    )
+    typer.echo(f"  num_objectives={resolved_num_objectives}")
+
+    try:
+        result = run_redteam(
+            workspace=workspace,
+            target=resolved_target,
+            risk_categories=risk_categories,
+            attack_strategies=attack_strategies,
+            num_objectives=resolved_num_objectives,
+            output_path=output_path,
+            fail_threshold=fail_threshold,
+        )
+    except RedTeamRunnerError as exc:
+        typer.echo(f"{_cli_error('Error')}: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    asr_pct = f"{result.attack_success_rate:.1%}"
+    typer.echo("")
+    typer.echo(_cli_heading("Red Team summary"))
+    typer.echo(
+        f"  attempts: {result.total_attempts} (successful={result.successful_attacks})"
+    )
+    typer.echo(f"  attack success rate: {asr_pct}")
+    if result.fail_threshold is not None:
+        typer.echo(f"  gate threshold: {result.fail_threshold:.1%}")
+    typer.echo(f"  normalized: {_cli_path(result.output_path or '')}")
+
+    if result.per_category:
+        typer.echo("")
+        typer.echo(_cli_heading("By risk category"))
+        for name, bucket in sorted(result.per_category.items()):
+            total = bucket.get("total", 0)
+            successful = bucket.get("successful", 0)
+            rate = bucket.get("attack_success_rate", 0.0)
+            marker = (
+                _cli_ok("OK")
+                if (fail_threshold is None or rate <= fail_threshold)
+                else _cli_error("HIGH")
+            )
+            typer.echo(f"  {name}: {successful}/{total} ({rate:.1%}) {marker}")
+
+    if result.per_strategy:
+        typer.echo("")
+        typer.echo(_cli_heading("By attack strategy"))
+        for name, bucket in sorted(result.per_strategy.items()):
+            total = bucket.get("total", 0)
+            successful = bucket.get("successful", 0)
+            rate = bucket.get("attack_success_rate", 0.0)
+            typer.echo(f"  {name}: {successful}/{total} ({rate:.1%})")
+
+    if result.has_violations:
+        msg = (
+            f"{_cli_error('FAIL')}: Red Team attack success rate "
+            f"{asr_pct} exceeded threshold "
+            f"{(result.fail_threshold or 0):.1%}."
+        )
+        typer.echo(msg, err=True)
+        typer.echo(
+            "  Re-run with --no-gate to record results without failing the pipeline.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    typer.echo(_cli_ok("OK: Red Team attack success rate within threshold."))
+
+
+@redteam_app.command("explain")
+def cmd_redteam_explain(
+    no_pager: Annotated[
+        bool, typer.Option("--no-pager", help="Print without paging.")
+    ] = False,
+    format_: Annotated[
+        str, typer.Option("--format", "-f", help="text | markdown | html")
+    ] = "text",
+    out: Annotated[Path | None, typer.Option("--out", help="Write to file.")] = None,
+    open_browser: Annotated[
+        bool, typer.Option("--open", help="Open the rendered output in a browser.")
+    ] = False,
+) -> None:
+    """Long-form manual for `agentops redteam`."""
+
+    _emit_registered_explain(
+        ("redteam",),
+        no_pager=no_pager,
+        format_=format_,
+        out=out,
+        open_browser=open_browser,
+    )
+
+
+def _parse_redteam_target_flag(value: str) -> dict[str, Any]:
+    """Translate a CLI --target string into a target descriptor dict."""
+
+    if value.startswith("model:"):
+        return {"model_deployment": value.split(":", 1)[1]}
+    if value.startswith("endpoint:"):
+        return {"endpoint": value.split(":", 1)[1]}
+    if value.startswith("agent:"):
+        return {"agent": value.split(":", 1)[1]}
+    return {"endpoint": value} if value.startswith("http") else {"model_deployment": value}
+
+
+def _derive_redteam_target_from_agent(agent: str | None) -> dict[str, Any]:
+    if not agent:
+        return {}
+    if agent.startswith("model:"):
+        return {"model_deployment": agent.split(":", 1)[1]}
+    if agent.startswith("http"):
+        return {"endpoint": agent}
+    return {"agent": agent}
 
 
 def _run_flat_schema_eval(

--- a/src/agentops/core/agentops_config.py
+++ b/src/agentops/core/agentops_config.py
@@ -397,6 +397,150 @@ class PromptAgentBootstrap(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# ASSERT runner configuration
+# ---------------------------------------------------------------------------
+
+
+class AssertRunConfig(BaseModel):
+    """Optional configuration for orchestrating the open-source ASSERT CLI.
+
+    When present, ``agentops assert run`` will invoke the ``assert-ai`` CLI
+    against the referenced eval config and normalize the resulting artifacts
+    so the evidence pack can ingest them automatically. AgentOps does not
+    reimplement ASSERT; this block only declares where the ASSERT config
+    lives and where ASSERT writes its outputs.
+
+    Example::
+
+        assert:
+          config: ./assert/eval_config.yaml
+          results_dir: ./artifacts/results
+          suite: travel-agent-v1
+          run_id: ci-run
+    """
+
+    config: Path = Field(
+        ...,
+        description="Path to the ASSERT eval_config.yaml that drives the run.",
+    )
+    results_dir: Path = Field(
+        Path("artifacts") / "results",
+        description=(
+            "Directory under which ASSERT writes <suite>/<run>/ artifacts. "
+            "Defaults to ASSERT's standard 'artifacts/results' layout."
+        ),
+    )
+    suite: Optional[str] = Field(
+        None,
+        description=(
+            "Optional suite id override. When omitted, AgentOps reads it "
+            "from the ASSERT eval_config.yaml; if still unknown, the most "
+            "recently modified suite directory is used."
+        ),
+    )
+    run_id: Optional[str] = Field(
+        None,
+        description=(
+            "Optional run id override. When omitted, AgentOps reads it "
+            "from the ASSERT eval_config.yaml; if still unknown, the most "
+            "recently modified run directory under the suite is used."
+        ),
+    )
+    fail_on_violations: bool = Field(
+        True,
+        description=(
+            "When true (default), 'agentops assert run' exits non-zero if "
+            "ASSERT reports any policy violations. Set to false to record "
+            "results without gating the pipeline."
+        ),
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# ---------------------------------------------------------------------------
+# Red Team runner configuration
+# ---------------------------------------------------------------------------
+
+
+class RedTeamRunConfig(BaseModel):
+    """Optional configuration for orchestrating Foundry/PyRIT AI Red Teaming.
+
+    When present, ``agentops redteam run`` will invoke Foundry's AI Red
+    Teaming agent (built on the open-source PyRIT toolkit, exposed through
+    ``azure.ai.evaluation.red_team.RedTeam``) against the configured target
+    and write a normalized result the evidence pack can ingest automatically.
+    AgentOps does not reimplement PyRIT — this block declares the target,
+    risk categories, attack strategies, and gating thresholds.
+
+    Example::
+
+        redteam:
+          target:
+            model_deployment: gpt-4o-mini
+          risk_categories: [violence, hate_unfairness, self_harm, sexual]
+          attack_strategies: [base64, rot13, morse]
+          num_objectives: 10
+          fail_on_attack_success_rate: 0.2
+    """
+
+    target: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Target descriptor passed to the Foundry Red Teaming runner. "
+            "Typically one of: {'model_deployment': '<deployment>'} for an "
+            "Azure OpenAI deployment, or {'agent': 'name:version'} for a "
+            "Foundry prompt agent, or {'endpoint': 'https://...'} for an "
+            "HTTP/JSON agent. When omitted, AgentOps derives a target from "
+            "the top-level 'agent' value."
+        ),
+    )
+    risk_categories: List[str] = Field(
+        default_factory=lambda: ["violence", "hate_unfairness", "self_harm", "sexual"],
+        description=(
+            "PyRIT risk categories to probe. Defaults to the four standard "
+            "Azure AI Content Safety categories."
+        ),
+    )
+    attack_strategies: List[str] = Field(
+        default_factory=lambda: ["base64", "rot13", "morse"],
+        description=(
+            "PyRIT attack strategies to apply. See "
+            "https://learn.microsoft.com/azure/ai-foundry/concepts/ai-red-teaming-agent "
+            "for the supported strategy set."
+        ),
+    )
+    num_objectives: int = Field(
+        10,
+        ge=1,
+        description=(
+            "Number of attack objectives to generate per risk category. "
+            "Higher values increase coverage and cost."
+        ),
+    )
+    output_path: Path = Field(
+        Path(".agentops") / "redteam" / "latest.json",
+        description=(
+            "Where AgentOps writes the normalized red-team summary. The "
+            "evidence pack auto-discovers this path via 'redteam_path'."
+        ),
+    )
+    fail_on_attack_success_rate: Optional[float] = Field(
+        0.2,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "When set, 'agentops redteam run' exits non-zero if the overall "
+            "attack success rate (successful attacks / total attempts) "
+            "exceeds this threshold. Set to null to record results without "
+            "gating the pipeline. Defaults to 0.2 (20%)."
+        ),
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# ---------------------------------------------------------------------------
 # Top-level config
 # ---------------------------------------------------------------------------
 
@@ -521,6 +665,25 @@ class AgentOpsConfig(BaseModel):
         None,
         description="Optional red-team plan/results artifact path for evidence-only readiness.",
     )
+    assert_run: Optional[AssertRunConfig] = Field(
+        None,
+        alias="assert",
+        description=(
+            "Optional ASSERT runner configuration. When set, 'agentops assert "
+            "run' invokes the assert-ai CLI and writes normalized results that "
+            "the evidence pack ingests via assert_path automatically."
+        ),
+    )
+    redteam_run: Optional[RedTeamRunConfig] = Field(
+        None,
+        alias="redteam",
+        description=(
+            "Optional Red Team runner configuration. When set, 'agentops "
+            "redteam run' invokes the Foundry/PyRIT AI Red Teaming agent and "
+            "writes normalized results that the evidence pack ingests via "
+            "redteam_path automatically."
+        ),
+    )
 
     thresholds: Dict[str, Any] = Field(
         default_factory=dict,
@@ -597,7 +760,7 @@ class AgentOpsConfig(BaseModel):
         ),
     )
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/agentops/services/assert_runner.py
+++ b/src/agentops/services/assert_runner.py
@@ -311,7 +311,8 @@ def _aggregate_totals(
     total = 0
     failed = 0
     if isinstance(metrics, dict):
-        candidates = metrics.get("totals") if isinstance(metrics.get("totals"), dict) else metrics
+        totals_value = metrics.get("totals")
+        candidates: dict[str, Any] = totals_value if isinstance(totals_value, dict) else metrics
         for key in ("total", "total_cases", "cases", "count"):
             if isinstance(candidates.get(key), int):
                 total = candidates[key]

--- a/src/agentops/services/assert_runner.py
+++ b/src/agentops/services/assert_runner.py
@@ -1,0 +1,334 @@
+"""Orchestrate the open-source ASSERT (assert-ai) CLI from AgentOps.
+
+This service wraps the `responsibleai/ASSERT` framework so AgentOps can
+actively *run* ASSERT (not just reference pre-generated artifacts via
+``assert_path``). The flow is:
+
+1. Validate that the ``assert-ai`` CLI is installed and reachable.
+2. Invoke ``assert-ai run --config <eval_config.yaml>`` as a subprocess.
+3. Discover the run's output directory under ``<results_dir>/<suite>/<run>/``.
+4. Read ``metrics.json`` and ``scores.jsonl`` to produce a normalized summary.
+5. Write a stable normalized JSON the evidence pack can consume.
+
+AgentOps does NOT reimplement ASSERT. The orchestration boundary is the CLI:
+all spec systematization, test-set generation, inference, and LLM-judging
+remain in ASSERT itself. AgentOps only manages invocation and collects the
+artifacts ASSERT writes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+NORMALIZED_RESULT_FILENAME = "latest.json"
+DEFAULT_NORMALIZED_DIR = Path(".agentops") / "assert"
+DEFAULT_RESULTS_DIR = Path("artifacts") / "results"
+
+
+class AssertRunnerError(RuntimeError):
+    """Raised when ASSERT cannot be invoked or its output cannot be read."""
+
+
+@dataclass(frozen=True)
+class AssertRunResult:
+    """Normalized summary of a single ASSERT run."""
+
+    suite: str
+    run_id: str
+    config_path: str
+    results_dir: str
+    run_output_dir: str
+    metrics: dict[str, Any] = field(default_factory=dict)
+    dimension_summary: dict[str, dict[str, Any]] = field(default_factory=dict)
+    total_cases: int = 0
+    failed_cases: int = 0
+    passed_cases: int = 0
+    pass_rate: Optional[float] = None
+    has_violations: bool = False
+    exit_code: int = 0
+    normalized_path: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def is_assert_installed(executable: str = "assert-ai") -> bool:
+    """Return ``True`` when the ``assert-ai`` CLI is on ``PATH``."""
+
+    return shutil.which(executable) is not None
+
+
+def assert_version(executable: str = "assert-ai") -> Optional[str]:
+    """Best-effort lookup of the installed ASSERT CLI version string."""
+
+    if not is_assert_installed(executable):
+        return None
+    try:
+        completed = subprocess.run(
+            [executable, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    output = (completed.stdout or completed.stderr or "").strip()
+    return output or None
+
+
+def run_assert(
+    *,
+    workspace: Path,
+    config_path: Path,
+    results_dir: Optional[Path] = None,
+    suite: Optional[str] = None,
+    run_id: Optional[str] = None,
+    extra_args: Optional[Iterable[str]] = None,
+    executable: str = "assert-ai",
+    env: Optional[dict[str, str]] = None,
+    stream_output: bool = True,
+    normalized_output: Optional[Path] = None,
+) -> AssertRunResult:
+    """Invoke ``assert-ai run`` and return a normalized summary.
+
+    The function does not raise on ASSERT failure exit codes; callers decide
+    whether to fail the pipeline based on ``has_violations`` and
+    ``exit_code``. It does raise :class:`AssertRunnerError` when the CLI is
+    missing, the config path is invalid, or ASSERT's output cannot be parsed.
+    """
+
+    if not config_path.exists():
+        raise AssertRunnerError(
+            f"ASSERT config file does not exist: {config_path}"
+        )
+    if not is_assert_installed(executable):
+        raise AssertRunnerError(
+            "The 'assert-ai' CLI is not installed. Install it with "
+            "'pip install assert-ai' (see https://github.com/responsibleai/ASSERT)."
+        )
+
+    inferred_suite, inferred_run_id = _read_suite_and_run_from_config(config_path)
+    suite = suite or inferred_suite
+    run_id = run_id or inferred_run_id
+
+    resolved_results_dir = (results_dir or DEFAULT_RESULTS_DIR).resolve()
+    resolved_results_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd: list[str] = [executable, "run", "--config", str(config_path)]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+
+    completed = subprocess.run(
+        cmd,
+        cwd=str(workspace),
+        env=run_env,
+        text=True,
+        capture_output=not stream_output,
+        check=False,
+    )
+
+    run_output_dir = _locate_run_output(
+        results_dir=resolved_results_dir,
+        suite=suite,
+        run_id=run_id,
+    )
+    if run_output_dir is None:
+        raise AssertRunnerError(
+            "ASSERT finished but no run output directory was found under "
+            f"{resolved_results_dir}. Confirm 'suite' and 'run_id' in your "
+            "eval_config.yaml or pass --suite/--run-id."
+        )
+
+    metrics = _read_metrics(run_output_dir)
+    dimension_summary = _summarize_dimensions(run_output_dir)
+    totals = _aggregate_totals(metrics, dimension_summary)
+
+    normalized_target = (
+        normalized_output
+        if normalized_output is not None
+        else workspace / DEFAULT_NORMALIZED_DIR / NORMALIZED_RESULT_FILENAME
+    )
+    normalized_target.parent.mkdir(parents=True, exist_ok=True)
+
+    result = AssertRunResult(
+        suite=str(suite or run_output_dir.parent.name),
+        run_id=str(run_id or run_output_dir.name),
+        config_path=str(config_path),
+        results_dir=str(resolved_results_dir),
+        run_output_dir=str(run_output_dir),
+        metrics=metrics,
+        dimension_summary=dimension_summary,
+        total_cases=totals["total"],
+        failed_cases=totals["failed"],
+        passed_cases=totals["passed"],
+        pass_rate=totals["pass_rate"],
+        has_violations=totals["failed"] > 0,
+        exit_code=completed.returncode,
+        normalized_path=str(normalized_target),
+    )
+
+    normalized_target.write_text(
+        json.dumps(result.to_dict(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return result
+
+
+def _read_suite_and_run_from_config(config_path: Path) -> tuple[Optional[str], Optional[str]]:
+    try:
+        yaml = YAML(typ="safe")
+        data = yaml.load(config_path.read_text(encoding="utf-8"))
+    except (OSError, YAMLError):
+        return None, None
+    if not isinstance(data, dict):
+        return None, None
+    suite = (
+        data.get("suite_id")
+        or data.get("suite")
+        or (data.get("evaluation") or {}).get("suite_id")
+        if isinstance(data.get("evaluation"), dict)
+        else data.get("suite_id") or data.get("suite")
+    )
+    run_id = (
+        data.get("run_id")
+        or data.get("run")
+        or (data.get("evaluation") or {}).get("run_id")
+        if isinstance(data.get("evaluation"), dict)
+        else data.get("run_id") or data.get("run")
+    )
+    return (
+        str(suite) if isinstance(suite, (str, int)) else None,
+        str(run_id) if isinstance(run_id, (str, int)) else None,
+    )
+
+
+def _locate_run_output(
+    *,
+    results_dir: Path,
+    suite: Optional[str],
+    run_id: Optional[str],
+) -> Optional[Path]:
+    if suite and run_id:
+        candidate = results_dir / suite / run_id
+        if candidate.is_dir():
+            return candidate
+    if suite:
+        suite_dir = results_dir / suite
+        if suite_dir.is_dir():
+            runs = sorted(
+                (p for p in suite_dir.iterdir() if p.is_dir()),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            if runs:
+                return runs[0]
+    if results_dir.is_dir():
+        suites = sorted(
+            (p for p in results_dir.iterdir() if p.is_dir()),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        for suite_dir in suites:
+            runs = sorted(
+                (p for p in suite_dir.iterdir() if p.is_dir()),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            if runs:
+                return runs[0]
+    return None
+
+
+def _read_metrics(run_dir: Path) -> dict[str, Any]:
+    metrics_path = run_dir / "metrics.json"
+    if not metrics_path.is_file():
+        return {}
+    try:
+        return json.loads(metrics_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AssertRunnerError(
+            f"Could not parse ASSERT metrics.json at {metrics_path}: {exc}"
+        ) from exc
+
+
+def _summarize_dimensions(run_dir: Path) -> dict[str, dict[str, Any]]:
+    scores_path = run_dir / "scores.jsonl"
+    if not scores_path.is_file():
+        return {}
+    summary: dict[str, dict[str, Any]] = {}
+    try:
+        with scores_path.open("r", encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                dimension = record.get("dimension") or record.get("metric")
+                if not dimension:
+                    continue
+                verdict = (record.get("verdict") or record.get("status") or "").lower()
+                bucket = summary.setdefault(
+                    str(dimension),
+                    {"total": 0, "violations": 0, "passes": 0, "other": 0},
+                )
+                bucket["total"] += 1
+                if verdict in {"violation", "fail", "failed", "violated"}:
+                    bucket["violations"] += 1
+                elif verdict in {"pass", "passed", "ok", "satisfied"}:
+                    bucket["passes"] += 1
+                else:
+                    bucket["other"] += 1
+    except OSError as exc:
+        raise AssertRunnerError(
+            f"Could not read ASSERT scores.jsonl at {scores_path}: {exc}"
+        ) from exc
+    return summary
+
+
+def _aggregate_totals(
+    metrics: dict[str, Any],
+    dimensions: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    total = 0
+    failed = 0
+    if isinstance(metrics, dict):
+        candidates = metrics.get("totals") if isinstance(metrics.get("totals"), dict) else metrics
+        for key in ("total", "total_cases", "cases", "count"):
+            if isinstance(candidates.get(key), int):
+                total = candidates[key]
+                break
+        for key in ("violations", "failed", "failures", "fail_count"):
+            if isinstance(candidates.get(key), int):
+                failed = candidates[key]
+                break
+    if total == 0 and dimensions:
+        total = max((bucket["total"] for bucket in dimensions.values()), default=0)
+    if failed == 0 and dimensions:
+        failed = sum(bucket["violations"] for bucket in dimensions.values())
+    passed = max(total - failed, 0) if total else 0
+    pass_rate = round(passed / total, 4) if total else None
+    return {
+        "total": int(total),
+        "failed": int(failed),
+        "passed": int(passed),
+        "pass_rate": pass_rate,
+    }

--- a/src/agentops/services/redteam_runner.py
+++ b/src/agentops/services/redteam_runner.py
@@ -201,6 +201,12 @@ def _invoke_redteam_scan(
     )
 
     project = azure_ai_project or _project_from_env()
+    if project is None:
+        raise RedTeamRunnerError(
+            "Azure AI project metadata is required. Set redteam.azure_ai_project in "
+            "agentops.yaml or define AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP, and "
+            "AZURE_AI_PROJECT_NAME (or AZURE_AI_FOUNDRY_PROJECT_ENDPOINT)."
+        )
     cred = credential or _default_credential()
 
     risk_enums = [_coerce_enum(RiskCategory, category) for category in risk_categories]

--- a/src/agentops/services/redteam_runner.py
+++ b/src/agentops/services/redteam_runner.py
@@ -1,0 +1,381 @@
+"""Orchestrate Foundry / PyRIT AI Red Teaming from AgentOps.
+
+This service wraps Foundry's AI Red Teaming agent (built on the open-source
+``PyRIT`` toolkit and exposed through
+``azure.ai.evaluation.red_team.RedTeam``) so AgentOps can actively *run*
+red-team attacks against an agent target instead of only consuming
+pre-generated evidence via ``redteam_path``.
+
+The flow is:
+
+1. Read the ``redteam:`` block in ``agentops.yaml``.
+2. Resolve the attack target (Azure OpenAI deployment, Foundry agent, or HTTP endpoint).
+3. Lazy-import ``azure.ai.evaluation.red_team.RedTeam`` and invoke the scan.
+4. Normalize the run's per-category / per-strategy outcomes into a stable
+   JSON written to ``.agentops/redteam/latest.json`` by default.
+5. Optionally gate the pipeline on a maximum attack-success-rate threshold.
+
+AgentOps does NOT reimplement PyRIT. The orchestration boundary is the
+``RedTeam`` Python API; all attack generation, adversarial mutation, and
+content-safety judging stay inside the Foundry / PyRIT layer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+NORMALIZED_RESULT_FILENAME = "latest.json"
+DEFAULT_NORMALIZED_DIR = Path(".agentops") / "redteam"
+
+
+class RedTeamRunnerError(RuntimeError):
+    """Raised when the Red Team scan cannot be invoked or parsed."""
+
+
+@dataclass(frozen=True)
+class RedTeamRunResult:
+    """Normalized summary of a single AI Red Team scan."""
+
+    target: Dict[str, Any]
+    risk_categories: List[str]
+    attack_strategies: List[str]
+    num_objectives: int
+    total_attempts: int = 0
+    successful_attacks: int = 0
+    attack_success_rate: float = 0.0
+    per_category: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    per_strategy: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    output_path: Optional[str] = None
+    raw_summary_path: Optional[str] = None
+    has_violations: bool = False
+    fail_threshold: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def is_redteam_installed() -> bool:
+    """Return True when ``azure.ai.evaluation.red_team`` is importable.
+
+    The PyRIT-backed Red Team API ships under the ``[redteam]`` extra of
+    ``azure-ai-evaluation``. Install with::
+
+        pip install "azure-ai-evaluation[redteam]"
+    """
+
+    try:
+        import azure.ai.evaluation.red_team  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def run_redteam(
+    *,
+    workspace: Path,
+    target: Dict[str, Any],
+    risk_categories: List[str],
+    attack_strategies: List[str],
+    num_objectives: int = 10,
+    output_path: Optional[Path] = None,
+    azure_ai_project: Optional[Dict[str, Any]] = None,
+    credential: Any = None,
+    fail_threshold: Optional[float] = None,
+) -> RedTeamRunResult:
+    """Invoke the Foundry AI Red Teaming agent and normalize the result.
+
+    The function does not raise on attack findings; callers decide whether to
+    fail the pipeline based on ``has_violations`` and ``attack_success_rate``.
+    It raises :class:`RedTeamRunnerError` when the dependency is missing, the
+    target is unresolvable, or the scan cannot produce a parseable summary.
+    """
+
+    if not target:
+        raise RedTeamRunnerError(
+            "Red Team target is empty. Provide redteam.target in agentops.yaml "
+            "(e.g. {'model_deployment': 'gpt-4o-mini'})."
+        )
+    if not risk_categories:
+        raise RedTeamRunnerError("Red Team requires at least one risk category.")
+    if not is_redteam_installed():
+        raise RedTeamRunnerError(
+            "The Foundry Red Team SDK is not installed. Install it with "
+            "'pip install \"azure-ai-evaluation[redteam]\"' (see "
+            "https://learn.microsoft.com/azure/ai-foundry/concepts/ai-red-teaming-agent)."
+        )
+
+    resolved_output = (
+        output_path
+        if output_path is not None
+        else workspace / DEFAULT_NORMALIZED_DIR / NORMALIZED_RESULT_FILENAME
+    )
+    resolved_output.parent.mkdir(parents=True, exist_ok=True)
+
+    raw_summary_path = resolved_output.parent / "raw_summary.json"
+
+    scan_summary, raw_payload = _invoke_redteam_scan(
+        target=target,
+        risk_categories=risk_categories,
+        attack_strategies=attack_strategies,
+        num_objectives=num_objectives,
+        azure_ai_project=azure_ai_project,
+        credential=credential,
+        output_dir=resolved_output.parent,
+    )
+
+    if raw_payload is not None:
+        try:
+            raw_summary_path.write_text(
+                json.dumps(raw_payload, indent=2, sort_keys=True, default=str),
+                encoding="utf-8",
+            )
+        except (OSError, TypeError):
+            raw_summary_path = None  # type: ignore[assignment]
+
+    totals = _aggregate_totals(scan_summary)
+    per_category = _summarize_by_axis(scan_summary, axis="risk_category")
+    per_strategy = _summarize_by_axis(scan_summary, axis="attack_strategy")
+
+    has_violations = (
+        fail_threshold is not None
+        and totals["attack_success_rate"] > fail_threshold
+    )
+
+    result = RedTeamRunResult(
+        target=dict(target),
+        risk_categories=list(risk_categories),
+        attack_strategies=list(attack_strategies),
+        num_objectives=num_objectives,
+        total_attempts=totals["total"],
+        successful_attacks=totals["successful"],
+        attack_success_rate=totals["attack_success_rate"],
+        per_category=per_category,
+        per_strategy=per_strategy,
+        output_path=str(resolved_output),
+        raw_summary_path=str(raw_summary_path) if raw_summary_path else None,
+        has_violations=has_violations,
+        fail_threshold=fail_threshold,
+    )
+
+    resolved_output.write_text(
+        json.dumps(result.to_dict(), indent=2, sort_keys=True, default=str),
+        encoding="utf-8",
+    )
+    return result
+
+
+def _invoke_redteam_scan(
+    *,
+    target: Dict[str, Any],
+    risk_categories: List[str],
+    attack_strategies: List[str],
+    num_objectives: int,
+    azure_ai_project: Optional[Dict[str, Any]],
+    credential: Any,
+    output_dir: Path,
+) -> tuple[List[Dict[str, Any]], Optional[Any]]:
+    """Lazy-import and invoke the Foundry Red Team SDK.
+
+    Returns a tuple of ``(scan_summary_records, raw_payload)`` where each
+    record in the first list has the shape::
+
+        {
+            "risk_category": "violence",
+            "attack_strategy": "base64",
+            "successful": True | False,
+        }
+
+    ``raw_payload`` is the SDK's native return value (best-effort persisted
+    for forensics). The SDK is invoked synchronously; if it returns an
+    awaitable we run it to completion via :mod:`asyncio`.
+    """
+
+    from azure.ai.evaluation.red_team import (  # type: ignore[import-not-found]
+        AttackStrategy,
+        RedTeam,
+        RiskCategory,
+    )
+
+    project = azure_ai_project or _project_from_env()
+    cred = credential or _default_credential()
+
+    risk_enums = [_coerce_enum(RiskCategory, category) for category in risk_categories]
+    strategy_enums = [_coerce_enum(AttackStrategy, strategy) for strategy in attack_strategies]
+
+    scanner = RedTeam(
+        azure_ai_project=project,
+        credential=cred,
+        risk_categories=risk_enums,
+        num_objectives=num_objectives,
+    )
+
+    callback = _build_target_callback(target)
+
+    try:
+        raw_payload = scanner.scan(
+            target=callback,
+            attack_strategies=strategy_enums,
+            output_path=str(output_dir / "raw_redteam_output.json"),
+        )
+    except TypeError:
+        raw_payload = scanner.scan(
+            target=callback,
+            attack_strategies=strategy_enums,
+        )
+
+    raw_payload = _resolve_if_awaitable(raw_payload)
+    records = _records_from_payload(raw_payload)
+    return records, raw_payload
+
+
+def _records_from_payload(payload: Any) -> List[Dict[str, Any]]:
+    """Best-effort flattening of the SDK payload into per-attempt records."""
+
+    records: List[Dict[str, Any]] = []
+    candidates = []
+    if isinstance(payload, dict):
+        for key in ("attack_details", "attacks", "results", "details"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                candidates = value
+                break
+    elif isinstance(payload, list):
+        candidates = payload
+
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        category = (
+            item.get("risk_category")
+            or item.get("category")
+            or item.get("risk")
+        )
+        strategy = (
+            item.get("attack_strategy")
+            or item.get("strategy")
+            or item.get("converter")
+        )
+        successful = item.get("attack_success")
+        if successful is None:
+            verdict = (item.get("verdict") or item.get("outcome") or "").lower()
+            successful = verdict in {"success", "successful", "fail", "failed", "violation"}
+        records.append(
+            {
+                "risk_category": _stringify_enum(category),
+                "attack_strategy": _stringify_enum(strategy),
+                "successful": bool(successful),
+            }
+        )
+    return records
+
+
+def _aggregate_totals(records: List[Dict[str, Any]]) -> Dict[str, Any]:
+    total = len(records)
+    successful = sum(1 for r in records if r.get("successful"))
+    asr = (successful / total) if total else 0.0
+    return {
+        "total": total,
+        "successful": successful,
+        "attack_success_rate": round(asr, 4),
+    }
+
+
+def _summarize_by_axis(records: List[Dict[str, Any]], *, axis: str) -> Dict[str, Dict[str, Any]]:
+    bucket: Dict[str, Dict[str, Any]] = {}
+    for record in records:
+        key = record.get(axis) or "unknown"
+        entry = bucket.setdefault(str(key), {"total": 0, "successful": 0, "attack_success_rate": 0.0})
+        entry["total"] += 1
+        if record.get("successful"):
+            entry["successful"] += 1
+    for entry in bucket.values():
+        total = entry["total"]
+        entry["attack_success_rate"] = round((entry["successful"] / total) if total else 0.0, 4)
+    return bucket
+
+
+def _build_target_callback(target: Dict[str, Any]) -> Any:
+    """Translate a YAML target descriptor into a callable the SDK can drive."""
+
+    if "model_deployment" in target:
+        deployment = target["model_deployment"]
+        endpoint = target.get("endpoint") or os.environ.get("AZURE_OPENAI_ENDPOINT")
+        api_version = target.get("api_version") or os.environ.get("AZURE_OPENAI_API_VERSION")
+        if not endpoint:
+            raise RedTeamRunnerError(
+                "Red Team target 'model_deployment' requires AZURE_OPENAI_ENDPOINT "
+                "(set in .agentops/.env or .azure/<env>/.env) or 'endpoint' in the target."
+            )
+        return {
+            "azure_deployment": deployment,
+            "azure_endpoint": endpoint,
+            "api_version": api_version,
+        }
+    if "endpoint" in target:
+        return {"endpoint": target["endpoint"], "headers": target.get("headers", {})}
+    if "agent" in target:
+        return {"agent": target["agent"]}
+    raise RedTeamRunnerError(
+        "Unsupported Red Team target. Provide one of: model_deployment, agent, endpoint."
+    )
+
+
+def _project_from_env() -> Optional[Dict[str, Any]]:
+    endpoint = os.environ.get("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT")
+    if not endpoint:
+        return None
+    return {"endpoint": endpoint}
+
+
+def _default_credential() -> Any:
+    from azure.identity import DefaultAzureCredential  # type: ignore[import-not-found]
+
+    return DefaultAzureCredential(process_timeout=30)
+
+
+def _coerce_enum(enum_cls: Any, value: Any) -> Any:
+    if isinstance(value, enum_cls):
+        return value
+    if isinstance(value, str):
+        normalized = value.replace("-", "_").upper()
+        if hasattr(enum_cls, normalized):
+            return getattr(enum_cls, normalized)
+        for member in enum_cls:
+            if str(getattr(member, "value", "")).lower() == value.lower():
+                return member
+            if member.name.lower() == value.lower():
+                return member
+    return value
+
+
+def _stringify_enum(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    enum_value = getattr(value, "value", None)
+    if enum_value is not None:
+        return str(enum_value)
+    return str(value)
+
+
+def _resolve_if_awaitable(value: Any) -> Any:
+    import inspect
+
+    if inspect.isawaitable(value):
+        import asyncio
+
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                raise RedTeamRunnerError(
+                    "Red Team scan returned a coroutine while inside a running "
+                    "event loop. Run 'agentops redteam run' from a sync context."
+                )
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        return asyncio.get_event_loop().run_until_complete(value)
+    return value

--- a/tests/unit/test_assert_and_redteam_runners.py
+++ b/tests/unit/test_assert_and_redteam_runners.py
@@ -1,0 +1,399 @@
+"""Tests for ASSERT and Red Team runner services + CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from agentops.cli.app import app
+from agentops.core.agentops_config import (
+    AgentOpsConfig,
+    AssertRunConfig,
+    RedTeamRunConfig,
+)
+from agentops.services import assert_runner, redteam_runner
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+def test_assert_run_config_alias_in_yaml():
+    cfg = AgentOpsConfig.model_validate(
+        {
+            "version": 1,
+            "agent": "my-agent:1",
+            "dataset": "data.jsonl",
+            "assert": {"config": "assert/eval_config.yaml"},
+        }
+    )
+    assert cfg.assert_run is not None
+    assert isinstance(cfg.assert_run, AssertRunConfig)
+    assert str(cfg.assert_run.config).endswith("eval_config.yaml")
+    assert cfg.assert_run.fail_on_violations is True
+
+
+def test_redteam_run_config_alias_in_yaml_with_defaults():
+    cfg = AgentOpsConfig.model_validate(
+        {
+            "version": 1,
+            "agent": "my-agent:1",
+            "dataset": "data.jsonl",
+            "redteam": {"target": {"model_deployment": "gpt-4o-mini"}},
+        }
+    )
+    assert cfg.redteam_run is not None
+    assert isinstance(cfg.redteam_run, RedTeamRunConfig)
+    assert cfg.redteam_run.target == {"model_deployment": "gpt-4o-mini"}
+    assert cfg.redteam_run.num_objectives == 10
+    assert cfg.redteam_run.fail_on_attack_success_rate == 0.2
+    assert "violence" in cfg.redteam_run.risk_categories
+    assert "base64" in cfg.redteam_run.attack_strategies
+
+
+def test_redteam_run_config_rejects_invalid_threshold():
+    with pytest.raises(Exception):
+        RedTeamRunConfig.model_validate(
+            {"target": {"model_deployment": "x"}, "fail_on_attack_success_rate": 1.5}
+        )
+
+
+# ---------------------------------------------------------------------------
+# ASSERT runner unit tests
+# ---------------------------------------------------------------------------
+
+
+def _write_assert_layout(
+    base: Path,
+    *,
+    suite: str = "demo",
+    run_id: str = "r1",
+    metrics: dict | None = None,
+    scores: list[dict] | None = None,
+) -> Path:
+    run_dir = base / "artifacts" / "results" / suite / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    if metrics is not None:
+        (run_dir / "metrics.json").write_text(json.dumps(metrics), encoding="utf-8")
+    if scores is not None:
+        (run_dir / "scores.jsonl").write_text(
+            "\n".join(json.dumps(s) for s in scores), encoding="utf-8"
+        )
+    return run_dir
+
+
+def test_assert_locate_run_output_prefers_explicit_suite_and_run(tmp_path: Path):
+    _write_assert_layout(tmp_path, suite="demo", run_id="r1", metrics={}, scores=[])
+    found = assert_runner._locate_run_output(
+        results_dir=(tmp_path / "artifacts" / "results").resolve(),
+        suite="demo",
+        run_id="r1",
+    )
+    assert found is not None
+    assert found.name == "r1"
+
+
+def test_assert_locate_run_output_falls_back_to_latest(tmp_path: Path):
+    _write_assert_layout(tmp_path, suite="demo", run_id="older", metrics={}, scores=[])
+    newer = _write_assert_layout(tmp_path, suite="demo", run_id="newer", metrics={}, scores=[])
+    # Bump mtime of newer
+    newer.touch()
+    found = assert_runner._locate_run_output(
+        results_dir=(tmp_path / "artifacts" / "results").resolve(),
+        suite=None,
+        run_id=None,
+    )
+    assert found is not None
+    assert found.parent.name == "demo"
+
+
+def test_assert_summarize_dimensions_counts_violations(tmp_path: Path):
+    run_dir = _write_assert_layout(
+        tmp_path,
+        suite="demo",
+        run_id="r1",
+        metrics={},
+        scores=[
+            {"dimension": "pii_leak", "verdict": "pass"},
+            {"dimension": "pii_leak", "verdict": "violation"},
+            {"dimension": "jailbreak", "verdict": "fail"},
+            {"dimension": "jailbreak", "verdict": "ok"},
+            {"dimension": "jailbreak", "verdict": "unknown_state"},
+        ],
+    )
+    summary = assert_runner._summarize_dimensions(run_dir)
+    assert summary["pii_leak"]["total"] == 2
+    assert summary["pii_leak"]["violations"] == 1
+    assert summary["jailbreak"]["violations"] == 1
+    assert summary["jailbreak"]["passes"] == 1
+    assert summary["jailbreak"]["other"] == 1
+
+
+def test_assert_aggregate_totals_uses_dimensions(tmp_path: Path):
+    metrics: dict[str, Any] = {}
+    dims = {
+        "a": {"total": 5, "violations": 2, "passes": 3, "other": 0},
+        "b": {"total": 5, "violations": 0, "passes": 5, "other": 0},
+    }
+    totals = assert_runner._aggregate_totals(metrics, dims)
+    # ASSERT design: total = max across dimensions (each case is judged on
+    # every dimension), failed = sum of violations.
+    assert totals["total"] == 5
+    assert totals["failed"] == 2
+    assert totals["passed"] == 3
+    assert totals["pass_rate"] == pytest.approx(3 / 5)
+
+
+def test_run_assert_invokes_cli_and_writes_normalized(tmp_path: Path, monkeypatch):
+    eval_cfg = tmp_path / "assert" / "eval_config.yaml"
+    eval_cfg.parent.mkdir(parents=True)
+    eval_cfg.write_text("suite_id: demo\nrun_id: r1\n", encoding="utf-8")
+    _write_assert_layout(
+        tmp_path,
+        suite="demo",
+        run_id="r1",
+        metrics={"pass_rate": 0.8},
+        scores=[{"dimension": "x", "verdict": "pass"}],
+    )
+
+    monkeypatch.setattr(assert_runner, "is_assert_installed", lambda executable="assert-ai": True)
+    fake_completed = mock.Mock(returncode=0, stdout="", stderr="")
+    monkeypatch.setattr(assert_runner.subprocess, "run", mock.Mock(return_value=fake_completed))
+
+    result = assert_runner.run_assert(
+        workspace=tmp_path,
+        config_path=eval_cfg,
+        results_dir=tmp_path / "artifacts" / "results",
+    )
+    assert result.suite == "demo"
+    assert result.run_id == "r1"
+    assert result.total_cases == 1
+    assert result.has_violations is False
+    assert result.normalized_path is not None
+    payload = json.loads(Path(result.normalized_path).read_text(encoding="utf-8"))
+    assert payload["suite"] == "demo"
+
+
+def test_run_assert_raises_when_cli_missing(tmp_path: Path, monkeypatch):
+    eval_cfg = tmp_path / "ec.yaml"
+    eval_cfg.write_text("suite: x\n", encoding="utf-8")
+    monkeypatch.setattr(assert_runner, "is_assert_installed", lambda executable="assert-ai": False)
+    with pytest.raises(assert_runner.AssertRunnerError):
+        assert_runner.run_assert(
+            workspace=tmp_path,
+            config_path=eval_cfg,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Red Team runner unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_redteam_aggregate_totals_zero_records():
+    totals = redteam_runner._aggregate_totals([])
+    assert totals == {"total": 0, "successful": 0, "attack_success_rate": 0.0}
+
+
+def test_redteam_aggregate_totals_mixed():
+    records = [
+        {"risk_category": "a", "attack_strategy": "x", "successful": True},
+        {"risk_category": "a", "attack_strategy": "x", "successful": False},
+        {"risk_category": "b", "attack_strategy": "y", "successful": True},
+        {"risk_category": "b", "attack_strategy": "y", "successful": True},
+    ]
+    totals = redteam_runner._aggregate_totals(records)
+    assert totals["total"] == 4
+    assert totals["successful"] == 3
+    assert totals["attack_success_rate"] == 0.75
+
+
+def test_redteam_summarize_by_axis_per_category():
+    records = [
+        {"risk_category": "violence", "attack_strategy": "base64", "successful": True},
+        {"risk_category": "violence", "attack_strategy": "rot13", "successful": False},
+        {"risk_category": "hate", "attack_strategy": "base64", "successful": False},
+    ]
+    by_cat = redteam_runner._summarize_by_axis(records, axis="risk_category")
+    assert by_cat["violence"]["total"] == 2
+    assert by_cat["violence"]["successful"] == 1
+    assert by_cat["violence"]["attack_success_rate"] == 0.5
+    assert by_cat["hate"]["successful"] == 0
+
+
+def test_redteam_records_from_payload_attack_details():
+    payload = {
+        "attack_details": [
+            {
+                "risk_category": "violence",
+                "attack_strategy": "base64",
+                "attack_success": True,
+            },
+            {
+                "category": "hate",
+                "strategy": "rot13",
+                "verdict": "pass",
+            },
+        ]
+    }
+    records = redteam_runner._records_from_payload(payload)
+    assert len(records) == 2
+    assert records[0]["risk_category"] == "violence"
+    assert records[0]["successful"] is True
+    assert records[1]["successful"] is False
+
+
+def test_redteam_build_target_callback_requires_endpoint(monkeypatch):
+    monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+    with pytest.raises(redteam_runner.RedTeamRunnerError):
+        redteam_runner._build_target_callback({"model_deployment": "x"})
+
+
+def test_redteam_build_target_callback_with_endpoint(monkeypatch):
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://x.openai.azure.com")
+    callback = redteam_runner._build_target_callback({"model_deployment": "gpt-4o-mini"})
+    assert callback["azure_deployment"] == "gpt-4o-mini"
+    assert callback["azure_endpoint"].startswith("https://")
+
+
+def test_redteam_build_target_callback_unsupported():
+    with pytest.raises(redteam_runner.RedTeamRunnerError):
+        redteam_runner._build_target_callback({"foo": "bar"})
+
+
+def test_run_redteam_raises_when_sdk_missing(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(redteam_runner, "is_redteam_installed", lambda: False)
+    with pytest.raises(redteam_runner.RedTeamRunnerError):
+        redteam_runner.run_redteam(
+            workspace=tmp_path,
+            target={"model_deployment": "gpt-4o-mini"},
+            risk_categories=["violence"],
+            attack_strategies=["base64"],
+        )
+
+
+def test_run_redteam_normalizes_and_gates(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(redteam_runner, "is_redteam_installed", lambda: True)
+
+    records = [
+        {"risk_category": "violence", "attack_strategy": "base64", "successful": True},
+        {"risk_category": "violence", "attack_strategy": "base64", "successful": True},
+        {"risk_category": "hate", "attack_strategy": "rot13", "successful": False},
+    ]
+    monkeypatch.setattr(
+        redteam_runner,
+        "_invoke_redteam_scan",
+        lambda **_: (records, {"attack_details": records}),
+    )
+
+    result = redteam_runner.run_redteam(
+        workspace=tmp_path,
+        target={"model_deployment": "gpt-4o-mini"},
+        risk_categories=["violence", "hate"],
+        attack_strategies=["base64", "rot13"],
+        num_objectives=3,
+        fail_threshold=0.5,
+    )
+    assert result.total_attempts == 3
+    assert result.successful_attacks == 2
+    assert result.attack_success_rate == pytest.approx(2 / 3, abs=1e-3)
+    assert result.has_violations is True
+    # default normalized path lives under workspace
+    assert Path(result.output_path).exists()
+    payload = json.loads(Path(result.output_path).read_text(encoding="utf-8"))
+    assert payload["successful_attacks"] == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _seed_minimal_workspace(tmp_path: Path, *, extra: dict | None = None) -> Path:
+    cfg_path = tmp_path / "agentops.yaml"
+    base = {
+        "version": 1,
+        "agent": "my-agent:1",
+        "dataset": "data.jsonl",
+    }
+    if extra:
+        base.update(extra)
+    import yaml as _yaml
+
+    cfg_path.write_text(_yaml.safe_dump(base), encoding="utf-8")
+    (tmp_path / "data.jsonl").write_text("", encoding="utf-8")
+    return cfg_path
+
+
+def test_cli_assert_run_missing_config_block(tmp_path: Path, runner: CliRunner, monkeypatch):
+    cfg = _seed_minimal_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["assert", "run", "--config", str(cfg)])
+    assert result.exit_code == 1
+    assert "no ASSERT configuration found" in result.output
+
+
+def test_cli_assert_run_missing_cli(tmp_path: Path, runner: CliRunner, monkeypatch):
+    eval_cfg = tmp_path / "assert" / "eval_config.yaml"
+    eval_cfg.parent.mkdir(parents=True)
+    eval_cfg.write_text("suite: x\nrun: r\n", encoding="utf-8")
+    cfg = _seed_minimal_workspace(
+        tmp_path, extra={"assert": {"config": "assert/eval_config.yaml"}}
+    )
+    monkeypatch.chdir(tmp_path)
+    from agentops.cli import app as app_module
+
+    monkeypatch.setattr(
+        app_module, "_resolve_eval_config_path", lambda c: cfg if c is None else c
+    )
+    monkeypatch.setattr(
+        "agentops.services.assert_runner.is_assert_installed", lambda *a, **k: False
+    )
+    result = runner.invoke(app, ["assert", "run", "--config", str(cfg)])
+    assert result.exit_code == 1
+    assert "assert-ai" in result.output
+
+
+def test_cli_redteam_run_missing_config_block(tmp_path: Path, runner: CliRunner, monkeypatch):
+    cfg = _seed_minimal_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["redteam", "run", "--config", str(cfg)])
+    assert result.exit_code == 1
+    assert "no Red Team configuration found" in result.output
+
+
+def test_cli_redteam_run_missing_sdk(tmp_path: Path, runner: CliRunner, monkeypatch):
+    cfg = _seed_minimal_workspace(
+        tmp_path,
+        extra={"redteam": {"target": {"model_deployment": "gpt-4o-mini"}}},
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "agentops.services.redteam_runner.is_redteam_installed", lambda: False
+    )
+    result = runner.invoke(app, ["redteam", "run", "--config", str(cfg)])
+    assert result.exit_code == 1
+    assert "Red Team SDK" in result.output
+
+
+def test_cli_assert_explain_runs(runner: CliRunner):
+    result = runner.invoke(app, ["assert", "explain", "--no-pager"])
+    assert result.exit_code == 0
+    assert "ASSERT" in result.output
+
+
+def test_cli_redteam_explain_runs(runner: CliRunner):
+    result = runner.invoke(app, ["redteam", "explain", "--no-pager"])
+    assert result.exit_code == 0
+    assert "Red Team" in result.output


### PR DESCRIPTION
## What

Turns ASSERT (open-source `assert-ai` framework) and the Foundry/PyRIT AI Red Teaming agent into **active, gated CI steps** that AgentOps orchestrates end-to-end — instead of just consuming pre-generated artifacts via `assert_path:` / `redteam_path:`.

Also rewrites the README Overview to position AgentOps as an **open-source orchestration framework + CLI** rather than a feature bullet list.

## New commands

- **`agentops assert run`** — subprocess wrapper around the `assert-ai` CLI. Parses `metrics.json` + `scores.jsonl`, writes a normalized summary at `.agentops/assert/latest.json`, and exits `2` on any policy violation (unless `--no-gate`).
- **`agentops redteam run`** — invokes `azure.ai.evaluation.red_team.RedTeam` against an Azure OpenAI deployment, Foundry agent, or HTTP endpoint. Aggregates per-category and per-strategy attack-success-rate into `.agentops/redteam/latest.json` and exits `2` when ASR exceeds the configured threshold (unless `--no-gate`).

Both runners produce artifacts that `agentops doctor --evidence-pack` ingests automatically.

## Schema additions (`agentops.yaml`)

```yaml
assert:
  cli: assert-ai
  config: assert/eval_config.yaml
  fail_on_violations: true

redteam:
  target:
    type: model_deployment
    deployment: gpt-4o-mini
  risk_categories: [violence, hate_unfairness, sexual, self_harm]
  attack_strategies: [base64, rot13]
  num_objectives: 5
  fail_on_attack_success_rate: 0.2
```

`assert` / `redteam` are YAML aliases for the Python fields `assert_run` / `redteam_run` (the keyword `assert` cannot be a Python identifier).

## Docs

- **Tutorial:** `docs/tutorial-prompt-agent-quickstart.md` step 10 rewritten as 10a (ASSERT) / 10b (Red Team) / 10c (evidence pack pickup), with install steps for `assert-ai` and `azure-ai-evaluation[redteam]`.
- **README:** new tagline, new Overview as a six-step orchestration narrative (Evaluate → Probe → Diagnose → Gate → Prove → Learn-from-production), updated Foundry boundary table with a new "Probe safety" row.

## Tests

- New file `tests/unit/test_assert_and_redteam_runners.py` — 24 tests covering schema aliases, run-output discovery, dimension summarization, totals aggregation, target-callback shapes, normalized JSON writing, gating, and CLI smoke (missing config / missing dependency / explain manuals).
- **Full suite: 921 passed, 1 skipped.**

## Exit-code contract preserved

- `0` — all gates passed
- `2` — threshold, ASSERT violation, or red-team ASR gate failed
- `1` — runtime / configuration error

## Scope notes

- Active runners are **additive**. Existing `assert_path:` / `redteam_path:` evidence-only paths still work.
- AgentOps does not reimplement ASSERT or PyRIT — it shells out to / imports the upstream tools and normalizes their output.
- No changes to `agentops doctor`, cockpit, or eval runner internals beyond the new normalized JSON inputs.

## Follow-ups (out of scope)

- Cockpit cards for ASSERT / Red Team latest runs.
- Patch release to PyPI (currently `v0.3.13`; user tutorial workspace will need `v0.3.14` to consume).
