### PR TITLE
fix(cli): resolve ruff F821 blocking v0.4.5 release build

### DIFF
--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -14,12 +14,15 @@ from html import escape as html_escape
 from pathlib import Path
 from textwrap import wrap
 from collections.abc import Sequence
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any, Optional, TYPE_CHECKING
 
 import typer
 
 from agentops.utils.colors import style
 from agentops.utils.logging import get_logger, setup_logging
+
+if TYPE_CHECKING:
+    from agentops.core.agentops_config import AgentOpsConfig
 
 app = typer.Typer(
     name="agentops",


### PR DESCRIPTION
Lint-only hotfix. The v0.4.5 release build failed at the ruff step with F821 Undefined name AgentOpsConfig in src/agentops/cli/app.py. The _apply_http_redteam_defaults helper annotated its cfg parameter with AgentOpsConfig without importing it. This adds a TYPE_CHECKING-guarded import (no runtime cost) so ruff resolves the name. ruff check src/ tests/ passes locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>