### PR TITLE
fix(tests): unbreak reconfigure wizard test hang blocking v0.4.5

### DIFF
--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -462,7 +462,7 @@ def test_run_wizard_reconfigure_forces_questions_even_when_defaults_present(
     monkeypatch.delenv(ENV_KEY_APPINSIGHTS, raising=False)
 
     (tmp_path / "agentops.yaml").write_text(
-        "version: 1\nagent: my-agent:1\ndataset: .agentops/data/smoke.jsonl\n",
+        "version: 1\nagent: configured-agent:1\ndataset: .agentops/data/smoke.jsonl\n",
         encoding="utf-8",
     )
     smoke = tmp_path / ".agentops" / "data" / "smoke.jsonl"
@@ -495,6 +495,6 @@ def test_run_wizard_reconfigure_forces_questions_even_when_defaults_present(
 
     assert prompt_calls == [
         "Foundry project endpoint",
-        "Agent",
+        "Agent / orchestrator endpoint",
         "Dataset path",
     ]


### PR DESCRIPTION
The HTTP governance commit renamed the agent prompt label and made 'my-agent:1' a placeholder that forces a re-prompt, but left test_run_wizard_reconfigure_forces_questions_even_when_defaults_present using that placeholder with an always-empty injected prompt. The agent prompt looped forever, hanging the release test job and blocking the v0.4.5 build.

Fix: use a non-placeholder agent value and assert the current question label, matching the sibling wizard tests.

Validation: test_init_command.py + test_setup_wizard.py = 72 passed in 4s (was hanging); ruff clean.