### PR TITLE
Update AgentOps CLI tagline to Operate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 ## [Unreleased]
 
 ### Changed
+- Updated the AgentOps CLI tagline to use `Operate` instead of `Own` for clearer
+  operator-focused positioning.
 - **Prompt-agent PR validation now uses sandbox instead of dev.** Generated
   GitHub and Azure DevOps PR workflows stage prompt-agent candidates in the
   sandbox Foundry environment, keeping dev for deployed-of-record versions.

--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -5417,8 +5417,8 @@ def _colorize_block(
 # fallback keeps the same words on a single line.
 def _agentops_tagline() -> str:
     if _terminal_unicode_enabled():
-        return "Evaluate  ·  Ship  ·  Observe  ·  Own  —  every Foundry agent."
-    return "Evaluate :: Ship :: Observe :: Own -- every Foundry agent."
+        return "Evaluate  ·  Ship  ·  Observe  ·  Operate  —  every Foundry agent."
+    return "Evaluate :: Ship :: Observe :: Operate -- every Foundry agent."
 
 
 def _render_brand_block(

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -303,7 +303,7 @@ def test_init_prints_brand_banner(tmp_path: Path, monkeypatch) -> None:
     # ASCII letterforms from _AGENTOPS_PLAIN_BANNER (figlet "Standard").
     assert "____ _____ _   _ _____" in text
     # The catchphrase, ASCII fallback variant.
-    assert "Evaluate :: Ship :: Observe :: Own -- every Foundry agent." in text
+    assert "Evaluate :: Ship :: Observe :: Operate -- every Foundry agent." in text
 
 
 def test_brand_tagline_is_used_by_explain_pages(monkeypatch) -> None:
@@ -315,7 +315,7 @@ def test_brand_tagline_is_used_by_explain_pages(monkeypatch) -> None:
     result = runner.invoke(app, ["init", "explain", "--no-pager"])
     assert result.exit_code == 0
     text = _strip_ansi(result.stdout)
-    assert "Evaluate :: Ship :: Observe :: Own -- every Foundry agent." in text
+    assert "Evaluate :: Ship :: Observe :: Operate -- every Foundry agent." in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose
Update the AgentOps CLI brand tagline from Own to Operate in the CLI banner and explain pages.

## Changes
- Updated the Unicode and ASCII CLI tagline strings.
- Updated focused init command assertions.
- Added an Unreleased changelog entry.

## Validation
- `uv run pytest tests/unit/test_init_command.py`