### PR TITLE
fix(cli): list cursor in skills install --platform help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+- **`agentops skills install --platform` help text now lists `cursor`.** The
+  CLI option help was advertising only `copilot` and `claude` even though the
+  `cursor` platform is fully implemented (registers rules in
+  `.cursor/rules/agentops.mdc`). Updated to `Target platform(s): copilot,
+  claude, cursor.` so users discover the supported value from `--help`.
+  ([#157](https://github.com/Azure/agentops/issues/157))
+
 ## [0.3.23] - 2026-06-12
 
 ### Fixed

--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -3313,7 +3313,7 @@ def cmd_skills_install(
         typer.Option(
             "--platform",
             "-p",
-            help="Target platform(s): copilot, claude.",
+            help="Target platform(s): copilot, claude, cursor.",
         ),
     ] = None,
     from_github: Annotated[


### PR DESCRIPTION
Closes #157.

The `--platform` help string for `agentops skills install` only mentioned `copilot` and `claude` even though the `cursor` platform has been a first-class target for some time:

- `PLATFORMS` in `src/agentops/services/skills.py` lists a full `cursor` entry mapping to `.cursor/rules`.
- `_register_cursor` in the same file writes `.cursor/rules/agentops.mdc`.
- Auto-detection in `detect_platforms` already returns `cursor` for repos with `.cursor/rules` or `.cursorrules`.

Updated the Typer `help` to `Target platform(s): copilot, claude, cursor.` so the supported value is discoverable from `--help`.

### Validation
- No existing test asserts that exact help string. Help-text-only change.
- Manual: `python -m agentops skills install --help` shows the new platform list.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>