### PR TITLE
fix(tests): cherry-pick #311 to main to unblock Release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ where = ["src"]
 [dependency-groups]
 dev = [
     "azure-ai-evaluation>=1.0,<2.0",
+    "azure-mgmt-authorization>=4.0,<5.0",
     "mypy>=1.19.1",
     "pre-commit>=4.0",
     "pytest>=8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,7 @@ dependencies = [
 [package.optional-dependencies]
 agent = [
     { name = "azure-identity" },
+    { name = "azure-mgmt-authorization" },
     { name = "azure-mgmt-cognitiveservices" },
     { name = "azure-mgmt-monitor" },
     { name = "azure-monitor-opentelemetry" },
@@ -44,6 +45,7 @@ mcp = [
 [package.dev-dependencies]
 dev = [
     { name = "azure-ai-evaluation" },
+    { name = "azure-mgmt-authorization" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -58,17 +60,18 @@ requires-dist = [
     { name = "azure-ai-projects", specifier = ">=2.0.1,<3.0" },
     { name = "azure-identity", marker = "extra == 'agent'", specifier = ">=1.17,<2.0" },
     { name = "azure-identity", marker = "extra == 'foundry'", specifier = ">=1.17,<2.0" },
-    { name = "azure-mgmt-cognitiveservices", marker = "extra == 'agent'", specifier = ">=13.5,<14.0" },
+    { name = "azure-mgmt-authorization", marker = "extra == 'agent'", specifier = ">=4.0,<5.0" },
+    { name = "azure-mgmt-cognitiveservices", marker = "extra == 'agent'", specifier = ">=13.5,<15.0" },
     { name = "azure-mgmt-monitor", marker = "extra == 'agent'", specifier = ">=6.0,<7.0" },
     { name = "azure-monitor-opentelemetry", marker = "extra == 'agent'", specifier = ">=1.6,<2.0" },
     { name = "azure-monitor-opentelemetry", marker = "extra == 'foundry'", specifier = ">=1.6,<2.0" },
-    { name = "azure-monitor-query", marker = "extra == 'agent'", specifier = ">=1.3,<2.0" },
+    { name = "azure-monitor-query", marker = "extra == 'agent'", specifier = ">=1.3,<3.0" },
     { name = "cryptography", marker = "extra == 'agent'", specifier = ">=42" },
     { name = "fastapi", marker = "extra == 'agent'", specifier = ">=0.110,<1.0" },
     { name = "httpx", marker = "extra == 'agent'", specifier = ">=0.27,<1.0" },
     { name = "markdown", marker = "extra == 'agent'", specifier = ">=3.6,<4.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0,<2" },
-    { name = "pandas", marker = "extra == 'foundry'", specifier = ">=2.0,<3.0" },
+    { name = "pandas", marker = "extra == 'foundry'", specifier = ">=2.0,<4.0" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "ruamel-yaml", specifier = ">=0.18,<1.0" },
     { name = "typer", specifier = ">=0.12,<1.0" },
@@ -79,6 +82,7 @@ provides-extras = ["mcp", "foundry", "agent"]
 [package.metadata.requires-dev]
 dev = [
     { name = "azure-ai-evaluation", specifier = ">=1.0,<2.0" },
+    { name = "azure-mgmt-authorization", specifier = ">=4.0,<5.0" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
@@ -365,6 +369,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
+]
+
+[[package]]
+name = "azure-mgmt-authorization"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-common" },
+    { name = "azure-mgmt-core" },
+    { name = "isodate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ab/e79874f166eed24f4456ce4d532b29a926fb4c798c2c609eefd916a3f73d/azure-mgmt-authorization-4.0.0.zip", hash = "sha256:69b85abc09ae64fc72975bd43431170d8c7eb5d166754b98aac5f3845de57dc4", size = 1134795, upload-time = "2023-07-25T04:47:46.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/b3/8ec1268082f4d20cc8bf723a1a8e6b9e330bcc338a4dbcee9c7737e9dc1c/azure_mgmt_authorization-4.0.0-py3-none-any.whl", hash = "sha256:d8feeb3842e6ddf1a370963ca4f61fb6edc124e8997b807dd025bc9b2379cd1a", size = 1072620, upload-time = "2023-07-25T04:47:49.26Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cherry-pick of #311 to `main` so that re-tagging `v0.4.1` (and any future
re-trigger of `Release`) finds the unblocked `build` job.

This is the same single-commit fix already merged to `develop` via #311.