### PR TITLE
docs: explain the auto-generated rubric evaluator in step 11

### DIFF
--- a/docs/tutorial-prompt-agent-quickstart.md
+++ b/docs/tutorial-prompt-agent-quickstart.md
@@ -902,6 +902,15 @@ Fill in two kinds of real names: the rubric evaluator name and the rubric
 dimension names. Do not invent values — both must come from files
 `agentops eval init` already generated on disk.
 
+> **About the auto-generated evaluator.** When you ran `agentops eval
+> init`, azd seeded `src/travel-agent/eval.yaml` with two kinds of
+> evaluators: built-ins like `builtin.coherence` and `builtin.fluency`
+> (general response-quality checks) plus a local rubric evaluator —
+> typically `name: smoke-core` — whose `local_uri` points at a JSON file
+> with rubric dimensions specific to this Travel Agent. That local
+> evaluator is the hook AgentOps `rubrics:` bind to. You will reference
+> its `name:` and its dimension `id`s in the next two steps.
+
 **1. Find the evaluator name.** Open `src/travel-agent/eval.yaml` and
 look under `evaluators:` for the entry with a `local_uri`:
 


### PR DESCRIPTION
Follow-up to #293. Dropping the step 10 callout removed the only explanation of what smoke-core (the local rubric evaluator auto-generated by agentops eval init) actually is. Step 11 still told readers to find the entry with a local_uri without context. Adds a short callout right before Find the evaluator name describing the built-ins vs the local rubric evaluator and why rubrics: reference its name.