### PR TITLE
Use sandbox for prompt-agent PR candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Changed
+- **Prompt-agent PR validation now uses sandbox instead of dev.** Generated
+  GitHub and Azure DevOps PR workflows stage prompt-agent candidates in the
+  sandbox Foundry environment, keeping dev for deployed-of-record versions.
+
 ## [0.5.3] - 2026-06-22
 
 ### Fixed

--- a/src/agentops/services/cicd.py
+++ b/src/agentops/services/cicd.py
@@ -211,10 +211,9 @@ _PROMPT_AGENT_VALUES: Dict[str, Dict[str, str]] = {
     "pr": {
         "__ENV_LABEL__": "PR",
         "__ENV_KEY__": "pr",
-        # PR candidates are staged in the dev Foundry project so the
-        # gate evaluates the same target the deploy workflow will use.
-        # Sandbox is the author's playground only.
-        "__ENV_NAME__": "dev",
+        # PR candidates are staged in sandbox. Deploy workflows are the
+        # only path that promotes reviewed prompts to dev, qa, and prod.
+        "__ENV_NAME__": "sandbox",
         "__BRANCHES__": "",
         "__EVAL_JOB_NAME__": "AgentOps eval (PR gate)",
     },
@@ -245,9 +244,9 @@ _PROMPT_AGENT_VALUES_ADO: Dict[str, Dict[str, str]] = {
     "pr": {
         "__ENV_LABEL__": "PR",
         "__ENV_KEY__": "pr",
-        # PR candidates are staged in the dev Foundry project so the
-        # gate evaluates the same target the deploy pipeline will use.
-        "__ENV_NAME__": "dev",
+        # PR candidates are staged in sandbox. Deploy pipelines are the
+        # only path that promotes reviewed prompts to dev, qa, and prod.
+        "__ENV_NAME__": "sandbox",
         "__BRANCHES__": "",
     },
     "dev": {

--- a/src/agentops/templates/pipelines/azuredevops/agentops-pr-prompt-agent.yml
+++ b/src/agentops/templates/pipelines/azuredevops/agentops-pr-prompt-agent.yml
@@ -5,12 +5,12 @@
 # For Foundry prompt-agent flows, the PR gate must evaluate the prompt
 # the PR is proposing, not the seed agent version pinned in
 # `agentops.yaml`. So this PR pipeline stages an ephemeral candidate
-# Foundry prompt-agent version in the dev project from the
+# Foundry prompt-agent version in the sandbox project from the
 # source-controlled `prompt_file`, evaluates that exact candidate, and
 # runs Doctor against it. The merge gate is the eval + Doctor result.
 #
 # Notes:
-#   - Each PR run creates or reuses a candidate version in the dev
+#   - Each PR run creates or reuses a candidate version in the sandbox
 #     Foundry project. AgentOps deduplicates only when the prompt is
 #     byte-identical to the current seed version's instructions.
 #     Candidate versions are tagged with `agentops:candidate=true` and

--- a/src/agentops/templates/skills/agentops-workflow/SKILL.md
+++ b/src/agentops/templates/skills/agentops-workflow/SKILL.md
@@ -62,11 +62,11 @@ by discovering the whole Azure subscription.
    - `azd env get-values` when `azure.yaml` exists and azd is available.
    - `.github/workflows/agentops-*.yml`.
 2. Read the generated workflows to determine exactly which GitHub environments
-   and variables are needed. For the prompt-agent tutorial, `pr` normally
-   means only `environment: dev`.
-3. Treat `dev` here as a GitHub Actions environment for OIDC and variables. It
-   normally points at the Foundry project already configured by `agentops init`;
-   it does not require creating a new Foundry project.
+   and variables are needed. For prompt-agent PR gates, `pr` uses
+   `environment: sandbox`; deploy workflows use `dev`, `qa`, or `production`.
+3. Treat these as GitHub Actions environments for OIDC and variables. `sandbox`
+   points at the Foundry authoring project. `dev` points at the first shared
+   post-merge project.
 4. Proceed only when these values are known or deliberately chosen:
    - GitHub `owner/repo`.
    - workflow environment names from `jobs.*.environment`.
@@ -271,7 +271,7 @@ The full scaffold writes:
 
 | Kind | GitHub Actions path | Azure DevOps path | Trigger | Environment |
 |---|---|---|---|---|
-| `pr` | `.github/workflows/agentops-pr.yml` | `.azuredevops/pipelines/agentops-pr.yml` | PRs to `develop`, `release/**`, `main` | `dev` |
+| `pr` | `.github/workflows/agentops-pr.yml` | `.azuredevops/pipelines/agentops-pr.yml` | PRs to `develop`, `release/**`, `main` | `sandbox` for prompt-agent PR candidates, `dev` for generic PR gates |
 | `dev` | `.github/workflows/agentops-deploy-dev.yml` | `.azuredevops/pipelines/agentops-deploy-dev.yml` | push to `develop` | `dev` |
 | `qa` | `.github/workflows/agentops-deploy-qa.yml` | `.azuredevops/pipelines/agentops-deploy-qa.yml` | push to `release/**` | `qa` |
 | `prod` | `.github/workflows/agentops-deploy-prod.yml` | `.azuredevops/pipelines/agentops-deploy-prod.yml` | push to `main` | `production` |
@@ -303,9 +303,10 @@ Useful flags:
 ### GitHub Actions
 
 Read the generated workflow files and create only the GitHub Environments used
-by `jobs.*.environment`. For `pr`, that is usually only **`dev`**. For the full
-scaffold, create **`dev`**, **`qa`**, and **`production`**.
+by `jobs.*.environment`. For prompt-agent PR gates, create **`sandbox`**. For the
+full scaffold, create **`sandbox`**, **`dev`**, **`qa`**, and **`production`**.
 
+- **`sandbox`** - no extra protection. Store the PR candidate endpoint and OIDC variables here when generated jobs use `environment: sandbox`.
 - **`dev`** - no extra protection. Store the OIDC variables here when the
   generated jobs use `environment: dev`.
 - **`qa`** - usually no required reviewers, but isolated variables for QA.

--- a/src/agentops/templates/workflows/agentops-pr-prompt-agent.yml
+++ b/src/agentops/templates/workflows/agentops-pr-prompt-agent.yml
@@ -5,12 +5,12 @@
 # For Foundry prompt-agent flows, the PR gate must evaluate the prompt
 # the PR is proposing, not the seed agent version pinned in
 # `agentops.yaml`. So this PR workflow stages an ephemeral candidate
-# Foundry prompt-agent version in the dev project from the
+# Foundry prompt-agent version in the sandbox project from the
 # source-controlled `prompt_file`, evaluates that exact candidate, and
 # runs Doctor against it. The merge gate is the eval + Doctor result.
 #
 # Notes:
-#   - Each PR run creates or reuses a candidate version in the dev
+#   - Each PR run creates or reuses a candidate version in the sandbox
 #     Foundry project. AgentOps deduplicates only when the prompt is
 #     byte-identical to the current seed version's instructions.
 #     Candidate versions are tagged with `agentops:candidate=true` and
@@ -49,9 +49,8 @@ jobs:
   stage-candidate:
     name: Stage Foundry prompt candidate (PR)
     runs-on: ubuntu-latest
-    # Stage candidates in the dev Foundry project. Sandbox is the
-    # author's playground; dev is where CI proves a change is safe to
-    # merge.
+    # Stage candidates in sandbox. Dev is updated only by the deploy
+    # workflow after the PR merges.
     environment: __ENV_NAME__
     timeout-minutes: 20
     steps:

--- a/tests/unit/test_cicd.py
+++ b/tests/unit/test_cicd.py
@@ -1072,8 +1072,9 @@ def test_prompt_agent_pr_template_stages_candidate_before_eval(tmp_path: Path) -
     assert "prompt_deploy record" not in content
     # Default doctor gate is critical
     assert "--severity-fail critical" in content
-    # PR candidates land in the dev Foundry project (not "pr", not sandbox)
-    assert "environment: dev" in content
+    # PR candidates stay in sandbox. Deploy workflows promote to dev after merge.
+    assert "environment: sandbox" in content
+    assert "--environment \"sandbox\"" in content
 
 
 def test_prompt_agent_pr_template_is_valid_yaml(tmp_path: Path) -> None:


### PR DESCRIPTION
Prompt-agent PR gates were staging candidate prompt versions in the dev Foundry project. That made the PR gate look like a dev deployment path instead of a pre-merge candidate check.\n\nThis changes generated GitHub Actions and Azure DevOps prompt-agent PR templates to use the sandbox environment for PR candidates. Deploy workflows continue to promote reviewed prompts to dev, qa, and production after merge.\n\nValidation:\n- PYTHONPATH=src python -m pytest tests\\unit\\test_cicd.py -q