### PR TITLE
Simplify README and make Foundry dependencies default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -472,7 +472,7 @@ Authentication rule (Windows-friendly):
 
 Recommended default behavior:
 - Keep Foundry cloud mode as the default for `name:version` agents
-- Install Azure runtime dependencies via the `[foundry]` extra
+- Install AgentOps normally; Foundry runtime dependencies are part of the default package
 - Keep Azure SDK imports inside functions (lazy) in `pipeline/` and `agent/`
 - Do not hardcode `api_version` in `get_openai_client()` — the SDK picks it
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 <h1 align="center">AgentOps Accelerator</h1>
 
 <p align="center">
-<b>The open-source AgentOps jumpstart for continuous evaluation, safety testing, observability, and release readiness of Microsoft Foundry agents.</b>
+<b>Evaluate. Ship. Observe. Own.</b>
 <br/>
-Can we ship it, and how do we know?
+Continuous evaluation, safety testing, observability, and release readiness for Microsoft Foundry agents.
+</p>
+
+<p align="center">
+<a href="https://aka.ms/agentops-accelerator"><b>Documentation</b></a> |
+<a href="https://pypi.org/project/agentops-accelerator/">PyPI</a> |
+<a href="https://marketplace.visualstudio.com/items?itemName=AgentOpsAccelerator.agentops-accelerator">VS Code Extension</a> |
+<a href="https://github.com/Azure/agentops/releases/latest">Latest release</a>
 </p>
 
 <p align="center">
@@ -11,219 +18,44 @@ Can we ship it, and how do we know?
 <a href="https://marketplace.visualstudio.com/items?itemName=AgentOpsAccelerator.agentops-accelerator"><img alt="VS Code Extension" src="https://img.shields.io/badge/VS%20Code-Extension-007ACC.svg?logo=visualstudiocode"/></a>
 <a href="https://github.com/Azure/agentops/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Azure/agentops/actions/workflows/ci.yml/badge.svg?branch=develop"/></a>
 <a href="https://github.com/Azure/agentops/actions/workflows/release.yml"><img alt="Release" src="https://github.com/Azure/agentops/actions/workflows/release.yml/badge.svg"/></a>
-<a href="https://github.com/Azure/agentops"><img alt="Status: Preview" src="https://img.shields.io/badge/Status-Preview-orange.svg"/></a>
-<br/>
-<a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-3776AB.svg"/></a>
-<a href="https://typer.tiangolo.com/"><img alt="CLI: Typer" src="https://img.shields.io/badge/CLI-Typer-5A67D8.svg"/></a>
-<a href="https://learn.microsoft.com/azure/ai-foundry/"><img alt="Built on Microsoft Foundry" src="https://img.shields.io/badge/Built%20on-Microsoft%20Foundry-0078D4.svg"/></a>
 <a href="https://github.com/Azure/agentops/blob/main/LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-green.svg"/></a>
 </p>
 
-## Overview
+AgentOps Accelerator helps Microsoft Foundry agent teams evaluate quality, prepare releases, monitor behavior, and stay accountable after launch. It gives you a practical starting point for agent operations, with Foundry integration as the default path and deeper setup guidance in the full docs.
 
-AgentOps Accelerator is an open-source AgentOps jumpstart that standardizes
-continuous evaluation, safety testing, observability, and release readiness
-for enterprise AI agents on Microsoft Foundry. It connects Foundry Evaluations,
-ASSERT, the PyRIT-backed AI Red Teaming agent, Azure Monitor, and your CI/CD
-platform into one repeatable release loop, packaging every result into a
-stable evidence pack that proves the release is ready for production.
-
-The output is a clear answer to the two questions reviewers actually ask:
-can we ship it, and how do we know?
-
-### Core outputs
-
-| Artifact | Produced by | Audience |
-|---|---|---|
-| `results.json` | `agentops eval run` | CI / automation |
-| `report.md` | `agentops eval run` | PR reviewers |
-| `.agentops/assert/latest.json` | `agentops assert run` | Evidence pack, CI gate |
-| `.agentops/redteam/latest.json` | `agentops redteam run` | Evidence pack, CI gate |
-| `evidence.json` / `evidence.md` | `agentops doctor --evidence-pack` | Release approver |
-| Cockpit (localhost) | `agentops cockpit` | Engineer reviewing readiness |
-
-### Exit-code contract
-
-AgentOps commands exit with `0` when execution succeeded and every gate
-passed, with `2` when execution itself succeeded but a threshold, an ASSERT
-violation, a red-team attack-success rate, or a Doctor severity gate
-failed, and with `1` for runtime or configuration errors. Pipelines can
-rely on this contract without parsing output.
-
-## AgentOps and Microsoft Foundry
-
-Foundry and AgentOps are designed to meet at the release boundary. Foundry is
-where teams create, deploy, run, observe, and investigate agents. AgentOps is
-the repo-side operating layer that turns those signals into a repeatable
-ship/no-ship workflow.
-
-| Moment | Foundry / Azure does | AgentOps adds |
-|---|---|---|
-| Build and version | Foundry portal, Foundry SDK/Toolkit, `microsoft-foundry` skill, azd | Pins the exact candidate in `agentops.yaml` and generates the PR/release gate around it |
-| Evaluate and compare | Foundry Evaluations, `azd ai agent eval`, Rubric evaluator, and official CI actions/extensions | Keeps datasets and thresholds in the repo, records evidence, normalizes azd/Rubric outputs, and provides local/fallback runs for non-prompt targets |
-| Probe safety | ASSERT framework, PyRIT-backed AI Red Teaming agent | Runs both as active CI steps via `agentops assert run` and `agentops redteam run`, normalizes verdicts, and gates the pipeline |
-| Observe and investigate | Foundry Monitor, Traces, Azure Monitor, App Insights | Surfaces deep links, telemetry readiness, Doctor findings, and Cockpit navigation |
-| Decide release | Branch protection, environments, approvals | Packages `evidence.json` / `evidence.md` for promotion review |
-| Govern controls | ACS, Foundry Guardrails | References reviewed artifacts by path/hash/status without executing or applying the external controls |
-| Improve from production | Production traces and Foundry datasets | Promotes reviewed trace learnings into regression candidates |
-
-The rhythm is simple: build and operate the agent in Foundry, keep the release
-contract in the repo, and let AgentOps connect the two into a clean review loop.
-
-## Quickstart
-
-### 1) Install
+## Get started
 
 ```powershell
-python -m venv .venv
-.\.venv\Scripts\Activate.ps1
-python -m pip install -U pip
-python -m pip install --upgrade "agentops-accelerator[foundry] @ git+https://github.com/Azure/agentops.git@main"
-```
-
-This installs the current AgentOps source from GitHub. After the next package
-release, you can switch the install line back to `agentops-accelerator[foundry]`
-from PyPI.
-
-### 2) Bootstrap
-
-```powershell
+python -m pip install agentops-accelerator
 agentops init
-```
-
-This writes a single `agentops.yaml` at the project root and an
-AgentOps-managed workspace under `.agentops/` for seed data, run history, and
-generated evidence. It is not a second `.foundry/` project directory.
-
-### 3) Configure your agent
-
-Pick one of these forms for the `agent:` field - AgentOps classifies the target automatically:
-
-```yaml
-agent: "my-rag:3"                          # Foundry prompt agent (name:version)
-agent: "https://...services.ai.azure.com/.../agents/<id>"  # Foundry hosted endpoint
-agent: "https://api.example.com/chat"      # any HTTP/JSON agent (ACA, AKS, custom)
-agent: "model:gpt-4o"                       # raw Foundry model deployment
-```
-
-AgentOps supports both Foundry Prompt Agents and Hosted Agents as evaluation
-and readiness targets. Create and deploy them with Foundry tools, then reference
-the published candidate in `agentops.yaml`.
-
-For the smoke dataset, create a Foundry prompt agent such as
-`agentops-smoke` and publish it with instructions that copy exact-answer
-requests verbatim:
-
-```text
-If the user message starts with "Answer with exactly this sentence:",
-copy only the sentence after that prefix. Do not add greetings,
-markdown, citations, caveats, or explanations.
-```
-
-Evaluators come from dataset shape: `context` triggers RAG checks;
-`tool_calls` / `tool_definitions` trigger tool-use checks. Minimal config:
-
-```yaml
-version: 1
-agent: "agentops-smoke:2"  # Foundry saves the first published version as v2
-dataset: .agentops/data/smoke.jsonl
-```
-
-### 4) Run
-
-```powershell
-az login
-$env:AZURE_AI_FOUNDRY_PROJECT_ENDPOINT = "https://<resource>.services.ai.azure.com/api/projects/<project>"
-$env:AZURE_OPENAI_ENDPOINT = "https://<openai-resource>.openai.azure.com"
-$env:AZURE_OPENAI_DEPLOYMENT = "gpt-4o-mini"
 agentops eval analyze
 agentops eval run
 agentops doctor --evidence-pack
 ```
 
-For Foundry targets, use either `project_endpoint:` in `agentops.yaml` or
-`AZURE_AI_FOUNDRY_PROJECT_ENDPOINT`. Config wins when both are set.
+## What it helps you do
 
-Outputs land in `.agentops/results/latest/`:
+Use AgentOps Accelerator when you need to:
 
-- `results.json` - machine-readable (versioned, stable schema)
-- `report.md` - human-readable, PR-friendly
+- Evaluate an agent before release
+- Compare changes across versions
+- Capture release evidence
+- Monitor agent quality and regressions
+- Give teams a repeatable way to own agent behavior in production
 
-Release evidence lands in `.agentops/release/latest/`:
+The accelerator keeps the local workflow simple, then points you to the full
+docs when you are ready to configure pipelines, dashboards, and release
+practices.
 
-- `evidence.json` - machine-readable production-readiness projection
-- `evidence.md` - PR/release summary
+## Learn more
 
-Capture the first successful run as a baseline:
+For setup guides, tutorials, architecture, CI/CD guidance, Doctor checks, and
+evaluator reference, see:
 
-```powershell
-New-Item -ItemType Directory -Force .agentops\baseline | Out-Null
-Copy-Item .agentops\results\latest\results.json .agentops\baseline\results.json
-```
-
-To see a visible comparison, publish a new agent version with a prompt
-that paraphrases instead of copying exact-answer requests, update
-`agentops.yaml` to that new `name:version`, and compare against the
-baseline:
-
-```powershell
-agentops eval run --baseline .agentops/baseline/results.json
-```
-
-The report grows a `Comparison vs Baseline` section with per-metric deltas.
-
----
-
-## Commands
-
-Install optional extras as needed: `[foundry]` for eval runtime, `[agent]` for
-Doctor/Cockpit, and `[mcp]` for MCP.
-
-- `agentops --version` - show installed version.
-- `agentops init` - bootstrap config and seed data.
-- `agentops eval analyze` - check eval readiness.
-- `agentops eval init` - bootstrap an azd `eval.yaml` recipe and wire `execution: azd`.
-- `agentops eval run [--baseline PATH]` - run an evaluation.
-- `agentops eval promote-traces --source FILE [--apply]` - promote traces.
-- `agentops report generate` - regenerate `report.md`.
-- `agentops workflow analyze` - recommend CI/CD shape.
-- `agentops workflow generate` - generate CI/CD workflows.
-- `agentops skills install` - install Copilot or Claude skills.
-- `agentops mcp serve` - start the MCP server.
-- `agentops doctor [--evidence-pack]` - run readiness checks.
-- `agentops cockpit` - open the local Cockpit.
-- `agentops agent serve` - serve Doctor as a Copilot Extension.
-
-## AgentOps Cockpit
-
-`agentops cockpit` opens a localhost command center for the current workspace.
-It combines eval history, Doctor findings, workflow status, and links to the
-matching Foundry and Azure Monitor views.
-
-Cockpit sections, in display order:
-
-- **Foundry connection** - project, tenant, agent, App Insights.
-- **Foundry launchpad** - links for the agent, project, and telemetry.
-- **Observability readiness** - tracing, evals, red team, alerts.
-- **AgentOps Doctor** - latest Doctor findings.
-- **Eval gate summary** - local and CI gate history.
-- **Quality gate summary** - score trends and regressions.
-- **Production signal** - App Insights health snapshot.
-- **CI/CD Pipelines** - GitHub Actions status.
-- **Next actions** - contextual recommendations.
-
-## Documentation
-
-- [Foundry Prompt Agent tutorial](docs/tutorial-prompt-agent-quickstart.md) - use this when the Foundry target is `agent: name:version`. Walks the sandbox → dev journey with a PR gate.
-- [Hosted or HTTP Agent tutorial](docs/tutorial-hosted-agent-quickstart.md) - use this when the target is a Foundry hosted or HTTP endpoint URL. Same sandbox → dev journey for endpoint-based agents.
-- [End-to-end tutorial](docs/tutorial-end-to-end.md) - extends either of the above with the full sandbox → dev → qa → prod promotion, Foundry red-team scans, and trace-to-regression promotion.
-- [Core concepts](docs/concepts.md)
-- [How it works](docs/how-it-works.md)
-- [Doctor explained](docs/doctor-explained.md)
-- [CI/CD with GitHub Actions](docs/ci-github-actions.md)
-- [Built-in evaluator reference](docs/foundry-evaluation-sdk-built-in-evaluators.md)
-- [Release process](docs/release-process.md)
+<p align="center">
+<a href="https://aka.ms/agentops-accelerator"><b>https://aka.ms/agentops-accelerator</b></a>
+</p>
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for architecture rules, testing, and contribution flow.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development, testing, and contribution guidance.

--- a/plugins/agentops/README.md
+++ b/plugins/agentops/README.md
@@ -46,7 +46,7 @@ skills from the extension/plugin.
 Run this from the repository where you want skills checked in:
 
 ```bash
-python -m pip install "agentops-accelerator[foundry] @ git+https://github.com/Azure/agentops.git@main"
+python -m pip install "agentops-accelerator @ git+https://github.com/Azure/agentops.git@main"
 agentops skills install --platform copilot --force
 ```
 

--- a/plugins/agentops/skills/agentops-config/SKILL.md
+++ b/plugins/agentops/skills/agentops-config/SKILL.md
@@ -17,7 +17,7 @@ then return here once there is a `name:version` or URL.
 
 ## Step 0 - Prerequisites
 
-1. `pip install "agentops-accelerator[foundry] @ git+https://github.com/Azure/agentops.git@main"` if `agentops` is missing.
+1. `pip install "agentops-accelerator @ git+https://github.com/Azure/agentops.git@main"` if `agentops` is missing.
 2. Run `agentops eval analyze` first. If it reports missing or ambiguous
    target/dataset/scenario signals, use this skill to adapt the config.
 3. If `agentops.yaml` does not exist, run `agentops init` first. The init

--- a/plugins/agentops/skills/agentops-eval/SKILL.md
+++ b/plugins/agentops/skills/agentops-eval/SKILL.md
@@ -15,7 +15,7 @@ with a `name:version` or URL.
 
 ## Step 0 - Setup
 
-1. Install if missing: `pip install "agentops-accelerator[foundry] @ git+https://github.com/Azure/agentops.git@main"`.
+1. Install if missing: `pip install "agentops-accelerator @ git+https://github.com/Azure/agentops.git@main"`.
 2. If `agentops.yaml` does not exist at the project root, run `agentops init`.
    The init wizard prompts (azd-style) for the Foundry project endpoint,
    agent reference, and dataset path, persists each answer to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,17 +13,15 @@ dependencies = [
   "pydantic>=2,<3",
   "ruamel.yaml>=0.18,<1.0",
   "azure-ai-projects>=2.0.1,<3.0",
-]
-license = { file = "LICENSE" }
-
-[project.optional-dependencies]
-mcp = ["mcp>=1.0,<2"]
-foundry = [
   "azure-ai-evaluation>=1.0,<2.0",
   "azure-identity>=1.17,<2.0",
   "azure-monitor-opentelemetry>=1.6,<2.0",
   "pandas>=2.0,<4.0",
 ]
+license = { file = "LICENSE" }
+
+[project.optional-dependencies]
+mcp = ["mcp>=1.0,<2"]
 agent = [
   "fastapi>=0.110,<1.0",
   "uvicorn[standard]>=0.30,<1.0",

--- a/src/agentops/agent/checks/foundry_config.py
+++ b/src/agentops/agent/checks/foundry_config.py
@@ -60,7 +60,7 @@ def _no_foundry_control_finding(diag: dict) -> Finding:
         recommendation=(
             "Set `sources.foundry_control.project_endpoint` (or the "
             "`AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` env var) in "
-            "`.agentops/agent.yaml`, install the `[foundry]` extra, "
+            "`.agentops/agent.yaml`, install AgentOps, "
             "and grant the running identity at least `Reader` on the "
             "Foundry project. If this project does not use Foundry, "
             "set `sources.foundry_control.enabled: false` to opt out "

--- a/src/agentops/agent/sources/foundry_control.py
+++ b/src/agentops/agent/sources/foundry_control.py
@@ -91,7 +91,7 @@ def collect_foundry_control(
         diagnostics["status"] = "skipped"
         diagnostics["reason"] = (
             "azure-ai-projects / azure-identity not installed "
-            "(install agentops-accelerator[foundry])"
+            "(install agentops-accelerator)"
         )
         log.info("azure-ai-projects unavailable: %s", exc)
         return FoundryControlPayload(diagnostics=diagnostics)

--- a/src/agentops/agent/sources/results_history.py
+++ b/src/agentops/agent/sources/results_history.py
@@ -301,7 +301,7 @@ def _collect_foundry_eval_runs(
         diagnostics["status"] = "skipped"
         diagnostics["reason"] = (
             "azure-ai-projects / azure-identity not installed "
-            "(install agentops-accelerator[foundry])"
+            "(install agentops-accelerator)"
         )
         log.info("Foundry cloud eval history unavailable: %s", exc)
         return [], diagnostics

--- a/src/agentops/pipeline/prompt_deploy.py
+++ b/src/agentops/pipeline/prompt_deploy.py
@@ -338,7 +338,7 @@ def _project_client(endpoint: str) -> Any:
     except ImportError as exc:
         raise RuntimeError(
             "prompt-agent deployment requires azure-ai-projects and "
-            "azure-identity; install agentops-accelerator[foundry]"
+            "azure-identity; install agentops-accelerator"
         ) from exc
 
     credential = DefaultAzureCredential(

--- a/src/agentops/pipeline/runtime.py
+++ b/src/agentops/pipeline/runtime.py
@@ -153,7 +153,7 @@ def load_evaluator(preset: EvaluatorPreset) -> EvaluatorRuntime:
         raise RuntimeError(
             "Evaluators require the 'azure-ai-evaluation' package. "
             "Install the Foundry extra in this virtual environment. "
-            "Run: python -m pip install --upgrade 'agentops-accelerator[foundry]'"
+            "Run: python -m pip install agentops-accelerator"
         ) from exc
 
     cls = getattr(module, preset.class_name, None)

--- a/src/agentops/templates/pipelines/azuredevops/agentops-deploy-dev-azd.yml
+++ b/src/agentops/templates/pipelines/azuredevops/agentops-deploy-dev-azd.yml
@@ -74,7 +74,7 @@ __AILZ_PREFLIGHT_COMMAND__
               versionSpec: "3.11"
           - bash: |
               python -m pip install --upgrade pip
-              python -m pip install "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+              python -m pip install "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
             displayName: Install AgentOps Toolkit
 
 __EVAL_TASKS__

--- a/src/agentops/templates/pipelines/azuredevops/agentops-deploy-dev.yml
+++ b/src/agentops/templates/pipelines/azuredevops/agentops-deploy-dev.yml
@@ -50,7 +50,7 @@ stages:
 
                 - bash: |
                     python -m pip install --upgrade pip
-                    python -m pip install "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+                    python -m pip install "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
                   displayName: Install AgentOps Toolkit
 
 __EVAL_TASKS__

--- a/src/agentops/templates/pipelines/azuredevops/agentops-deploy-prompt-agent.yml
+++ b/src/agentops/templates/pipelines/azuredevops/agentops-deploy-prompt-agent.yml
@@ -48,7 +48,7 @@ stages:
               scriptLocation: inlineScript
               inlineScript: |
                 python -m pip install --upgrade pip
-                python -m pip install "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+                python -m pip install "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
                 python -m agentops.pipeline.prompt_deploy stage \
                   --config "$(AGENTOPS_CONFIG)" \
                   --environment "$(TARGET_ENVIRONMENT)" \

--- a/src/agentops/templates/pipelines/azuredevops/agentops-deploy-qa-azd.yml
+++ b/src/agentops/templates/pipelines/azuredevops/agentops-deploy-qa-azd.yml
@@ -74,7 +74,7 @@ __AILZ_PREFLIGHT_COMMAND__
               versionSpec: "3.11"
           - bash: |
               python -m pip install --upgrade pip
-              python -m pip install "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+              python -m pip install "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
             displayName: Install AgentOps Toolkit
 
 __EVAL_TASKS__

--- a/src/agentops/templates/pipelines/azuredevops/agentops-deploy-qa.yml
+++ b/src/agentops/templates/pipelines/azuredevops/agentops-deploy-qa.yml
@@ -46,7 +46,7 @@ stages:
 
                 - bash: |
                     python -m pip install --upgrade pip
-                    python -m pip install "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+                    python -m pip install "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
                   displayName: Install AgentOps Toolkit
 
 __EVAL_TASKS__

--- a/src/agentops/templates/pipelines/azuredevops/agentops-pr-prompt-agent.yml
+++ b/src/agentops/templates/pipelines/azuredevops/agentops-pr-prompt-agent.yml
@@ -73,7 +73,7 @@ stages:
               scriptLocation: inlineScript
               inlineScript: |
                 python -m pip install --upgrade pip
-                python -m pip install "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+                python -m pip install "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
                 python -m agentops.pipeline.prompt_deploy stage \
                   --config "$(AGENTOPS_CONFIG)" \
                   --environment "$(TARGET_ENVIRONMENT)" \

--- a/src/agentops/templates/skills/agentops-config/SKILL.md
+++ b/src/agentops/templates/skills/agentops-config/SKILL.md
@@ -17,7 +17,7 @@ then return here once there is a `name:version` or URL.
 
 ## Step 0 - Prerequisites
 
-1. `pip install "agentops-accelerator[foundry] @ git+https://github.com/Azure/agentops.git@main"` if `agentops` is missing.
+1. `pip install "agentops-accelerator @ git+https://github.com/Azure/agentops.git@main"` if `agentops` is missing.
 2. Run `agentops eval analyze` first. If it reports missing or ambiguous
    target/dataset/scenario signals, use this skill to adapt the config.
 3. If `agentops.yaml` does not exist, run `agentops init` first. The init

--- a/src/agentops/templates/skills/agentops-eval/SKILL.md
+++ b/src/agentops/templates/skills/agentops-eval/SKILL.md
@@ -15,7 +15,7 @@ with a `name:version` or URL.
 
 ## Step 0 - Setup
 
-1. Install if missing: `pip install "agentops-accelerator[foundry] @ git+https://github.com/Azure/agentops.git@main"`.
+1. Install if missing: `pip install "agentops-accelerator @ git+https://github.com/Azure/agentops.git@main"`.
 2. If `agentops.yaml` does not exist at the project root, run `agentops init`.
    The init wizard prompts (azd-style) for the Foundry project endpoint,
    agent reference, and dataset path, persists each answer to

--- a/src/agentops/templates/workflows/agentops-deploy-dev-azd.yml
+++ b/src/agentops/templates/workflows/agentops-deploy-dev-azd.yml
@@ -114,7 +114,7 @@ __AILZ_PREFLIGHT_COMMAND__
 
       - name: Install AgentOps Toolkit
         run: |
-          uv pip install --system "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+          uv pip install --system "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
 
 __EVAL_STEPS__
 

--- a/src/agentops/templates/workflows/agentops-deploy-dev.yml
+++ b/src/agentops/templates/workflows/agentops-deploy-dev.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install AgentOps Toolkit
         run: |
-          uv pip install --system "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+          uv pip install --system "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
 
 __EVAL_STEPS__
 

--- a/src/agentops/templates/workflows/agentops-deploy-prompt-agent.yml
+++ b/src/agentops/templates/workflows/agentops-deploy-prompt-agent.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Install AgentOps Toolkit
         run: |
-          uv pip install --system "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+          uv pip install --system "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
 
 __EVAL_STEPS__
 

--- a/src/agentops/templates/workflows/agentops-deploy-qa-azd.yml
+++ b/src/agentops/templates/workflows/agentops-deploy-qa-azd.yml
@@ -109,7 +109,7 @@ __AILZ_PREFLIGHT_COMMAND__
           enable-cache: false
 
       - name: Install AgentOps Toolkit
-        run: uv pip install --system "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+        run: uv pip install --system "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
 __EVAL_STEPS__
       - name: Upload AgentOps results
         if: always()

--- a/src/agentops/templates/workflows/agentops-deploy-qa.yml
+++ b/src/agentops/templates/workflows/agentops-deploy-qa.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install AgentOps Toolkit
         run: |
-          uv pip install --system "agentops-accelerator[foundry]__AGENTOPS_INSTALL_SPEC__"
+          uv pip install --system "agentops-accelerator__AGENTOPS_INSTALL_SPEC__"
 
 __EVAL_STEPS__
 


### PR DESCRIPTION
## Summary
- Simplifies the README into a concise GitHub landing page that points users to https://aka.ms/agentops-accelerator.
- Moves Foundry runtime dependencies into the default package install.
- Updates generated workflow templates, skills, and error guidance to stop referencing the old `[foundry]` extra.

## Validation
- `python -m pytest tests/ -x -q`
- `python -m pip install --dry-run .`