### PR TITLE
Render gate results in Actions summary; Node24 workflow templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Added
+- **Rendered gate results in GitHub Actions job summaries.** When AgentOps runs
+  inside GitHub Actions (`GITHUB_STEP_SUMMARY` set), `agentops eval run` now
+  appends the full rendered `report.md` to the workflow run summary, and
+  `agentops assert run` / `agentops redteam run` append a concise pass/fail
+  summary (suite, cases, pass rate, per-dimension and per-risk-category
+  breakdowns). Reviewers can read the report directly on the run page without
+  downloading the uploaded artifacts. Writes are best-effort and a no-op outside
+  GitHub Actions, so local runs are unaffected.
+
+### Changed
+- **Generated workflows use Node24-ready action versions.** The prompt-agent and
+  watchdog workflow templates now pin `actions/download-artifact@v7` (instead of
+  the Node20 `@v4`), so generated pipelines no longer emit the "Node.js 20
+  actions are deprecated" warning. A regression guard checks every workflow
+  template against the known Node20 action majors.
+
 ## [0.5.0] - 2026-06-19
 
 ### Added

--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -2354,6 +2354,70 @@ def _resolve_eval_config_path(config: Path | None) -> Path:
     return Path("agentops.yaml")
 
 
+def _append_assert_step_summary(result, *, scored_cases, pass_rate) -> None:
+    """Append an ASSERT gate summary to the GitHub Actions step summary."""
+    from agentops.core.step_summary import append_step_summary, is_active
+
+    if not is_active():
+        return
+    status = "❌ VIOLATIONS" if result.has_violations else "✅ PASS"
+    lines = [
+        "## AgentOps ASSERT gate",
+        "",
+        f"**Result:** {status}",
+        "",
+        f"- **Suite:** `{result.suite}`",
+        f"- **Run:** `{result.run_id}`",
+        f"- **Cases:** {result.total_cases} "
+        f"(scored={scored_cases}, passed={result.passed_cases}, "
+        f"failed={result.failed_cases}, skipped={result.skipped_cases})",
+        f"- **Pass rate:** {pass_rate}",
+    ]
+    if result.dimension_summary:
+        lines += ["", "| Dimension | Result |", "| --- | --- |"]
+        for name, bucket in sorted(result.dimension_summary.items()):
+            violations = bucket.get("violations", 0)
+            total = bucket.get("total", 0)
+            skipped = bucket.get("skipped", 0)
+            if violations == 0:
+                clean = max(total - skipped, 0)
+                cell = f"{clean}/{total} clean ✅"
+            else:
+                cell = f"{violations}/{total} violating ❌"
+            if skipped:
+                cell += f" (skipped={skipped})"
+            lines.append(f"| {name} | {cell} |")
+    append_step_summary("\n".join(lines))
+
+
+def _append_redteam_step_summary(result, *, asr_pct) -> None:
+    """Append a Red Team gate summary to the GitHub Actions step summary."""
+    from agentops.core.step_summary import append_step_summary, is_active
+
+    if not is_active():
+        return
+    status = "❌ HIGH" if result.has_violations else "✅ PASS"
+    lines = [
+        "## AgentOps Red Team gate",
+        "",
+        f"**Result:** {status}",
+        "",
+        f"- **Attempts:** {result.total_attempts} "
+        f"(successful={result.successful_attacks})",
+        f"- **Attack success rate:** {asr_pct}",
+    ]
+    if result.fail_threshold is not None:
+        lines.append(f"- **Gate threshold:** {result.fail_threshold:.1%}")
+    if result.per_category:
+        lines += ["", "| Risk category | Successful | Rate |", "| --- | --- | --- |"]
+        for name, bucket in sorted(result.per_category.items()):
+            total = bucket.get("total", 0)
+            successful = bucket.get("successful", 0)
+            rate = bucket.get("attack_success_rate", 0.0)
+            lines.append(f"| {name} | {successful}/{total} | {rate:.1%} |")
+    append_step_summary("\n".join(lines))
+
+
 @assert_app.command("run")
 def cmd_assert_run(
     config: Annotated[
@@ -2563,6 +2627,8 @@ def cmd_assert_run(
             "  (skipped cases usually mean the tester model self-refused before "
             "reaching the target; try a less restrictive tester deployment.)"
         )
+
+    _append_assert_step_summary(result, scored_cases=scored_cases, pass_rate=pass_rate)
 
     if result.has_violations:
         msg = (
@@ -2805,6 +2871,8 @@ def cmd_redteam_run(
             rate = bucket.get("attack_success_rate", 0.0)
             typer.echo(f"  {name}: {successful}/{total} ({rate:.1%})")
 
+    _append_redteam_step_summary(result, asr_pct=asr_pct)
+
     if result.has_violations:
         msg = (
             f"{_cli_error('FAIL')}: Red Team attack success rate "
@@ -2946,6 +3014,9 @@ def _run_flat_schema_eval(
     report_url = azd_eval.get("report_url") if isinstance(azd_eval, dict) else None
     if isinstance(report_url, str) and report_url.strip():
         typer.echo(f"{_cli_label('Foundry run')}:  {report_url.strip()}")
+    from agentops.core.step_summary import append_report_file
+
+    append_report_file(output_dir / "report.md")
     if result.summary.overall_passed:
         typer.echo(f"{_cli_label('Threshold status')}: {style('PASSED', 'bold', 'green')}")
         return

--- a/src/agentops/core/step_summary.py
+++ b/src/agentops/core/step_summary.py
@@ -1,0 +1,65 @@
+"""Helpers for surfacing AgentOps gate output in CI job summaries.
+
+When AgentOps runs inside GitHub Actions, the ``GITHUB_STEP_SUMMARY``
+environment variable points at a Markdown file whose contents render on the
+workflow run page. These helpers append AgentOps output there so reviewers can
+read the rendered report directly on the run page, without downloading the
+uploaded artifacts.
+
+All writes are best-effort and never raise, so command handlers can call them
+unconditionally: outside GitHub Actions they simply do nothing.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+
+def _summary_path() -> Optional[Path]:
+    raw = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not raw or not raw.strip():
+        return None
+    return Path(raw)
+
+
+def is_active() -> bool:
+    """Return True when a GitHub Actions step summary target is available."""
+    return _summary_path() is not None
+
+
+def append_step_summary(markdown: str) -> bool:
+    """Append a Markdown block to the GitHub Actions step summary.
+
+    Returns ``True`` when the block was written, ``False`` when not running
+    under GitHub Actions or when the write failed. Never raises.
+    """
+    path = _summary_path()
+    if path is None:
+        return False
+    try:
+        text = markdown if markdown.endswith("\n") else markdown + "\n"
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.write("\n")
+        return True
+    except Exception:
+        return False
+
+
+def append_report_file(report_path: Path, *, heading: Optional[str] = None) -> bool:
+    """Append the contents of a rendered report file to the step summary.
+
+    Used for ``agentops eval run`` so the full ``report.md`` renders inline on
+    the workflow run page. Returns ``False`` when not under GitHub Actions or
+    when the report cannot be read. Never raises.
+    """
+    if _summary_path() is None:
+        return False
+    try:
+        body = Path(report_path).read_text(encoding="utf-8")
+    except Exception:
+        return False
+    block = body if heading is None else f"{heading}\n\n{body}"
+    return append_step_summary(block)

--- a/src/agentops/templates/workflows/agentops-deploy-prompt-agent.yml
+++ b/src/agentops/templates/workflows/agentops-deploy-prompt-agent.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download candidate deployment record
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: foundry-agent-__ENV_KEY__-candidate
           path: .agentops/deployments
@@ -169,7 +169,7 @@ __EVAL_STEPS__
     timeout-minutes: 10
     steps:
       - name: Download candidate deployment record
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: foundry-agent-__ENV_KEY__-candidate
           path: .agentops/deployments

--- a/src/agentops/templates/workflows/agentops-pr-prompt-agent.yml
+++ b/src/agentops/templates/workflows/agentops-pr-prompt-agent.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download candidate deployment record
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: foundry-agent-__ENV_KEY__-candidate
           path: .agentops/deployments

--- a/src/agentops/templates/workflows/agentops-watchdog.yml
+++ b/src/agentops/templates/workflows/agentops-watchdog.yml
@@ -69,7 +69,7 @@ jobs:
       # downloads when the artifact does not exist yet, instead of
       # surfacing a red error annotation on every first run.
       - name: Restore Doctor history (if any)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: agentops-doctor-history
           path: .agentops/agent/

--- a/tests/unit/test_cicd.py
+++ b/tests/unit/test_cicd.py
@@ -31,8 +31,14 @@ _DEPRECATED_NODE20_ACTION_REFS = (
     "actions/checkout@v4",
     "actions/setup-python@v5",
     "actions/upload-artifact@v4",
+    "actions/upload-artifact@v5",
+    "actions/download-artifact@v4",
+    "actions/download-artifact@v5",
+    "actions/download-artifact@v6",
     "actions/github-script@v7",
     "astral-sh/setup-uv@v3",
+    "astral-sh/setup-uv@v5",
+    "astral-sh/setup-uv@v6",
     "azure/login@v2",
 )
 

--- a/tests/unit/test_step_summary.py
+++ b/tests/unit/test_step_summary.py
@@ -1,0 +1,72 @@
+"""Unit tests for the GitHub Actions step-summary helpers."""
+
+from __future__ import annotations
+
+from agentops.core import step_summary
+
+
+def test_is_active_reflects_env(monkeypatch, tmp_path):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    assert step_summary.is_active() is False
+
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    assert step_summary.is_active() is True
+
+
+def test_append_step_summary_noop_without_env(monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    assert step_summary.append_step_summary("# hello") is False
+
+
+def test_append_step_summary_writes_and_appends(monkeypatch, tmp_path):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    assert step_summary.append_step_summary("# first") is True
+    assert step_summary.append_step_summary("# second\n") is True
+
+    content = summary.read_text(encoding="utf-8")
+    assert "# first" in content
+    assert "# second" in content
+    # Each block ends with its own newline plus a separating blank line.
+    assert content.index("# first") < content.index("# second")
+
+
+def test_append_report_file_appends_contents(monkeypatch, tmp_path):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    report = tmp_path / "report.md"
+    report.write_text("# AgentOps Evaluation Report\n\nPASS\n", encoding="utf-8")
+
+    assert step_summary.append_report_file(report) is True
+    content = summary.read_text(encoding="utf-8")
+    assert "AgentOps Evaluation Report" in content
+    assert "PASS" in content
+
+
+def test_append_report_file_with_heading(monkeypatch, tmp_path):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    report = tmp_path / "report.md"
+    report.write_text("body\n", encoding="utf-8")
+
+    assert step_summary.append_report_file(report, heading="## Eval") is True
+    content = summary.read_text(encoding="utf-8")
+    assert "## Eval" in content
+    assert "body" in content
+
+
+def test_append_report_file_missing_file_is_false(monkeypatch, tmp_path):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    assert step_summary.append_report_file(tmp_path / "missing.md") is False
+    assert summary.exists() is False or summary.read_text(encoding="utf-8") == ""
+
+
+def test_append_report_file_noop_without_env(monkeypatch, tmp_path):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    report = tmp_path / "report.md"
+    report.write_text("body\n", encoding="utf-8")
+    assert step_summary.append_report_file(report) is False


### PR DESCRIPTION
## Summary
Two CI/governance polish changes that came out of finishing the GPT-RAG HTTP governance tutorial.

### 1. Rendered gate results in the GitHub Actions job summary
When AgentOps runs inside GitHub Actions (`GITHUB_STEP_SUMMARY` set):
- `agentops eval run` appends the full rendered `report.md` to the run summary.
- `agentops assert run` and `agentops redteam run` append a concise pass/fail block (suite, cases, pass rate, per-dimension and per-risk-category breakdown).

Reviewers can read the report inline on the run page instead of downloading artifacts. New module `core/step_summary.py` with best-effort helpers that never raise and no-op outside Actions, so a gate can never break because of summary writing. Mirrors the existing `prompt_deploy.py` pattern.

### 2. Node24-ready workflow templates
Bump `actions/download-artifact@v4` (Node20) to `@v7` (Node24) in the prompt-agent and watchdog templates, and extend the existing node20 deprecation guard to cover the download/upload/setup-uv node20 majors. Generated pipelines stop emitting the "Node.js 20 actions are deprecated" warning.

## Tests
- `tests/unit/test_step_summary.py` (new, 7 tests).
- `tests/unit/test_cicd.py` guard extended.
- Local: `test_cicd.py` + `test_step_summary.py` = 80 passed. ruff clean.

## Notes
- CHANGELOG Unreleased updated (Added + Changed).
