### PR TITLE
feat(http): capture multi-field JSON responses for grey-box RAG eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Added
+- **Grey-box retrieval capture for HTTP JSON targets.** An HTTP target can now
+  capture extra named fields from a JSON response via a `response_fields` map
+  (`name -> dot-path`). Captured values are exposed to evaluator `input_mapping`
+  as `$response.<name>` (for example `$response.context`,
+  `$response.retrieved_documents`), and dataset columns can be referenced with
+  `$row.<name>` (for example `$row.qrels`). This lets RAG evaluators such as
+  Groundedness, Retrieval, and Document Retrieval score the retrieval actually
+  used at eval time instead of static dataset context. The primary prediction
+  (`response_field`) and single-field behavior are unchanged when
+  `response_fields` is not set.
+
 ## [0.4.5] - 2026-06-19
 
 ### Added

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -96,6 +96,8 @@ metadata:
 | `$prediction` | Model or agent response |
 | `$expected` | Ground truth / expected answer from the dataset row |
 | `$context` | Retrieved context documents from the dataset row |
+| `$response.<name>` | A field captured from the live HTTP JSON response via the target's `response_fields` map (e.g. `$response.context`, `$response.retrieved_documents`). Missing captures are skipped. |
+| `$row.<name>` | An arbitrary column from the dataset row (e.g. `$row.qrels` for Document Retrieval ground truth). Missing columns are skipped. |
 | `$tool_calls` | Tool calls returned by the agent |
 | `$tool_definitions` | Tool definitions from the dataset row |
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -325,6 +325,7 @@ That's a complete config. AgentOps:
 | `thresholds` | no | Metric gates such as `">=3"` or `"<=10"`. |
 | `protocol` | no | URL protocol: `responses`, `invocations`, or `http-json`. |
 | `request_field` / `response_field` / `tool_calls_field` | no | Request/response JSON keys or dot-paths. |
+| `response_fields` | no | Map of `name -> dot-path` capturing extra fields from a JSON response. Each captured value is exposed to evaluator `input_mapping` as `$response.<name>`. Only used when `response_mode` is `json`. |
 | `headers` | no | Static HTTP headers (dict). |
 | `auth_header_env` | no | Env var name holding a Bearer token. |
 | `evaluators` | no | Escape-hatch list of evaluator names that overrides auto-selection. |
@@ -377,6 +378,35 @@ dataset: .agentops/data/qa.jsonl
 request_field: message            # default is "message"
 response_field: text              # dot-path; default is "text"
 auth_header_env: APP_API_TOKEN    # value used as Bearer token
+```
+
+**HTTP-deployed agent with grey-box retrieval capture (RAG evaluators):**
+
+When the endpoint can return its retrieval alongside the answer (for example a
+JSON body `{"answer": ..., "context": ..., "retrieved_documents": [...]}`),
+capture the extra fields with `response_fields` and reference them in evaluator
+`input_mapping` via `$response.<name>`. This scores the retrieval actually used
+at eval time instead of static dataset context.
+
+```yaml
+version: 1
+agent: https://my-aca-app.eastus2.azurecontainerapps.io/orchestrator
+dataset: .agentops/data/qa.jsonl
+response_mode: json
+request_field: ask
+response_field: answer             # primary prediction (dot-path)
+response_fields:                   # extra fields captured per row
+  context: context
+  retrieved_documents: retrieved_documents
+bundle:
+  evaluators:
+    - name: groundedness
+      config:
+        kind: builtin
+        class_name: GroundednessEvaluator
+        input_mapping:
+          response: $response.answer
+          context: $response.context
 ```
 
 **Raw model deployment:**

--- a/src/agentops/core/agentops_config.py
+++ b/src/agentops/core/agentops_config.py
@@ -758,6 +758,18 @@ class AgentOpsConfig(BaseModel):
     request_field: Optional[str] = None
     response_field: Optional[str] = None
     tool_calls_field: Optional[str] = None
+    response_fields: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Extra named fields to capture from an http-json response, mapping "
+            "a name to a dot-path into the JSON body (e.g. {context: context, "
+            "retrieved_documents: retrieved_documents}). Each captured value is "
+            "exposed to evaluator input_mapping via the '$response.<name>' "
+            "token, so RAG evaluators can score the live retrieved context "
+            "returned by the same call. Only used when response_mode is "
+            "'json'. The primary answer still comes from response_field."
+        ),
+    )
     headers: Dict[str, str] = Field(default_factory=dict)
     auth_header_env: Optional[str] = None
     response_mode: ResponseMode = Field(
@@ -943,6 +955,7 @@ class AgentOpsConfig(BaseModel):
             self.request_field
             or self.response_field
             or self.tool_calls_field
+            or self.response_fields
             or self.headers
             or self.auth_header_env
             or self.response_mode != "json"

--- a/src/agentops/pipeline/invocations.py
+++ b/src/agentops/pipeline/invocations.py
@@ -658,10 +658,17 @@ def _invoke_http_json(
         if isinstance(extracted, list):
             tool_calls = extracted
 
+    captured: Dict[str, Any] = {}
+    for name, path in (config.response_fields or {}).items():
+        value = _dot_path(payload, path)
+        if value is not None:
+            captured[name] = value
+
     return InvocationResult(
         response=response_text.strip(),
         latency_seconds=elapsed,
         tool_calls=tool_calls,
+        metadata={"response_fields": captured} if captured else {},
     )
 
 

--- a/src/agentops/pipeline/orchestrator.py
+++ b/src/agentops/pipeline/orchestrator.py
@@ -760,6 +760,7 @@ def _evaluate_row(
         )
 
         metrics: List[RowMetric] = []
+        captured_fields = invocation.metadata.get("response_fields") or {}
         for evaluator in evaluators:
             metric = runtime.run_evaluator(
                 evaluator,
@@ -767,6 +768,7 @@ def _evaluate_row(
                 response=invocation.response,
                 latency_seconds=invocation.latency_seconds,
                 actual_tool_calls=invocation.tool_calls,
+                response_fields=captured_fields,
             )
             metrics.append(metric)
 
@@ -819,7 +821,7 @@ def _evaluate_row(
         input=str(row.get("input", "")),
         expected=row.get("expected"),
         response=invocation.response,
-        context=row.get("context"),
+        context=captured_fields.get("context", row.get("context")),
         latency_seconds=invocation.latency_seconds,
         tool_calls=invocation.tool_calls,
         metrics=metrics,

--- a/src/agentops/pipeline/runtime.py
+++ b/src/agentops/pipeline/runtime.py
@@ -298,12 +298,32 @@ def _resolve_kwargs(
     *,
     row: Dict[str, Any],
     response: str,
+    response_fields: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     resolved: Dict[str, Any] = {}
     merged = {**row, "response": response, "input": row.get("input")}
+    captured = response_fields or {}
     for kwarg, placeholder in mapping.items():
         if not isinstance(placeholder, str) or not placeholder.startswith("$"):
             resolved[kwarg] = placeholder
+            continue
+        if placeholder.startswith("$response."):
+            # Live multi-field capture from an http-json target, e.g.
+            # '$response.context' resolves to the context the endpoint
+            # returned alongside the answer on the same call.
+            name = placeholder[len("$response."):]
+            value = captured.get(name)
+            if value is not None:
+                resolved[kwarg] = value
+            continue
+        if placeholder.startswith("$row."):
+            # Arbitrary dataset column, e.g. '$row.qrels' for Document
+            # Retrieval ground-truth labels that the fixed token set does
+            # not name explicitly.
+            name = placeholder[len("$row."):]
+            value = row.get(name)
+            if value is not None:
+                resolved[kwarg] = value
             continue
         source_key = _PLACEHOLDERS.get(placeholder)
         if source_key is None:
@@ -359,6 +379,7 @@ def run_evaluator(
     response: str,
     latency_seconds: float,
     actual_tool_calls: Optional[List[Any]] = None,
+    response_fields: Optional[Dict[str, Any]] = None,
 ) -> RowMetric:
     """Execute one evaluator on one row. Captures errors so the run continues."""
     preset = runtime.preset
@@ -389,7 +410,12 @@ def run_evaluator(
             )
 
     try:
-        kwargs = _resolve_kwargs(preset.input_mapping, row=row, response=response)
+        kwargs = _resolve_kwargs(
+            preset.input_mapping,
+            row=row,
+            response=response,
+            response_fields=response_fields,
+        )
         if preset.needs_conversation:
             # Prefer the actual calls made by the agent during invocation;
             # fall back to the dataset's expected calls if the runner did

--- a/tests/unit/test_http_streaming.py
+++ b/tests/unit/test_http_streaming.py
@@ -232,3 +232,77 @@ def test_custom_auth_header_on_streaming_target(monkeypatch) -> None:
 
     assert result.response == "Hello"
     assert captured["headers"].get("X-api-key") == "s3cret"
+
+
+# ---------------------------------------------------------------------------
+# (e) response_fields: capture extra named fields from a json response
+# ---------------------------------------------------------------------------
+
+
+def test_response_fields_capture_dotted_paths(monkeypatch) -> None:
+    payload = json.dumps(
+        {
+            "answer": "Paris is the capital of France.",
+            "context": "France is a country in Europe. Its capital is Paris.",
+            "retrieval": {
+                "documents": [
+                    {"id": "doc-1", "score": 0.91},
+                    {"id": "doc-2", "score": 0.42},
+                ]
+            },
+        }
+    ).encode("utf-8")
+    _patch_urlopen(monkeypatch, _FakeJsonResponse(payload))
+
+    config = _config(
+        request_field="ask",
+        response_field="answer",
+        response_fields={
+            "context": "context",
+            "retrieved_documents": "retrieval.documents",
+        },
+    )
+    result = _invoke(config, {"input": "capital of France?"})
+
+    assert result.response == "Paris is the capital of France."
+    captured = result.metadata["response_fields"]
+    assert captured["context"].startswith("France is a country")
+    assert captured["retrieved_documents"] == [
+        {"id": "doc-1", "score": 0.91},
+        {"id": "doc-2", "score": 0.42},
+    ]
+
+
+def test_response_fields_missing_path_is_skipped(monkeypatch) -> None:
+    payload = json.dumps({"answer": "ok", "context": "ctx"}).encode("utf-8")
+    _patch_urlopen(monkeypatch, _FakeJsonResponse(payload))
+
+    config = _config(
+        response_field="answer",
+        response_fields={"context": "context", "missing": "not.there"},
+    )
+    result = _invoke(config, {"input": "x"})
+
+    captured = result.metadata["response_fields"]
+    assert captured == {"context": "ctx"}
+
+
+def test_no_response_fields_leaves_metadata_empty(monkeypatch) -> None:
+    payload = json.dumps({"text": "echo: hi"}).encode("utf-8")
+    _patch_urlopen(monkeypatch, _FakeJsonResponse(payload))
+
+    config = _config()  # no response_fields configured
+    result = _invoke(config, {"input": "hi"})
+
+    assert result.response == "echo: hi"
+    assert result.metadata == {}
+
+
+def test_response_fields_rejected_on_non_http_target() -> None:
+    with pytest.raises(ValueError, match="only valid for"):
+        AgentOpsConfig(
+            version=1,
+            agent="my-prompt-agent:3",
+            dataset="./qa.jsonl",
+            response_fields={"context": "context"},
+        )

--- a/tests/unit/test_runtime_response_fields.py
+++ b/tests/unit/test_runtime_response_fields.py
@@ -1,0 +1,79 @@
+"""Unit tests for the ``$response.<name>`` evaluator placeholder.
+
+The grey-box RAG evaluators need to score the live context an http-json
+target returns alongside the answer on the same call. ``_resolve_kwargs``
+exposes those captured fields through the ``$response.<name>`` token so an
+evaluator's ``input_mapping`` can wire ``context: $response.context`` to the
+value captured by the target's ``response_fields`` map.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentops.pipeline.runtime import _resolve_kwargs
+
+
+def test_response_token_resolves_from_captured_fields() -> None:
+    out = _resolve_kwargs(
+        {"response": "$prediction", "context": "$response.context"},
+        row={"input": "capital of France?"},
+        response="Paris.",
+        response_fields={"context": "France's capital is Paris."},
+    )
+    assert out == {"response": "Paris.", "context": "France's capital is Paris."}
+
+
+def test_response_token_missing_capture_is_skipped() -> None:
+    # No captured value -> the kwarg is omitted rather than passing None,
+    # mirroring how unresolved dataset placeholders behave.
+    out = _resolve_kwargs(
+        {"context": "$response.context"},
+        row={"input": "x"},
+        response="ans",
+        response_fields={},
+    )
+    assert out == {}
+
+
+def test_response_token_for_arbitrary_field_name() -> None:
+    docs = [{"id": "doc-1", "score": 0.9}]
+    out = _resolve_kwargs(
+        {"retrieval_ground_truth": "$row.qrels",
+         "retrieved_documents": "$response.retrieved_documents"},
+        row={"input": "q", "qrels": {"doc-1": 1}},
+        response="ans",
+        response_fields={"retrieved_documents": docs},
+    )
+    assert out["retrieved_documents"] == docs
+    assert out["retrieval_ground_truth"] == {"doc-1": 1}
+
+
+def test_row_token_missing_field_is_skipped() -> None:
+    out = _resolve_kwargs(
+        {"qrels": "$row.qrels"},
+        row={"input": "x"},
+        response="ans",
+    )
+    assert out == {}
+
+
+def test_builtin_context_token_unchanged_without_capture() -> None:
+    # Backward compat: $context still resolves from the dataset row when no
+    # response_fields are provided.
+    out = _resolve_kwargs(
+        {"context": "$context"},
+        row={"input": "x", "context": "dataset context"},
+        response="ans",
+    )
+    assert out == {"context": "dataset context"}
+
+
+def test_unknown_placeholder_still_raises() -> None:
+    with pytest.raises(ValueError, match="unknown evaluator placeholder"):
+        _resolve_kwargs(
+            {"x": "$nope"},
+            row={"input": "x"},
+            response="ans",
+            response_fields={"context": "c"},
+        )


### PR DESCRIPTION
## What

Adds **multi-field HTTP JSON response capture** so an `http-json` target can
expose more than just the answer to evaluators. This unblocks grey-box RAG
evaluation where Groundedness / Retrieval / Document Retrieval score the
retrieval the endpoint *actually used* on the same call, instead of static
dataset context.

## Changes

- **Config** (`agentops_config.py`): new `response_fields: {name -> dot-path}`
  on the http-json target block, guarded to http-json only.
- **Capture** (`invocations.py`): in `response_mode: json`, capture each
  `response_fields` value per row and carry it on `InvocationResult.metadata`.
- **Resolver** (`runtime.py`): evaluator `input_mapping` now supports
  `$response.<name>` (live captured field) and `$row.<name>` (arbitrary dataset
  column, e.g. `$row.qrels`). Missing values are skipped. The fixed token set
  (`$prompt`, `$prediction`, `$context`, ...) is unchanged.
- **Threading** (`orchestrator.py`): captured fields are passed to
  `run_evaluator`; `RowResult.context` prefers live captured context over the
  dataset column.
- **Docs**: HTTP target reference (`how-it-works.md`), input-mapping tokens
  (`bundles.md`), and a CHANGELOG `[Unreleased]` entry.

## Backward compatibility

Fully backward compatible. With no `response_fields`, metadata stays empty,
`$context` still resolves from the dataset, and single-field extraction is
unchanged.

## Tests

- `tests/unit/test_http_streaming.py`: capture of dotted paths, missing path
  skipped, empty when unset, rejected on non-http targets.
- `tests/unit/test_runtime_response_fields.py`: `$response.<name>` /
  `$row.<name>` resolution, missing-skip, backward-compat `$context`, unknown
  placeholder still raises.

Local: targeted suites green, full unit suite 985 passed (1 unrelated
azure.mgmt namespace import failure in the shared venv), ruff clean on changed
files.
