### PR TITLE
feat(telemetry): Foundry operations dashboard + cockpit redesign (#343)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,9 @@ Public CLI contract:
 - `agentops doctor [--workspace PATH] [--config PATH] [--out PATH] [--lookback-days N] [--severity-fail SEVERITY] [--evidence-pack] [--evidence-out PATH]`
 - `agentops doctor explain [--no-pager] [--format text|markdown|html] [--out PATH] [--open]`
 - `agentops cockpit [--host HOST] [--port PORT] [--workspace PATH] [--no-preflight]`
+- `agentops telemetry dashboard deploy [--dry-run] [--subscription ID] [--resource-group RG] [--workspace-id ID] [--name NAME] [--dir PATH]`
+- `agentops telemetry dashboard open [--print-url] [--subscription ID] [--resource-group RG] [--name NAME] [--dir PATH]`
+- `agentops telemetry dashboard export [--out PATH]`
 - `agentops agent serve [--host HOST] [--port PORT] [--config PATH] [--no-verify] [--workers N]`
 
 Exit code contract:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Added
+- **Foundry operations dashboard.** A new Azure Monitor Workbook
+  (`agentops telemetry dashboard`) surfaces Azure OpenAI capacity (PTU
+  utilization, rate-limit, spillover), traffic and tokens, latency
+  percentiles (TTFT, TBT, TTLT, tokens/sec), and errors and throttling for a
+  given Azure OpenAI resource and Log Analytics workspace. The workbook JSON,
+  its per-metric KQL queries, and an authoring README ship as package data.
+  Three commands manage it: `deploy` (RBAC + diagnostic-settings preflight,
+  then deploy the `Microsoft.Insights/workbooks` ARM resource, with
+  `--dry-run` to emit the template), `open` (build the portal deep link and
+  open a browser, `--print-url` for non-interactive shells), and `export`
+  (copy the packaged workbook JSON to a local path). `agentops telemetry
+  dashboard deploy` is the first CLI command that creates an Azure resource;
+  it is scoped to a single workbook.
+- **Doctor check for Azure OpenAI usage telemetry.** A new WAF-AI Operational
+  Excellence posture rule (`waf.observability.aoai_diagnostic_categories`)
+  warns when the Azure OpenAI account is not emitting the `RequestResponse`
+  and `AzureOpenAIRequestUsage` diagnostic log categories to a Log Analytics
+  workspace, and prints the exact `az monitor diagnostic-settings create`
+  fix. Doctor stays read-only.
+
+### Changed
+- **Cockpit redesign answers "can I ship?" first.** The Cockpit now opens with
+  three consolidated status cards (Readiness, Doctor, Eval gate) that expand
+  their detail sections on click, promotes "Next actions" to second position,
+  and collapses the detailed sections by default. The former "Eval gate
+  summary" and "Quality gate summary" are merged into a single "Eval gates"
+  section with two subgroups. The Foundry launchpad footer adds a "Foundry
+  operations dashboard" tile (the same workbook portal URL used by
+  `agentops telemetry dashboard open`) next to "Operate overview", folds the
+  single-tile "Azure Monitor" group into the Foundry project group, and
+  removes the duplicated App Insights CTA from the Production signal section.
+  Cockpit remains read-only.
+
 ## [0.6.0] - 2026-06-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ where = ["src"]
   "pipelines/azuredevops/*.yml",
   "skills/*/SKILL.md",
   "agent-server/*",
+  "workbooks/*.json",
+  "workbooks/*.md",
+  "workbooks/queries/*.kql",
 ]
 "agentops.agent.knowledge" = ["*.csv"]
 

--- a/src/agentops/agent/checks/catalog.py
+++ b/src/agentops/agent/checks/catalog.py
@@ -722,6 +722,19 @@ CHECKS: Tuple[CheckSpec, ...] = (
         severities=(Severity.WARNING, Severity.CRITICAL),
         requires=("azure_resources",),
     ),
+    CheckSpec(
+        id="waf.observability.aoai_diagnostic_categories",
+        category=Category.OPERATIONAL_EXCELLENCE,
+        title="Azure OpenAI usage telemetry categories are not enabled",
+        summary=(
+            "The Azure OpenAI account is not emitting the RequestResponse "
+            "and AzureOpenAIRequestUsage diagnostic log categories to a Log "
+            "Analytics workspace, so the Foundry operations dashboard and "
+            "any token / latency / throttling analysis render empty."
+        ),
+        severities=(Severity.WARNING,),
+        requires=("azure_resources",),
+    ),
     # ------------------------------------------------------------------
     # Responsible AI
     # ------------------------------------------------------------------

--- a/src/agentops/agent/checks/posture_rules/__init__.py
+++ b/src/agentops/agent/checks/posture_rules/__init__.py
@@ -36,6 +36,9 @@ def _build_registry() -> Dict[str, RuleFn]:
     from agentops.agent.checks.posture_rules.diagnostics import (
         evaluate as diagnostics_rule,
     )
+    from agentops.agent.checks.posture_rules.aoai_diagnostic_categories import (
+        evaluate as aoai_diagnostic_categories_rule,
+    )
     from agentops.agent.checks.posture_rules.local_auth import (
         evaluate as local_auth_rule,
     )
@@ -47,6 +50,7 @@ def _build_registry() -> Dict[str, RuleFn]:
         "waf.security.local_auth_disabled": local_auth_rule,
         "waf.security.managed_identity": managed_identity_rule,
         "waf.security.diagnostic_settings": diagnostics_rule,
+        "waf.observability.aoai_diagnostic_categories": aoai_diagnostic_categories_rule,
     }
 
 

--- a/src/agentops/agent/checks/posture_rules/aoai_diagnostic_categories.py
+++ b/src/agentops/agent/checks/posture_rules/aoai_diagnostic_categories.py
@@ -1,0 +1,88 @@
+"""WAF-AI Operational Excellence: Azure OpenAI usage telemetry must flow.
+
+The Foundry operations dashboard (``agentops telemetry dashboard``) and any
+token / latency / throttling analysis depend on two diagnostic log categories
+being enabled on the Azure OpenAI (Cognitive Services) account and routed to a
+Log Analytics workspace:
+
+* ``RequestResponse`` - per-request traces (status codes, streaming).
+* ``AzureOpenAIRequestUsage`` - prompt / generated token counts.
+
+When either category is missing the workbook tiles render empty. This rule
+fires when the account does not emit both categories and prints the exact
+``az monitor diagnostic-settings create`` command to fix it. The check is
+read-only; it never changes Azure.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+from agentops.agent.findings import Category, Finding, Severity
+from agentops.agent.sources.azure_resources import AzureResourcesPayload
+
+RULE_ID = "waf.observability.aoai_diagnostic_categories"
+
+REQUIRED_CATEGORIES = ("RequestResponse", "AzureOpenAIRequestUsage")
+
+
+def _fix_command(account_id: str, workspace_id: str) -> str:
+    logs = json.dumps([{"category": c, "enabled": True} for c in REQUIRED_CATEGORIES])
+    return (
+        "az monitor diagnostic-settings create "
+        "--name agentops-foundry-ops "
+        f"--resource {account_id} "
+        f"--workspace {workspace_id} "
+        f"--logs '{logs}'"
+    )
+
+
+def evaluate(payload: AzureResourcesPayload, source_name: str) -> List[Finding]:
+    account = payload.account
+    if account is None:
+        return []
+
+    enabled: set[str] = set()
+    for setting in payload.diagnostic_settings:
+        for category in setting.enabled_log_categories:
+            enabled.add(str(category))
+
+    missing = [c for c in REQUIRED_CATEGORIES if c not in enabled]
+    if not missing:
+        return []
+
+    account_id = getattr(account, "id", None) or f"<{account.name}-resource-id>"
+    workspace_id = next(
+        (s.workspace_id for s in payload.diagnostic_settings if s.workspace_id),
+        "<log-analytics-workspace-id>",
+    )
+
+    return [
+        Finding(
+            id=RULE_ID,
+            severity=Severity.WARNING,
+            category=Category.OPERATIONAL_EXCELLENCE,
+            title="Azure OpenAI usage telemetry categories are not enabled",
+            summary=(
+                f"Azure OpenAI account `{account.name}` is not emitting the "
+                f"`{'`, `'.join(missing)}` diagnostic log "
+                f"{'category' if len(missing) == 1 else 'categories'}. The "
+                "Foundry operations dashboard and any token, latency, or "
+                "throttling analysis need both `RequestResponse` and "
+                "`AzureOpenAIRequestUsage` streamed to a Log Analytics "
+                "workspace, so those tiles will render empty."
+            ),
+            recommendation=(
+                "Enable the missing categories with:\n"
+                f"{_fix_command(account_id, workspace_id)}"
+            ),
+            source=source_name,
+            evidence={
+                "account": account.name,
+                "required_categories": list(REQUIRED_CATEGORIES),
+                "missing_categories": missing,
+                "enabled_categories": sorted(enabled),
+            },
+        )
+    ]

--- a/src/agentops/agent/cockpit.py
+++ b/src/agentops/agent/cockpit.py
@@ -334,6 +334,11 @@ def _build_eval_section(eval_runs: List[Dict[str, Any]]) -> Dict[str, Any]:
         "has_runs": True,
         "cards": cards,
         "latest_execution": latest_execution,
+        # Compact gate status consumed by the top status cards. ``latest_passed``
+        # reflects the most recent run's overall_passed; ``pass_rate`` is the
+        # share across all recorded runs (0.0-1.0).
+        "latest_passed": bool(latest["passed"]),
+        "pass_rate": pass_rate,
     }
 
 
@@ -1784,14 +1789,16 @@ def _build_open_in_foundry(
     """Build the deep-link panel that sends users from the cockpit
     straight into the equivalent Foundry / Azure Monitor surface.
 
-    Cockpit surfaces a curated panel of Foundry and Azure Monitor links so
-    users can drill down without manually navigating the portal. The Azure
-    Monitor tile is rendered as a separate subgroup to keep runtime views
-    and raw telemetry views easy to distinguish.
+    Cockpit surfaces a curated panel of Foundry links so users can drill
+    down without manually navigating the portal. Azure Monitor surfaces
+    (raw App Insights telemetry and the Foundry operations workbook) are
+    folded into the Foundry project subgroup so there is a single place to
+    look, rather than a duplicated one-tile group.
     """
     deeplinks = _foundry_deeplinks(workspace)
     portal_url = telemetry.get("portal_url") if isinstance(telemetry, dict) else None
     project_url = _resolve_foundry_project_url(workspace)
+    workbook_url = _resolve_workbook_portal_url(workspace)
 
     agent_targets: List[Dict[str, Any]] = [
         {
@@ -1838,11 +1845,22 @@ def _build_open_in_foundry(
         {
             "key": "operate",
             "title": "Operate overview",
-            "description": "Foundry operations overview: active alerts, agents, cost, and run health.",
+            "description": (
+                "Foundry's native Operate surface: active alerts, agent "
+                "inventory, cost, and run health at a glance."
+            ),
             "url": deeplinks.get("operate") or project_url,
         },
-    ]
-    azure_monitor_targets: List[Dict[str, Any]] = [
+        {
+            "key": "foundry_ops_dashboard",
+            "title": "Foundry operations dashboard",
+            "description": (
+                "Azure Monitor workbook with PTU capacity, token traffic, "
+                "latency percentiles, and throttling. Deploy or open it with "
+                "`agentops telemetry dashboard`."
+            ),
+            "url": workbook_url,
+        },
         {
             "key": "app_insights",
             "title": "App Insights",
@@ -1851,9 +1869,10 @@ def _build_open_in_foundry(
         },
     ]
     # Backwards-compat: callers and tests that still expect a flat
-    # ``targets`` list can keep working — Foundry tiles come first,
-    # then the Azure Monitor tile.
-    targets = agent_targets + project_targets + azure_monitor_targets
+    # ``targets`` list can keep working — Foundry agent tiles come first,
+    # then the Foundry project tiles (which now include the Azure Monitor
+    # surfaces).
+    targets = agent_targets + project_targets
     return {
         "targets": targets,
         "groups": [
@@ -1867,13 +1886,29 @@ def _build_open_in_foundry(
                 "label": "Foundry project",
                 "targets": project_targets,
             },
-            {
-                "key": "azure_monitor",
-                "label": "Azure Monitor",
-                "targets": azure_monitor_targets,
-            },
         ],
     }
+
+
+def _resolve_workbook_portal_url(workspace: Path) -> Optional[str]:
+    """Return the Foundry operations workbook portal URL (read-only).
+
+    Mirrors ``agentops telemetry dashboard open``: discovery reads the azd
+    ``.env`` (a file read, no Azure calls) so the deep link matches. Any
+    failure falls back to ``None`` so the cockpit never breaks.
+    """
+    try:
+        from agentops.services import dashboard as dash
+
+        target = dash.discover_target(workspace)
+        return dash.build_workbook_portal_url(
+            subscription_id=target.subscription_id,
+            resource_group=target.resource_group,
+            name=target.name,
+            tenant_id=target.tenant_id,
+        )
+    except Exception:  # noqa: BLE001 - deep link is best-effort, cockpit stays up
+        return None
 
 
 def _build_readiness_checklist(
@@ -3405,24 +3440,136 @@ def _collapsible_section(
     body_html: str,
     *,
     section_id: Optional[str] = None,
+    open_by_default: bool = True,
 ) -> str:
     """Wrap a cockpit section in a collapsible ``<details>`` block.
 
-    All sections are expanded by default so the cockpit reads the same
-    on first load; the chevron in the summary lets users hide noisy
-    sections (e.g. production telemetry on a stale workspace). The
-    optional ``section_id`` makes a section anchor-linkable from the
-    Next actions panel.
+    Top-level status is now surfaced by the consolidated status cards, so
+    the detailed sections below collapse by default (``open_by_default=
+    False``) to keep the cockpit focused on the "can I ship?" question.
+    A small template script auto-expands any section whose ``section_id``
+    is targeted via the URL hash (e.g. from a status card or the Next
+    actions panel), so anchor navigation still reveals the detail.
     """
     id_attr = f' id="{_html_escape(section_id)}"' if section_id else ""
+    open_attr = " open" if open_by_default else ""
     return (
-        f'<details class="section-block" open{id_attr}>'
+        f'<details class="section-block"{open_attr}{id_attr}>'
         '<summary class="section-summary">'
         '<span class="section-chevron" aria-hidden="true">&#x25BE;</span>'
         f'<span class="section-title-text">{title_inner_html}</span>'
         '</summary>'
         f'<div class="section-body">{body_html}</div>'
         '</details>'
+    )
+
+
+def _render_status_cards_section(
+    readiness: Dict[str, Any],
+    watchdog: Dict[str, Any],
+    eval_payload: Dict[str, Any],
+) -> str:
+    """Render the consolidated top status: three clickable cards that
+    answer "can I ship?" at a glance (Readiness, Doctor, Eval gate).
+
+    Each card is an anchor to the matching detail section below; the
+    template's hash-open script expands that (collapsed) section when the
+    card is clicked.
+    """
+
+    def _card(
+        *, title: str, value: str, tone: str, sub: str, anchor: str,
+    ) -> str:
+        dot = _status_dot(tone)
+        return (
+            f'<a class="card status-card status-card-{tone}" '
+            f'href="{anchor}">'
+            f'<div class="card-label">{dot}{_html_escape(title)}</div>'
+            f'<div class="card-value status-card-value">{_html_escape(value)}</div>'
+            f'<div class="status-card-sub">{_html_escape(sub)}</div>'
+            '</a>'
+        )
+
+    checks = readiness.get("checks", []) or []
+    green = sum(1 for c in checks if c.get("status") == "ok")
+    total = len(checks)
+    readiness_label = readiness.get("label") or f"{green}/{total} ready"
+    if total == 0:
+        readiness_tone = "muted"
+    elif green >= total:
+        readiness_tone = "ok"
+    else:
+        readiness_tone = "warn"
+    readiness_card = _card(
+        title="Readiness",
+        value=readiness_label,
+        tone=readiness_tone,
+        sub="Observability checks green",
+        anchor="#section-readiness",
+    )
+
+    headline = watchdog.get("headline_cards") or []
+
+    def _headline_value(key: str) -> int:
+        for card in headline:
+            if card.get("key") == key:
+                try:
+                    return int(card.get("value") or 0)
+                except (TypeError, ValueError):
+                    return 0
+        return 0
+
+    if not watchdog.get("has_history"):
+        doctor_tone = "muted"
+        doctor_value = "No runs"
+        doctor_sub = "Run agentops doctor"
+    else:
+        findings_total = _headline_value("findings_total")
+        critical = _headline_value("critical")
+        if critical > 0:
+            doctor_tone = "crit"
+        elif findings_total > 0:
+            doctor_tone = "warn"
+        else:
+            doctor_tone = "ok"
+        doctor_value = f"{findings_total} finding(s)"
+        doctor_sub = f"{critical} critical"
+    doctor_card = _card(
+        title="Doctor",
+        value=doctor_value,
+        tone=doctor_tone,
+        sub=doctor_sub,
+        anchor="#section-agentops-doctor",
+    )
+
+    if not eval_payload.get("has_runs"):
+        eval_tone = "muted"
+        eval_value = "No runs"
+        eval_sub = "Run agentops eval run"
+    else:
+        passed = bool(eval_payload.get("latest_passed"))
+        eval_tone = "ok" if passed else "crit"
+        eval_value = "Pass" if passed else "Fail"
+        pass_rate = eval_payload.get("pass_rate")
+        if isinstance(pass_rate, (int, float)):
+            eval_sub = f"{int(pass_rate * 100)}% pass rate"
+        else:
+            eval_sub = "Latest run"
+    eval_card = _card(
+        title="Eval gate",
+        value=eval_value,
+        tone=eval_tone,
+        sub=eval_sub,
+        anchor="#section-eval-gates",
+    )
+
+    cards = readiness_card + doctor_card + eval_card
+    return (
+        '<section class="status-cards-section" id="section-status-cards">'
+        '<div class="status-cards-caption">Can I ship? '
+        'Click a card for the full detail below.</div>'
+        f'<div class="grid status-cards-grid">{cards}</div>'
+        '</section>'
     )
 
 
@@ -3517,8 +3664,9 @@ def _render_open_in_foundry_section(open_panel: Dict[str, Any]) -> str:
 
     groups = open_panel.get("groups")
     if groups:
-        # Render each group with its own subheader so Foundry tiles stay
-        # visually distinct from the Azure Monitor tile.
+        # Render each group with its own subheader (Configured agent /
+        # Foundry project). The Azure Monitor surfaces (App Insights, the
+        # Foundry operations workbook) are folded into the project group.
         group_html: List[str] = []
         for group in groups:
             label = _html_escape(group.get("label", ""))
@@ -3569,7 +3717,8 @@ def _render_readiness_section(readiness: Dict[str, Any]) -> str:
         f'<span class="live-pill">{label}</span>'
     )
     return _collapsible_section(
-        title_html, body, section_id="section-readiness"
+        title_html, body, section_id="section-readiness",
+        open_by_default=False,
     )
 
 
@@ -3781,7 +3930,8 @@ def render_cockpit_html(payload: Dict[str, Any]) -> str:
             f'View CI evals in App Insights →</a>'
         )
 
-    eval_section = ""
+    eval_body = ""
+    eval_subtitle = "Eval gate summary"
     eval_caption = (
         '<div class="section-subcaption">'
         'AgentOps gate history from local artifacts and CI runs. For '
@@ -3795,10 +3945,7 @@ def render_cockpit_html(payload: Dict[str, Any]) -> str:
             payload["eval"].get("latest_execution"),
         )
         eval_body = f'{eval_caption}<div class="grid">{cards_html}{telemetry_card}</div>'
-        eval_section = _collapsible_section(
-            f"Eval gate summary{exec_tag}{eval_link}", eval_body,
-            section_id="section-eval-runs",
-        )
+        eval_subtitle = f"Eval gate summary{exec_tag}"
     else:
         official_eval = payload["eval"].get("official_eval") or {}
         if official_eval.get("present"):
@@ -3823,10 +3970,7 @@ def render_cockpit_html(payload: Dict[str, Any]) -> str:
             "</div>"
             + (f'<div class="grid">{telemetry_card}</div>' if telemetry_card else "")
         )
-        eval_section = _collapsible_section(
-            f"Eval gate summary{eval_link}", eval_body,
-            section_id="section-eval-runs",
-        )
+        eval_subtitle = "Eval gate summary"
 
     deployments = payload.get("deployments") or {}
     if deployments.get("has_data") and deployments.get("cards"):
@@ -3840,9 +3984,11 @@ def render_cockpit_html(payload: Dict[str, Any]) -> str:
         deployments_body = f'<div class="empty-state">{hint}</div>'
     deployments_section = _collapsible_section(
         "CI/CD Pipelines", deployments_body, section_id="section-cicd",
+        open_by_default=False,
     )
 
-    metrics_section = ""
+    metrics_subtitle = "Quality gate summary"
+    metrics_body = ""
     if payload["metrics"]:
         metrics_html = "".join(_render_card(c) for c in payload["metrics"])
         exec_tag = _render_exec_section_tag(
@@ -3856,10 +4002,32 @@ def render_cockpit_html(payload: Dict[str, Any]) -> str:
             '</div>'
         )
         metrics_body = f'{metrics_caption}<div class="grid">{metrics_html}</div>'
-        metrics_section = _collapsible_section(
-            f"Quality gate summary{exec_tag}", metrics_body,
-            section_id="section-quality-metrics",
+        metrics_subtitle = f"Quality gate summary{exec_tag}"
+
+    # Merge the eval gate + quality gate into a single "Eval gates" section
+    # with two subgroups. They share a source (AgentOps result artifacts)
+    # and CTA (View CI evals in App Insights), so folding them removes a
+    # redundant top-level section and keeps the gate story in one place.
+    eval_gate_subgroup = (
+        '<div class="deeplink-group">'
+        f'<div class="deeplink-group-label">{eval_subtitle}</div>'
+        f'{eval_body}'
+        '</div>'
+    )
+    quality_gate_subgroup = ""
+    if metrics_body:
+        quality_gate_subgroup = (
+            '<div class="deeplink-group">'
+            f'<div class="deeplink-group-label">{metrics_subtitle}</div>'
+            f'{metrics_body}'
+            '</div>'
         )
+    eval_gates_section = _collapsible_section(
+        f"Eval gates{eval_link}",
+        eval_gate_subgroup + quality_gate_subgroup,
+        section_id="section-eval-gates",
+        open_by_default=False,
+    )
 
     watchdog = payload["watchdog"]
     watchdog_title = "AgentOps Doctor"
@@ -3891,18 +4059,16 @@ def render_cockpit_html(payload: Dict[str, Any]) -> str:
         )
     watchdog_section = _collapsible_section(
         watchdog_title, watchdog_body, section_id="section-agentops-doctor",
+        open_by_default=False,
     )
 
     production = payload.get("production") or {}
     production_section = ""
-    portal_link = ""
-    portal_url = telemetry.get("portal_url") if isinstance(telemetry, dict) else None
-    if portal_url:
-        portal_link = (
-            f' <a class="section-link" href="{_html_escape(portal_url)}" '
-            f'target="_blank" rel="noopener noreferrer">'
-            f'Open App Insights KQL →</a>'
-        )
+    # The App Insights KQL portal URL is already surfaced by the launchpad
+    # "App Insights" tile and the Doctor / Eval gate "View in App Insights"
+    # links, so we no longer repeat it here. Production signal keeps a
+    # single primary CTA: the full Foundry Monitor view.
+    _portal_url_unused = telemetry.get("portal_url") if isinstance(telemetry, dict) else None
 
     # Cockpit surfaces a 2-card teaser (error rate + P95); this link is
     # the primary call-to-action for the full Foundry Monitor view.
@@ -3925,7 +4091,6 @@ def render_cockpit_html(payload: Dict[str, Any]) -> str:
         'Production signal'
         ' <span class="live-pill">live · App Insights</span>'
         f'{foundry_monitor_link}'
-        f'{portal_link}'
     )
     if production.get("has_data") and production.get("cards"):
         # Server-side render (rare - happens when /api/production/html is
@@ -3935,12 +4100,14 @@ def render_cockpit_html(payload: Dict[str, Any]) -> str:
             '<div class="section-subcaption">'
             'Fast health snapshot from App Insights. Use '
             '<strong>Foundry Monitor</strong> for the full production view '
-            '(invocations, tokens, per-model breakdown), or open '
-            '<strong>App Insights KQL</strong> for the exact raw telemetry query.'
+            '(invocations, tokens, per-model breakdown). Raw App Insights '
+            'KQL is available from the launchpad "App Insights" tile.'
             '</div>'
         )
         prod_body = f'{prod_caption}<div class="grid" id="production-grid">{prod_html}</div>'
-        production_section = _collapsible_section(prod_title, prod_body)
+        production_section = _collapsible_section(
+            prod_title, prod_body, open_by_default=False,
+        )
     elif production.get("deferred"):
         # Telemetry is wired up; the cards will arrive async from
         # /api/production/html so the page can render immediately.
@@ -3963,15 +4130,17 @@ def render_cockpit_html(payload: Dict[str, Any]) -> str:
             '<div class="section-subcaption">'
             'Fast health snapshot from App Insights. Use '
             '<strong>Foundry Monitor</strong> for the full production view '
-            '(invocations, tokens, per-model breakdown), or open '
-            '<strong>App Insights KQL</strong> for the exact raw telemetry query.'
+            '(invocations, tokens, per-model breakdown). Raw App Insights '
+            'KQL is available from the launchpad "App Insights" tile.'
             '</div>'
         )
         prod_body = (
             f'{prod_caption}'
             f'<div class="grid" id="production-grid">{skeleton_cards}</div>'
         )
-        production_section = _collapsible_section(prod_title, prod_body)
+        production_section = _collapsible_section(
+            prod_title, prod_body, open_by_default=False,
+        )
 
     counts = payload["summary_counts"]
     workspace_display = _shorten_workspace(payload["workspace"])
@@ -4008,15 +4177,20 @@ def render_cockpit_html(payload: Dict[str, Any]) -> str:
     next_actions_section = _render_next_actions_section(
         payload.get("next_actions") or {"actions": []}
     )
+    status_cards_section = _render_status_cards_section(
+        payload.get("readiness") or {"checks": [], "label": "0/0 ready"},
+        payload.get("watchdog") or {},
+        payload.get("eval") or {},
+    )
 
     return _COCKPIT_TEMPLATE.format(
         foundry_connection_section=foundry_connection_section,
         open_in_foundry_section=open_in_foundry_section,
+        status_cards_section=status_cards_section,
         readiness_section=readiness_section,
         next_actions_section=next_actions_section,
-        eval_section=eval_section,
+        eval_gates_section=eval_gates_section,
         deployments_section=deployments_section,
-        metrics_section=metrics_section,
         production_section=production_section,
         watchdog_section=watchdog_section,
         eval_runs=counts["eval_runs"],
@@ -4473,8 +4647,29 @@ _COCKPIT_TEMPLATE = """<!doctype html>
     opacity: 0.55; cursor: not-allowed;
   }}
   .deeplink-card .deeplink-cta.muted {{ color: var(--text-dim); }}
+  /* Consolidated top status cards - the "can I ship?" answer. */
+  .status-cards-section {{ margin: 18px 0 8px; }}
+  .status-cards-caption {{
+    font-size: 12px; color: var(--text-dim); margin: 0 0 10px;
+  }}
+  .status-card {{
+    display: flex; flex-direction: column; gap: 6px;
+    text-decoration: none; color: inherit;
+    transition: border-color 0.15s ease, transform 0.15s ease;
+  }}
+  .status-card:hover {{
+    border-color: rgba(56, 189, 248, 0.4);
+    transform: translateY(-1px);
+  }}
+  .status-card .status-card-value {{ font-size: 22px; font-weight: 700; }}
+  .status-card .status-card-sub {{
+    font-size: 12px; color: var(--text-dim);
+  }}
+  .status-card-ok {{ border-color: rgba(34, 197, 94, 0.4); }}
+  .status-card-warn {{ border-color: rgba(245, 158, 11, 0.4); }}
+  .status-card-crit {{ border-color: rgba(239, 68, 68, 0.45); }}
   /* Subgroups inside "Foundry launchpad". Each group
-     (configured agent / Foundry project / Azure Monitor) gets its own subheader. */
+     (configured agent / Foundry project) gets its own subheader. */
   .deeplink-group + .deeplink-group {{
     margin-top: 18px;
   }}
@@ -5026,14 +5221,14 @@ _COCKPIT_TEMPLATE = """<!doctype html>
 <div class="range-current">window: {range_label}</div>
 
 {foundry_connection_section}
-{open_in_foundry_section}
+{status_cards_section}
+{next_actions_section}
 {readiness_section}
 {watchdog_section}
-{eval_section}
-{metrics_section}
+{eval_gates_section}
 {production_section}
 {deployments_section}
-{next_actions_section}
+{open_in_foundry_section}
 
 <footer>Auto-refresh: <span id="refreshFooter">every 5 min</span> · <code>agentops cockpit</code></footer>
 
@@ -5089,7 +5284,22 @@ function wireSparklineHover(root) {{
 }}
 wireSparklineHover();
 
-// Copy full connection values (for example, the full Foundry project endpoint)
+// Auto-expand a collapsed <details> section when it is targeted via the
+// URL hash (status cards and Next-actions CTAs link to #section-... ids).
+// Details sections collapse by default now, so anchor navigation must open
+// the target for the deep link to reveal any content.
+function openHashSection() {{
+  var id = (window.location.hash || '').replace('#', '');
+  if (!id) return;
+  var el = document.getElementById(id);
+  if (el && el.tagName && el.tagName.toLowerCase() === 'details') {{
+    el.open = true;
+    el.scrollIntoView({{ behavior: 'smooth', block: 'start' }});
+  }}
+}}
+window.addEventListener('hashchange', openHashSection);
+openHashSection();
+
 // while keeping the visible card label compact.
 (function() {{
   document.querySelectorAll('.copy-btn[data-copy]').forEach(function(btn) {{

--- a/src/agentops/cli/app.py
+++ b/src/agentops/cli/app.py
@@ -82,6 +82,13 @@ redteam_app = typer.Typer(
 telemetry_app = typer.Typer(
     help="Import Azure Monitor telemetry into AgentOps datasets."
 )
+dashboard_app = typer.Typer(
+    help=(
+        "Deploy, open, and export the Foundry operations Azure Monitor "
+        "workbook (capacity, traffic and tokens, latency, errors)."
+    )
+)
+telemetry_app.add_typer(dashboard_app, name="dashboard")
 app.add_typer(eval_app, name="eval")
 app.add_typer(report_app, name="report")
 app.add_typer(workflow_app, name="workflow")
@@ -822,6 +829,84 @@ EXPLAIN_PAGES: dict[tuple[str, ...], ExplainPage] = {
         outputs=("`.github/skills/agentops-*` for Copilot", "`.claude/commands/agentops-*` for Claude Code"),
         examples=("agentops skills install", "agentops skills install --platform copilot", "agentops skills install --from github:org/repo@v1"),
     ),
+    ("telemetry", "dashboard"): ExplainPage(
+        title="Foundry operations dashboard",
+        command="agentops telemetry dashboard",
+        synopsis=("agentops telemetry dashboard COMMAND [ARGS]...", "agentops telemetry dashboard explain"),
+        summary=(
+            "Deploys, opens, and exports the Foundry operations Azure Monitor "
+            "workbook: capacity (PTU), traffic and tokens, latency percentiles, "
+            "and errors and throttling for an Azure OpenAI resource.",
+            "The workbook is scoped per Azure OpenAI resource and per Log "
+            "Analytics workspace and reads from AzureMetrics and "
+            "AzureDiagnostics.",
+        ),
+        children=("deploy", "open", "export"),
+    ),
+    ("telemetry", "dashboard", "deploy"): ExplainPage(
+        title="Deploy the Foundry operations workbook",
+        command="agentops telemetry dashboard deploy",
+        synopsis=(
+            "agentops telemetry dashboard deploy [--dry-run] [--subscription ID] "
+            "[--resource-group RG] [--workspace-id ID] [--name NAME] [--dir PATH]",
+            "agentops telemetry dashboard deploy explain",
+        ),
+        summary=(
+            "Deploys the workbook as a Microsoft.Insights/workbooks ARM resource "
+            "into the discovered (or supplied) resource group.",
+            "This is the first AgentOps CLI command that creates an Azure "
+            "resource; it deploys a single workbook and nothing else.",
+        ),
+        how_it_works=(
+            "Discovers subscription, resource group, Log Analytics workspace, "
+            "and the Azure OpenAI resource from agentops.yaml and the azd env.",
+            "Runs an RBAC preflight: Workbook Contributor on the resource group "
+            "and Log Analytics Reader on the workspace. Missing roles fail with "
+            "the exact role and scope to request.",
+            "Warns (non-fatally) and prints the exact "
+            "`az monitor diagnostic-settings create` command when the Azure "
+            "OpenAI resource is missing the RequestResponse or "
+            "AzureOpenAIRequestUsage categories.",
+            "Deploys via `az deployment group create` and prints the portal URL.",
+        ),
+        outputs=("A deployed workbook and its Azure portal URL", "The ARM template when --dry-run is used"),
+        examples=(
+            "agentops telemetry dashboard deploy --dry-run",
+            "agentops telemetry dashboard deploy --resource-group my-rg",
+        ),
+    ),
+    ("telemetry", "dashboard", "open"): ExplainPage(
+        title="Open the Foundry operations workbook",
+        command="agentops telemetry dashboard open",
+        synopsis=(
+            "agentops telemetry dashboard open [--print-url] [--subscription ID] "
+            "[--resource-group RG] [--name NAME] [--dir PATH]",
+            "agentops telemetry dashboard open explain",
+        ),
+        summary=(
+            "Builds the Azure portal URL for the workbook and opens it in the "
+            "default browser.",
+            "In a non-interactive shell, or with --print-url, it prints the URL "
+            "instead of opening a browser.",
+        ),
+        examples=(
+            "agentops telemetry dashboard open",
+            "agentops telemetry dashboard open --print-url",
+        ),
+    ),
+    ("telemetry", "dashboard", "export"): ExplainPage(
+        title="Export the workbook JSON",
+        command="agentops telemetry dashboard export",
+        synopsis=(
+            "agentops telemetry dashboard export [--out PATH]",
+            "agentops telemetry dashboard export explain",
+        ),
+        summary=(
+            "Copies the packaged workbook JSON to a local path so you can import "
+            "it manually or customize it before deploying.",
+        ),
+        examples=("agentops telemetry dashboard export --out foundry-ops.workbook.json",),
+    ),
     ("mcp",): ExplainPage(
         title="MCP commands",
         command="agentops mcp",
@@ -1469,6 +1554,7 @@ skills_app.command("explain")(_make_group_explain(("skills",)))
 prompt_app.command("explain")(_make_group_explain(("prompt",)))
 mcp_app.command("explain")(_make_group_explain(("mcp",)))
 agent_app.command("explain")(_make_group_explain(("agent",)))
+dashboard_app.command("explain")(_make_group_explain(("telemetry", "dashboard")))
 
 
 # ---------------------------------------------------------------------------
@@ -2459,6 +2545,197 @@ def _resolve_eval_config_path(config: Path | None) -> Path:
     if config is not None:
         return config
     return Path("agentops.yaml")
+
+
+# ---------------------------------------------------------------------------
+# agentops telemetry dashboard {deploy, open, export}
+# ---------------------------------------------------------------------------
+@dashboard_app.command("deploy")
+def cmd_dashboard_deploy(
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Emit the ARM template and make no changes."),
+    ] = False,
+    subscription: Annotated[
+        Optional[str],
+        typer.Option("--subscription", help="Azure subscription id override."),
+    ] = None,
+    resource_group: Annotated[
+        Optional[str],
+        typer.Option("--resource-group", help="Resource group for the workbook."),
+    ] = None,
+    workspace_id: Annotated[
+        Optional[str],
+        typer.Option("--workspace-id", help="Log Analytics workspace resource id."),
+    ] = None,
+    name: Annotated[
+        Optional[str],
+        typer.Option("--name", help="Workbook display name."),
+    ] = None,
+    workspace: Annotated[
+        Path,
+        typer.Option("--dir", help="AgentOps workspace root for discovery."),
+    ] = Path("."),
+    explain: Annotated[str | None, typer.Argument(hidden=True)] = None,
+) -> None:
+    """Deploy the Foundry operations workbook to Azure Monitor."""
+
+    if _maybe_explain_leaf(("telemetry", "dashboard", "deploy"), explain):
+        return
+
+    import json
+
+    from agentops.services import dashboard as dash
+
+    target = dash.discover_target(
+        workspace.resolve(),
+        subscription_id=subscription,
+        resource_group=resource_group,
+        workspace_id=workspace_id,
+        name=name,
+    )
+
+    if dry_run:
+        template = dash.build_arm_template(target=target)
+        typer.echo(json.dumps(template, indent=2))
+        typer.echo(
+            _cli_warn(
+                "Dry run only. No Azure changes were made. Re-run without "
+                "--dry-run to deploy."
+            ),
+            err=True,
+        )
+        return
+
+    # RBAC preflight — fail gracefully with the exact role and scope needed.
+    rbac = dash.check_rbac(
+        subscription_id=target.subscription_id,
+        resource_group=target.resource_group,
+        workspace_id=target.workspace_id,
+    )
+    for message in rbac.messages:
+        if rbac.level == "ok":
+            typer.echo(_cli_ok(message))
+        elif rbac.level == "warn":
+            typer.echo(_cli_warn(message), err=True)
+        else:
+            typer.echo(_cli_error(message), err=True)
+    if not rbac.ok:
+        raise typer.Exit(code=1)
+
+    # Diagnostic-settings advisory (non-fatal): print the exact fix command.
+    enabled = list(target.discovery.get("enabled_log_categories", []) or [])
+    missing = dash.missing_diagnostic_categories(enabled) if enabled else list(
+        dash.REQUIRED_DIAGNOSTIC_CATEGORIES
+    )
+    if missing:
+        typer.echo(
+            _cli_warn(
+                "The Azure OpenAI resource may not emit the categories the "
+                f"workbook needs ({', '.join(missing)}). If the tiles are "
+                "empty, enable them with:"
+            ),
+            err=True,
+        )
+        typer.echo(
+            _cli_command(
+                dash.build_diagnostic_settings_command(
+                    aoai_resource_id=target.aoai_resource_id,
+                    workspace_id=target.workspace_id,
+                )
+            ),
+            err=True,
+        )
+
+    try:
+        url = dash.deploy_workbook(target=target)
+    except dash.DashboardError as exc:
+        typer.echo(_cli_error(str(exc)), err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(_cli_ok("Workbook deployed."))
+    typer.echo(f"{_cli_label('Portal')}: {_cli_path(url)}")
+
+
+@dashboard_app.command("open")
+def cmd_dashboard_open(
+    print_url: Annotated[
+        bool,
+        typer.Option("--print-url", help="Print the URL instead of opening a browser."),
+    ] = False,
+    subscription: Annotated[
+        Optional[str],
+        typer.Option("--subscription", help="Azure subscription id override."),
+    ] = None,
+    resource_group: Annotated[
+        Optional[str],
+        typer.Option("--resource-group", help="Resource group for the workbook."),
+    ] = None,
+    name: Annotated[
+        Optional[str],
+        typer.Option("--name", help="Workbook display name."),
+    ] = None,
+    workspace: Annotated[
+        Path,
+        typer.Option("--dir", help="AgentOps workspace root for discovery."),
+    ] = Path("."),
+    explain: Annotated[str | None, typer.Argument(hidden=True)] = None,
+) -> None:
+    """Open the Foundry operations workbook in the Azure portal."""
+
+    if _maybe_explain_leaf(("telemetry", "dashboard", "open"), explain):
+        return
+
+    from agentops.services import dashboard as dash
+
+    target = dash.discover_target(
+        workspace.resolve(),
+        subscription_id=subscription,
+        resource_group=resource_group,
+        name=name,
+    )
+    url = dash.build_workbook_portal_url(
+        subscription_id=target.subscription_id,
+        resource_group=target.resource_group,
+        name=target.name,
+        tenant_id=target.tenant_id,
+    )
+
+    if print_url or not _stream_is_interactive(sys.stdout):
+        typer.echo(url)
+        return
+    typer.echo(f"{_cli_heading('Foundry operations dashboard')} → {_cli_path(url)}")
+    try:
+        webbrowser.open(url)
+    except Exception:  # noqa: BLE001 - best effort
+        typer.echo(url)
+
+
+@dashboard_app.command("export")
+def cmd_dashboard_export(
+    out: Annotated[
+        Path,
+        typer.Option("--out", help="Destination path for the workbook JSON."),
+    ] = Path("foundry-ops.workbook.json"),
+    explain: Annotated[str | None, typer.Argument(hidden=True)] = None,
+) -> None:
+    """Export the packaged workbook JSON to a local path."""
+
+    if _maybe_explain_leaf(("telemetry", "dashboard", "export"), explain):
+        return
+
+    from agentops.services import dashboard as dash
+
+    try:
+        content = dash.load_workbook_template()
+    except dash.DashboardError as exc:
+        typer.echo(_cli_error(str(exc)), err=True)
+        raise typer.Exit(code=1) from exc
+
+    destination = out.resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(content, encoding="utf-8")
+    typer.echo(_cli_updated(destination))
 
 
 def _append_assert_step_summary(result, *, scored_cases, pass_rate) -> None:

--- a/src/agentops/services/dashboard.py
+++ b/src/agentops/services/dashboard.py
@@ -1,0 +1,503 @@
+"""Thin service layer for the Foundry operations Azure Monitor workbook.
+
+This module is the single place that knows how to:
+
+* load the packaged ``foundry-ops.workbook.json`` gallery template,
+* build the Azure portal deep link for the deployed workbook,
+* run the RBAC / diagnostic-settings preflight for ``agentops telemetry
+  dashboard deploy``, and
+* wrap the workbook content into a ``Microsoft.Insights/workbooks`` ARM
+  template and (optionally) deploy it via the Azure CLI.
+
+Azure SDK / CLI access is kept lazy and fail-open so importing this module
+never requires the management SDKs or a live Azure session. The CLI layer in
+:mod:`agentops.cli.app` stays thin and delegates the Azure logic here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+import uuid
+from dataclasses import dataclass, field
+from importlib.resources import files as _pkg_files
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+log = logging.getLogger(__name__)
+
+_TEMPLATE_PACKAGE = "agentops.templates"
+_WORKBOOK_RESOURCE_PATH = "workbooks/foundry-ops.workbook.json"
+
+#: ARM resource type for an Azure Monitor workbook.
+WORKBOOK_RESOURCE_TYPE = "Microsoft.Insights/workbooks"
+
+#: Diagnostic log categories the Azure OpenAI resource must emit for the
+#: workbook queries to return data.
+REQUIRED_DIAGNOSTIC_CATEGORIES = ("RequestResponse", "AzureOpenAIRequestUsage")
+
+_PORTAL_BASE = "https://portal.azure.com"
+
+# Deterministic namespace so ``deploy`` and ``open`` agree on the workbook
+# resource name without querying Azure.
+_WORKBOOK_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_DNS, "agentops.foundry-ops.workbook")
+
+# Built-in Azure role definition GUIDs used by the preflight. A role that can
+# write workbooks (Owner / Contributor / Workbook Contributor) satisfies the
+# deploy requirement; a role that can read the workspace satisfies the query
+# requirement.
+_ROLE_WORKBOOK_CONTRIBUTOR = "e8ddcd69-c73f-4f9f-9844-4100522f16ad"
+_ROLE_LOG_ANALYTICS_READER = "73c42c96-874c-492b-b04d-ab87d138a893"
+_ROLE_LOG_ANALYTICS_CONTRIBUTOR = "92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+_ROLE_READER = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+_ROLE_CONTRIBUTOR = "b24988ac-6180-42a0-ab88-20f7382dd24c"
+_ROLE_OWNER = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+
+_WORKBOOK_WRITE_ROLES = frozenset(
+    {_ROLE_WORKBOOK_CONTRIBUTOR, _ROLE_CONTRIBUTOR, _ROLE_OWNER}
+)
+_WORKSPACE_READ_ROLES = frozenset(
+    {
+        _ROLE_LOG_ANALYTICS_READER,
+        _ROLE_LOG_ANALYTICS_CONTRIBUTOR,
+        _ROLE_READER,
+        _ROLE_CONTRIBUTOR,
+        _ROLE_OWNER,
+    }
+)
+
+
+class DashboardError(RuntimeError):
+    """Raised for user-facing dashboard failures (surfaced by the CLI)."""
+
+
+@dataclass
+class DashboardTarget:
+    """Resolved Azure context for the workbook deploy."""
+
+    name: str = "AgentOps Foundry operations"
+    subscription_id: Optional[str] = None
+    resource_group: Optional[str] = None
+    workspace_id: Optional[str] = None
+    aoai_resource_id: Optional[str] = None
+    aoai_account_name: Optional[str] = None
+    tenant_id: Optional[str] = None
+    location: str = "global"
+    discovery: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PreflightResult:
+    """Outcome of a single preflight check.
+
+    ``ok`` is ``True`` when the check passed. ``level`` is ``"ok"``,
+    ``"warn"`` (deploy can still proceed) or ``"error"`` (deploy must stop).
+    ``messages`` carries friendly, actionable text for the CLI to print.
+    """
+
+    ok: bool
+    level: str
+    messages: List[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Template loading
+# ---------------------------------------------------------------------------
+def load_workbook_template() -> str:
+    """Return the packaged workbook JSON as a string."""
+    resource = _pkg_files(_TEMPLATE_PACKAGE).joinpath(_WORKBOOK_RESOURCE_PATH)
+    return resource.read_text(encoding="utf-8")
+
+
+def load_workbook_content() -> Dict[str, Any]:
+    """Return the packaged workbook JSON parsed into a dict."""
+    try:
+        return json.loads(load_workbook_template())
+    except (OSError, json.JSONDecodeError) as exc:  # pragma: no cover - packaging
+        raise DashboardError(
+            f"Could not load the packaged workbook template: {exc}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Portal URL
+# ---------------------------------------------------------------------------
+def make_workbook_resource_id(
+    subscription_id: str, resource_group: str, name: str
+) -> str:
+    """Build the deterministic ARM id for the deployed workbook.
+
+    The workbook resource name is a GUID derived from the display name and
+    resource group so ``deploy`` and ``open`` agree without a live lookup.
+    """
+    guid = str(uuid.uuid5(_WORKBOOK_NAMESPACE, f"{resource_group}:{name}"))
+    return (
+        f"/subscriptions/{subscription_id}"
+        f"/resourceGroups/{resource_group}"
+        f"/providers/{WORKBOOK_RESOURCE_TYPE}/{guid}"
+    )
+
+
+def build_workbook_portal_url(
+    *,
+    workbook_resource_id: Optional[str] = None,
+    tenant_id: Optional[str] = None,
+    subscription_id: Optional[str] = None,
+    resource_group: Optional[str] = None,
+    name: Optional[str] = None,
+) -> str:
+    """Return an Azure portal deep link for the workbook.
+
+    When the workbook ARM id is known (directly, or derivable from
+    subscription/resource-group/name) the link opens that workbook. Otherwise
+    it falls back to the Azure Monitor Workbooks gallery so the tile is never
+    broken.
+    """
+    rid = workbook_resource_id
+    if not rid and subscription_id and resource_group and name:
+        rid = make_workbook_resource_id(subscription_id, resource_group, name)
+    if rid:
+        prefix = f"{_PORTAL_BASE}/#@{tenant_id}" if tenant_id else f"{_PORTAL_BASE}/#"
+        return f"{prefix}/resource{rid}/workbook"
+    return (
+        f"{_PORTAL_BASE}/#view/Microsoft_Azure_Monitoring_Workbooks"
+        "/WorkbookMenuBlade/~/gallery"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic settings
+# ---------------------------------------------------------------------------
+def missing_diagnostic_categories(enabled_categories: Iterable[str]) -> List[str]:
+    """Return the required categories not present in ``enabled_categories``."""
+    enabled = {str(c) for c in enabled_categories}
+    return [c for c in REQUIRED_DIAGNOSTIC_CATEGORIES if c not in enabled]
+
+
+def build_diagnostic_settings_command(
+    *,
+    aoai_resource_id: Optional[str],
+    workspace_id: Optional[str],
+    name: str = "agentops-foundry-ops",
+) -> str:
+    """Return the exact ``az`` command that wires the required categories."""
+    resource = aoai_resource_id or "<azure-openai-resource-id>"
+    workspace = workspace_id or "<log-analytics-workspace-id>"
+    logs = json.dumps(
+        [{"category": c, "enabled": True} for c in REQUIRED_DIAGNOSTIC_CATEGORIES]
+    )
+    return (
+        "az monitor diagnostic-settings create "
+        f"--name {name} "
+        f"--resource {resource} "
+        f"--workspace {workspace} "
+        f"--logs '{logs}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# RBAC preflight
+# ---------------------------------------------------------------------------
+def check_rbac(
+    *,
+    subscription_id: Optional[str],
+    resource_group: Optional[str],
+    workspace_id: Optional[str],
+) -> PreflightResult:
+    """Preflight the caller's RBAC for a workbook deploy.
+
+    Requires ``Workbook Contributor`` (or a superset) on the resource group and
+    ``Log Analytics Reader`` (or a superset) on the workspace. When the RBAC
+    listing cannot run (SDK missing, no credential, listing denied) the check
+    fails **open** with a warning so ``deploy`` can still be attempted and let
+    ARM enforce permissions.
+    """
+    if not subscription_id or not resource_group:
+        return PreflightResult(
+            ok=False,
+            level="error",
+            messages=[
+                "Cannot check RBAC: subscription and resource group are "
+                "unknown. Pass --subscription and --resource-group, or run "
+                "from an initialized AgentOps workspace.",
+            ],
+        )
+
+    rg_scope = f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}"
+    try:
+        from agentops.agent.checks._rbac_authorization import (
+            AuthorizationCheckError,
+            list_principal_role_definition_ids,
+            resolve_signed_in_principal_object_id,
+        )
+    except ImportError as exc:  # pragma: no cover - shipped together
+        return PreflightResult(
+            ok=True,
+            level="warn",
+            messages=[
+                "Skipping RBAC preflight (authorization helpers unavailable: "
+                f"{exc}). ARM will enforce permissions at deploy time.",
+            ],
+        )
+
+    try:
+        principal = resolve_signed_in_principal_object_id()
+        rg_roles = set(
+            list_principal_role_definition_ids(
+                subscription_id=subscription_id,
+                scope=rg_scope,
+                principal_object_id=principal,
+            )
+        )
+    except AuthorizationCheckError as exc:
+        return PreflightResult(
+            ok=True,
+            level="warn",
+            messages=[
+                f"Skipping RBAC preflight ({exc}). ARM will enforce "
+                "permissions at deploy time.",
+            ],
+        )
+
+    messages: List[str] = []
+    ok = True
+    if not (rg_roles & _WORKBOOK_WRITE_ROLES):
+        ok = False
+        messages.append(
+            "You need the 'Workbook Contributor' role on resource group "
+            f"'{resource_group}'. Ask an admin to grant it, or run with "
+            "--dry-run to emit the ARM template instead."
+        )
+
+    if workspace_id:
+        try:
+            ws_roles = set(
+                list_principal_role_definition_ids(
+                    subscription_id=subscription_id,
+                    scope=workspace_id,
+                    principal_object_id=principal,
+                )
+            )
+        except AuthorizationCheckError as exc:
+            messages.append(
+                f"Could not verify Log Analytics access ({exc}); make sure you "
+                "have 'Log Analytics Reader' on the workspace."
+            )
+            ws_roles = set()
+        if ws_roles and not (ws_roles & _WORKSPACE_READ_ROLES):
+            ok = False
+            messages.append(
+                "You need the 'Log Analytics Reader' role on workspace "
+                f"'{workspace_id}' so the workbook can query it."
+            )
+
+    if ok and not messages:
+        messages.append(
+            "RBAC preflight passed: you can write workbooks to "
+            f"'{resource_group}' and read the workspace."
+        )
+    return PreflightResult(ok=ok, level="ok" if ok else "error", messages=messages)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+_WORKSPACE_ENV_KEYS = (
+    "AZURE_LOG_ANALYTICS_WORKSPACE_ID",
+    "AZURE_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID",
+    "LOG_ANALYTICS_WORKSPACE_ID",
+    "AZURE_MONITOR_WORKSPACE_ID",
+    "AZURE_MONITOR_WORKSPACE_RESOURCE_ID",
+)
+_ACCOUNT_ENV_KEYS = (
+    "AZURE_OPENAI_RESOURCE",
+    "AZURE_OPENAI_RESOURCE_NAME",
+    "AZURE_AI_SERVICES_RESOURCE_NAME",
+    "AZURE_AI_SERVICES_NAME",
+)
+_TENANT_ENV_KEYS = ("AZURE_TENANT_ID",)
+
+
+def _first(values: Mapping[str, str], keys: Iterable[str]) -> Optional[str]:
+    for key in keys:
+        val = values.get(key)
+        if val:
+            return val
+    return None
+
+
+def discover_target(
+    workspace: Optional[Path],
+    *,
+    subscription_id: Optional[str] = None,
+    resource_group: Optional[str] = None,
+    workspace_id: Optional[str] = None,
+    name: Optional[str] = None,
+) -> DashboardTarget:
+    """Resolve the deploy target from explicit flags, then the AZD env.
+
+    Reuses the AgentOps foundry discovery path (the AZD ``.env`` read used by
+    the Azure resources doctor source). Explicit arguments always win.
+    """
+    env_values: Dict[str, str] = {}
+    discovery: Dict[str, Any] = {}
+    try:
+        from agentops.agent.sources.azure_resources import (
+            _discover_azd_environment,
+        )
+
+        _env_name, env_values, azd_diag = _discover_azd_environment(workspace)
+        discovery["azd"] = azd_diag
+    except Exception as exc:  # noqa: BLE001 - discovery is best-effort
+        discovery["azd"] = {"status": "error", "reason": str(exc)}
+
+    sub = subscription_id or env_values.get("AZURE_SUBSCRIPTION_ID")
+    rg = resource_group or env_values.get("AZURE_RESOURCE_GROUP")
+    ws = workspace_id or _first(env_values, _WORKSPACE_ENV_KEYS)
+    tenant = _first(env_values, _TENANT_ENV_KEYS)
+    account = _first(env_values, _ACCOUNT_ENV_KEYS)
+
+    aoai_resource_id: Optional[str] = None
+    if account and account.startswith("/subscriptions/"):
+        aoai_resource_id = account
+        account = account.rstrip("/").rsplit("/", 1)[-1]
+    elif account and sub and rg:
+        aoai_resource_id = (
+            f"/subscriptions/{sub}/resourceGroups/{rg}"
+            f"/providers/Microsoft.CognitiveServices/accounts/{account}"
+        )
+
+    return DashboardTarget(
+        name=name or "AgentOps Foundry operations",
+        subscription_id=sub,
+        resource_group=rg,
+        workspace_id=ws,
+        aoai_resource_id=aoai_resource_id,
+        aoai_account_name=account,
+        tenant_id=tenant,
+        discovery=discovery,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ARM template + deploy
+# ---------------------------------------------------------------------------
+def build_arm_template(
+    *,
+    target: DashboardTarget,
+    workbook_content: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Wrap the workbook content into a deployable ARM template."""
+    content = (
+        workbook_content if workbook_content is not None else load_workbook_content()
+    )
+    guid = str(
+        uuid.uuid5(_WORKBOOK_NAMESPACE, f"{target.resource_group}:{target.name}")
+    )
+    resource: Dict[str, Any] = {
+        "type": WORKBOOK_RESOURCE_TYPE,
+        "apiVersion": "2022-04-01",
+        "name": guid,
+        "location": target.location,
+        "kind": "shared",
+        "properties": {
+            "displayName": target.name,
+            "serializedData": json.dumps(content),
+            "version": "1.0",
+            "sourceId": target.workspace_id or "Azure Monitor",
+            "category": "workbook",
+        },
+    }
+    return {
+        "$schema": (
+            "https://schema.management.azure.com/schemas/2019-04-01/"
+            "deploymentTemplate.json#"
+        ),
+        "contentVersion": "1.0.0.0",
+        "resources": [resource],
+        "outputs": {
+            "workbookId": {
+                "type": "string",
+                "value": f"[resourceId('{WORKBOOK_RESOURCE_TYPE}', '{guid}')]",
+            }
+        },
+    }
+
+
+def _az_executable() -> Optional[str]:
+    return shutil.which("az") or shutil.which("az.cmd")
+
+
+def deploy_workbook(
+    *,
+    target: DashboardTarget,
+    workbook_content: Optional[Dict[str, Any]] = None,
+    timeout: int = 300,
+) -> str:
+    """Deploy the workbook via ``az deployment group create``.
+
+    Returns the portal URL for the deployed workbook. Raises
+    :class:`DashboardError` with a friendly message on any failure.
+    """
+    if not target.subscription_id or not target.resource_group:
+        raise DashboardError(
+            "Deploy needs a subscription and resource group. Pass "
+            "--subscription and --resource-group, or run from an initialized "
+            "AgentOps workspace."
+        )
+    az = _az_executable()
+    if az is None:
+        raise DashboardError(
+            "The Azure CLI ('az') was not found on PATH. Install it and run "
+            "'az login', or use --dry-run to emit the ARM template."
+        )
+
+    template = build_arm_template(target=target, workbook_content=workbook_content)
+    with tempfile.TemporaryDirectory(prefix="agentops-workbook-") as tmp:
+        template_path = Path(tmp) / "foundry-ops.deploy.json"
+        template_path.write_text(json.dumps(template), encoding="utf-8")
+        cmd = [
+            az,
+            "deployment",
+            "group",
+            "create",
+            "--subscription",
+            target.subscription_id,
+            "--resource-group",
+            target.resource_group,
+            "--name",
+            "agentops-foundry-ops",
+            "--template-file",
+            str(template_path),
+            "--only-show-errors",
+            "--output",
+            "json",
+        ]
+        try:
+            completed = subprocess.run(  # noqa: S603 - args are controlled
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise DashboardError(
+                f"Failed to run 'az deployment group create': {exc}"
+            ) from exc
+
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()
+        raise DashboardError(
+            f"Workbook deployment failed. The Azure CLI reported:\n{detail}"
+        )
+
+    return build_workbook_portal_url(
+        subscription_id=target.subscription_id,
+        resource_group=target.resource_group,
+        name=target.name,
+        tenant_id=target.tenant_id,
+    )

--- a/src/agentops/templates/workbooks/README.md
+++ b/src/agentops/templates/workbooks/README.md
@@ -1,0 +1,99 @@
+# Foundry operations dashboard (Azure Monitor workbook)
+
+`foundry-ops.workbook.json` is an Azure Monitor **gallery-template workbook** that
+visualizes Azure AI Foundry / Azure OpenAI operational metrics end to end: PTU
+utilization, PAYG spillover, traffic and token consumption, latency percentiles,
+and error / throttling rates.
+
+The workbook is scoped **per Azure OpenAI resource** and **per Log Analytics
+workspace**. Pick the subscription, workspace, and Azure OpenAI resource in the
+parameters bar, then use the deployment, model, time-range, and streaming
+filters to narrow each tab.
+
+## Tabs
+
+| Tab | Shows |
+| --- | --- |
+| Capacity | `PTU_Avg_Pct`, `PTU_Max_Pct`, `Ratelimit`, PAYG `Spillover`, `Aggregated_PTU_With_Spillover`, `PTU_Normalizado` |
+| Traffic and tokens | `TotalCalls`, `AzureOpenAIRequests`, `InputTokens`, `OutputTokens`, `TotalTokens`, `ProcessedPromptTokens`, `GeneratedTokens`, `TokensPorRequest`, and a PTU vs PAYG spillover pivot |
+| Latency | `TTFT`, `TBT`, `TTLT`, tokens/sec, time-to-response, and `P95` / `P99` / `Avg` / `Max` over `DurationMs` |
+| Errors and throttling | HTTP `429` / `400` / `500` counts, `BlockedCalls`, `TasaThrottling_Pct`, `TasaError_Pct` |
+
+`PTU_Normalizado` (`PTU% * 100000`) is a **display-only** scaling series so the
+0-100 PTU utilization percentage can share a Y axis with raw token counts in a
+single timechart. Read true utilization from `PTU_Avg_Pct` / `PTU_Max_Pct`.
+
+## KQL queries
+
+The raw KQL for each derived-metric family lives under
+[`queries/`](./queries), so operators can reuse the logic outside the workbook:
+
+| File | Derived metrics |
+| --- | --- |
+| [`capacity_ptu_spillover.kql`](./queries/capacity_ptu_spillover.kql) | PTU avg/max %, Ratelimit, Spillover, Aggregated PTU with spillover, PTU_Normalizado |
+| [`traffic_tokens.kql`](./queries/traffic_tokens.kql) | Calls, input/output/total tokens, processed/generated tokens, tokens per request, PTU vs PAYG split |
+| [`latency_percentiles.kql`](./queries/latency_percentiles.kql) | TTFT/TBT/TTLT, tokens/sec, time-to-response, and P95/P99/Avg/Max over DurationMs |
+| [`errors_throttling.kql`](./queries/errors_throttling.kql) | HTTP 429/400/500 counts, blocked calls, throttling rate, error rate |
+
+The standalone `.kql` files expose the parameter bindings as `let` declarations
+at the top; the workbook substitutes the same values through its parameter bar.
+
+## Required diagnostic settings
+
+The Azure OpenAI resource must send both of these log categories to the Log
+Analytics workspace the workbook queries:
+
+- `RequestResponse`
+- `AzureOpenAIRequestUsage`
+
+If they are missing, create them with:
+
+```bash
+az monitor diagnostic-settings create \
+  --name agentops-foundry-ops \
+  --resource <azure-openai-resource-id> \
+  --workspace <log-analytics-workspace-id> \
+  --logs '[{"category":"RequestResponse","enabled":true},{"category":"AzureOpenAIRequestUsage","enabled":true}]'
+```
+
+`agentops doctor` flags this automatically (rule
+`waf.observability.aoai_diagnostic_categories`) and prints the exact command.
+
+## Required roles
+
+| Role | Scope | Why |
+| --- | --- | --- |
+| `Workbook Contributor` | Resource group that will hold the workbook | Deploy / update the `Microsoft.Insights/workbooks` resource |
+| `Log Analytics Reader` | The Log Analytics workspace | Let the workbook query `AzureMetrics` / `AzureDiagnostics` |
+
+## How to use it
+
+Ship it with the CLI:
+
+```bash
+# Emit the ARM template without touching Azure.
+agentops telemetry dashboard deploy --dry-run
+
+# Deploy the workbook (needs Workbook Contributor on the resource group).
+agentops telemetry dashboard deploy
+
+# Open the workbook in the Azure portal.
+agentops telemetry dashboard open
+
+# Copy the workbook JSON to a local path for manual import.
+agentops telemetry dashboard export --out ./foundry-ops.workbook.json
+```
+
+Or import it manually: **Azure portal → Monitor → Workbooks → New → Advanced
+Editor**, paste the contents of `foundry-ops.workbook.json`, then Apply and Save,
+selecting the target workspace and Azure OpenAI resource.
+
+## Authoring note (validate before GA)
+
+This workbook JSON was authored from the issue's KQL and the Azure Monitor
+workbook schema **without a live Azure environment**. Before relying on it in
+production, smoke-validate it against a real Log Analytics workspace that
+receives `RequestResponse` and `AzureOpenAIRequestUsage` from an Azure OpenAI
+resource: confirm the parameters resolve, each tab renders, and the derived
+metrics match expectations. Adjust metric/field names if your platform emits
+different `AzureMetrics` names or `properties_s` shapes.

--- a/src/agentops/templates/workbooks/foundry-ops.workbook.json
+++ b/src/agentops/templates/workbooks/foundry-ops.workbook.json
@@ -1,0 +1,479 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# Foundry operations dashboard\nPTU capacity, traffic and tokens, latency, and errors for Azure AI Foundry / Azure OpenAI deployments."
+      },
+      "name": "title"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "p-subscription",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscription",
+            "label": "Subscription",
+            "type": 6,
+            "isRequired": true,
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "includeAll": false
+            }
+          },
+          {
+            "id": "p-workspace",
+            "version": "KqlParameterItem/1.0",
+            "name": "Workspace",
+            "label": "Log Analytics workspace",
+            "type": 5,
+            "isRequired": true,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.operationalinsights/workspaces": true
+              },
+              "additionalResourceOptions": []
+            }
+          },
+          {
+            "id": "p-resource",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resource",
+            "label": "Azure OpenAI resource",
+            "type": 5,
+            "isRequired": true,
+            "resourceType": "microsoft.cognitiveservices/accounts",
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.cognitiveservices/accounts": true
+              },
+              "additionalResourceOptions": []
+            }
+          },
+          {
+            "id": "p-timerange",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "label": "Time range",
+            "type": 4,
+            "isRequired": true,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 2592000000
+                }
+              ]
+            },
+            "value": {
+              "durationMs": 86400000
+            }
+          },
+          {
+            "id": "p-deployment",
+            "version": "KqlParameterItem/1.0",
+            "name": "Deployment",
+            "label": "Deployment",
+            "type": 2,
+            "isRequired": false,
+            "multiSelect": false,
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
+            "query": "AzureDiagnostics\n| where Category == 'AzureOpenAIRequestUsage'\n| extend props = parse_json(properties_s)\n| extend Deployment = tostring(props.modelDeploymentName)\n| where isnotempty(Deployment)\n| distinct Deployment\n| order by Deployment asc",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "value": "value::all"
+          },
+          {
+            "id": "p-model",
+            "version": "KqlParameterItem/1.0",
+            "name": "Model",
+            "label": "Model",
+            "type": 2,
+            "isRequired": false,
+            "multiSelect": false,
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
+            "query": "AzureDiagnostics\n| where Category == 'AzureOpenAIRequestUsage'\n| extend props = parse_json(properties_s)\n| extend Model = tostring(props.modelName)\n| where isnotempty(Model)\n| distinct Model\n| order by Model asc",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "value": "value::all"
+          },
+          {
+            "id": "p-streamtype",
+            "version": "KqlParameterItem/1.0",
+            "name": "StreamType",
+            "label": "Streaming",
+            "type": 2,
+            "isRequired": false,
+            "multiSelect": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[{\"value\": \"*\", \"label\": \"All\"}, {\"value\": \"Streaming\", \"label\": \"Streaming\"}, {\"value\": \"NonStreaming\", \"label\": \"Non-streaming\"}]",
+            "value": "*"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - top"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "tab-capacity",
+            "cellValue": "SelectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Capacity",
+            "subTarget": "capacity",
+            "style": "link"
+          },
+          {
+            "id": "tab-traffic",
+            "cellValue": "SelectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Traffic and tokens",
+            "subTarget": "traffic",
+            "style": "link"
+          },
+          {
+            "id": "tab-latency",
+            "cellValue": "SelectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Latency",
+            "subTarget": "latency",
+            "style": "link"
+          },
+          {
+            "id": "tab-errors",
+            "cellValue": "SelectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Errors and throttling",
+            "subTarget": "errors",
+            "style": "link"
+          }
+        ]
+      },
+      "name": "tabs"
+    },
+    {
+      "type": 12,
+      "conditionalVisibility": {
+        "parameterName": "SelectedTab",
+        "comparison": "isEqualTo",
+        "value": "capacity"
+      },
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "## Foundry / Azure OpenAI operations dashboard\nThis workbook is scoped **per Azure OpenAI resource** and **per Log Analytics workspace**. Pick the subscription, workspace, and Azure OpenAI resource above, then use the deployment, model, time-range, and streaming filters to narrow each tab.\n\n> **PTU_Normalizado** is a display-only scaling series (`PTU% * 100000`). It exists so the 0-100 PTU utilization percentage can share a Y axis with raw token counts in a single timechart. It is not a real token volume - read the true utilization from **PTU_Avg_Pct** / **PTU_Max_Pct**."
+            },
+            "name": "capacity-note"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureMetrics\n| where MetricName in ('AzureOpenAIProvisionedManagedUtilizationV2','Ratelimit','TokenTransaction','ProcessedPromptTokens')\n| extend Deployment = tostring(split(Resource, '/')[-1])\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| summarize PTU_Avg_Pct = avgif(Average, MetricName == 'AzureOpenAIProvisionedManagedUtilizationV2'),\n    PTU_Max_Pct = maxif(Maximum, MetricName == 'AzureOpenAIProvisionedManagedUtilizationV2'),\n    Ratelimit = avgif(Average, MetricName == 'Ratelimit'),\n    ProcessedTokens = sumif(Total, MetricName in ('TokenTransaction','ProcessedPromptTokens'))\n    by TimeGenerated = bin(TimeGenerated, 1m), Deployment\n| extend Spillover = max_of(0.0, ProcessedTokens - Ratelimit)\n| extend Aggregated_PTU_With_Spillover = ProcessedTokens\n| extend PTU_Normalizado = PTU_Avg_Pct * 100000\n| project TimeGenerated, PTU_Avg_Pct, PTU_Max_Pct, Ratelimit, Spillover, Aggregated_PTU_With_Spillover, PTU_Normalizado\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "PTU utilization and PAYG spillover",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "timechart"
+            },
+            "name": "capacity-ptu"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureMetrics\n| where MetricName in ('AzureOpenAIProvisionedManagedUtilizationV2','Ratelimit','TokenTransaction','ProcessedPromptTokens')\n| extend Deployment = tostring(split(Resource, '/')[-1])\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| summarize PTU_Avg_Pct = avgif(Average, MetricName == 'AzureOpenAIProvisionedManagedUtilizationV2'),\n    PTU_Max_Pct = maxif(Maximum, MetricName == 'AzureOpenAIProvisionedManagedUtilizationV2'),\n    Ratelimit = avgif(Average, MetricName == 'Ratelimit'),\n    ProcessedTokens = sumif(Total, MetricName in ('TokenTransaction','ProcessedPromptTokens'))\n    by TimeGenerated = bin(TimeGenerated, 1m), Deployment\n| extend Spillover = max_of(0.0, ProcessedTokens - Ratelimit)\n| extend Aggregated_PTU_With_Spillover = ProcessedTokens\n| extend PTU_Normalizado = PTU_Avg_Pct * 100000\n| project TimeGenerated, PTU_Avg_Pct, PTU_Max_Pct, Ratelimit, Spillover, Aggregated_PTU_With_Spillover, PTU_Normalizado\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "Capacity summary (per bin)",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "table"
+            },
+            "name": "capacity-ptu-table"
+          }
+        ]
+      },
+      "name": "group-capacity"
+    },
+    {
+      "type": 12,
+      "conditionalVisibility": {
+        "parameterName": "SelectedTab",
+        "comparison": "isEqualTo",
+        "value": "traffic"
+      },
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "### Traffic and tokens\nCall volume and token consumption broken down by deployment and model. The PTU vs PAYG pivot splits token volume by capacity type (streaming traffic maps to PTU, non-streaming overflow to PAYG spillover)."
+            },
+            "name": "traffic-note"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureDiagnostics\n| where Category == 'AzureOpenAIRequestUsage'\n| extend props = parse_json(properties_s)\n| extend Deployment = tostring(props.modelDeploymentName), Model = tostring(props.modelName), StreamType = tostring(props.streamType),\n    PromptTokens = toreal(props.promptTokens[0]), GeneratedTokens = toreal(props.generatedTokens[0])\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| where '{Model}' == 'value::all' or Model == '{Model}'\n| where '{StreamType}' == '*' or StreamType == '{StreamType}'\n| summarize AzureOpenAIRequests = count(), InputTokens = sum(PromptTokens), OutputTokens = sum(GeneratedTokens),\n    ProcessedPromptTokens = sum(PromptTokens) by TimeGenerated = bin(TimeGenerated, 5m), Deployment, Model\n| extend TotalTokens = InputTokens + OutputTokens, GeneratedTokens = OutputTokens, TotalCalls = AzureOpenAIRequests\n| extend TokensPorRequest = iff(AzureOpenAIRequests > 0, ProcessedPromptTokens / AzureOpenAIRequests, 0.0)\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "Calls and tokens over time",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "timechart"
+            },
+            "name": "traffic-tokens"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureDiagnostics\n| where Category == 'AzureOpenAIRequestUsage'\n| extend props = parse_json(properties_s)\n| extend Deployment = tostring(props.modelDeploymentName), Model = tostring(props.modelName), StreamType = tostring(props.streamType),\n    PromptTokens = toreal(props.promptTokens[0]), GeneratedTokens = toreal(props.generatedTokens[0])\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| where '{Model}' == 'value::all' or Model == '{Model}'\n| where '{StreamType}' == '*' or StreamType == '{StreamType}'\n| summarize AzureOpenAIRequests = count(), InputTokens = sum(PromptTokens), OutputTokens = sum(GeneratedTokens),\n    ProcessedPromptTokens = sum(PromptTokens) by TimeGenerated = bin(TimeGenerated, 5m), Deployment, Model\n| extend TotalTokens = InputTokens + OutputTokens, GeneratedTokens = OutputTokens, TotalCalls = AzureOpenAIRequests\n| extend TokensPorRequest = iff(AzureOpenAIRequests > 0, ProcessedPromptTokens / AzureOpenAIRequests, 0.0)\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "Tokens per request (by deployment and model)",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "table"
+            },
+            "name": "traffic-tokens-table"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureDiagnostics\n| where Category == 'AzureOpenAIRequestUsage'\n| extend props = parse_json(properties_s)\n| extend Deployment = tostring(props.modelDeploymentName), StreamType = tostring(props.streamType),\n    PromptTokens = toreal(props.promptTokens[0]), GeneratedTokens = toreal(props.generatedTokens[0])\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| extend CapacityType = iff(StreamType == 'Streaming', 'PTU', 'PAYGO_SPILLOVER')\n| summarize Tokens = sum(PromptTokens + GeneratedTokens) by TimeGenerated = bin(TimeGenerated, 5m), CapacityType\n| evaluate pivot(CapacityType, sum(Tokens))\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "PTU vs PAYG spillover (token volume)",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "timechart"
+            },
+            "name": "traffic-pivot"
+          }
+        ]
+      },
+      "name": "group-traffic"
+    },
+    {
+      "type": 12,
+      "conditionalVisibility": {
+        "parameterName": "SelectedTab",
+        "comparison": "isEqualTo",
+        "value": "latency"
+      },
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "### Latency\nNormalized Azure OpenAI latency metrics (TTFT, TBT, TTLT, tokens/sec, time-to-response) plus P95/P99/Avg/Max computed from per-request `DurationMs`."
+            },
+            "name": "latency-note"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureMetrics\n| where MetricName in ('AzureOpenAINormalizedTTFTInMS','AzureOpenAINormalizedTBTInMS','AzureOpenAITTLTInMS','AzureOpenAITokenPerSecond','AzureOpenAITimeToResponse','Latency')\n| extend Deployment = tostring(split(Resource, '/')[-1])\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| summarize TTFT_Ms = avgif(Average, MetricName == 'AzureOpenAINormalizedTTFTInMS'),\n    TBT_Ms = avgif(Average, MetricName == 'AzureOpenAINormalizedTBTInMS'),\n    TTLT_Ms = avgif(Average, MetricName == 'AzureOpenAITTLTInMS'),\n    TokensPerSecond = avgif(Average, MetricName == 'AzureOpenAITokenPerSecond'),\n    TimeToResponse_Ms = avgif(Average, MetricName == 'AzureOpenAITimeToResponse'),\n    Latency_Ms = avgif(Average, MetricName == 'Latency') by TimeGenerated = bin(TimeGenerated, 5m)\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "Normalized latency and throughput",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "timechart"
+            },
+            "name": "latency-platform"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureDiagnostics\n| where OperationName in ('ChatCompletions_Create','RequestResponse')\n| extend props = parse_json(properties_s)\n| extend Deployment = tostring(props.modelDeploymentName), StreamType = tostring(props.streamType)\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| where '{StreamType}' == '*' or StreamType == '{StreamType}'\n| where isnotnull(DurationMs)\n| summarize P95LatencyMs = percentile(DurationMs, 95), P99LatencyMs = percentile(DurationMs, 99),\n    AvgLatencyMs = avg(DurationMs), MaxLatencyMs = max(DurationMs) by TimeGenerated = bin(TimeGenerated, 5m)\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "DurationMs percentiles (P95 / P99 / Avg / Max)",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "timechart"
+            },
+            "name": "latency-percentiles"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureDiagnostics\n| where OperationName in ('ChatCompletions_Create','RequestResponse')\n| extend props = parse_json(properties_s)\n| extend Deployment = tostring(props.modelDeploymentName), StreamType = tostring(props.streamType)\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| where '{StreamType}' == '*' or StreamType == '{StreamType}'\n| where isnotnull(DurationMs)\n| summarize P95LatencyMs = percentile(DurationMs, 95), P99LatencyMs = percentile(DurationMs, 99),\n    AvgLatencyMs = avg(DurationMs), MaxLatencyMs = max(DurationMs) by TimeGenerated = bin(TimeGenerated, 5m)\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "Latency percentiles (per bin)",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "table"
+            },
+            "name": "latency-percentiles-table"
+          }
+        ]
+      },
+      "name": "group-latency"
+    },
+    {
+      "type": 12,
+      "conditionalVisibility": {
+        "parameterName": "SelectedTab",
+        "comparison": "isEqualTo",
+        "value": "errors"
+      },
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "### Errors and throttling\nHTTP status breakdown (429 / 400 / 500), blocked calls, and derived throttling / error rates."
+            },
+            "name": "errors-note"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureDiagnostics\n| where OperationName in ('ChatCompletions_Create','RequestResponse')\n| extend props = parse_json(properties_s)\n| extend Deployment = tostring(props.modelDeploymentName), StreamType = tostring(props.streamType), Status = toint(ResultSignature)\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| where '{StreamType}' == '*' or StreamType == '{StreamType}'\n| summarize TotalRequests = count(), HTTP429 = countif(Status == 429), HTTP400 = countif(Status == 400),\n    HTTP500 = countif(Status >= 500 and Status < 600), Successful = countif(Status == 200)\n    by TimeGenerated = bin(TimeGenerated, 5m)\n| extend BlockedCalls = HTTP429\n| extend TasaThrottling_Pct = iff(TotalRequests > 0, todouble(HTTP429) / TotalRequests * 100, 0.0)\n| extend TasaError_Pct = iff(TotalRequests > 0, todouble(TotalRequests - Successful) / TotalRequests * 100, 0.0)\n| project TimeGenerated, BlockedCalls, HTTP429, HTTP400, HTTP500, TasaThrottling_Pct, TasaError_Pct\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "HTTP status counts over time",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "timechart"
+            },
+            "name": "errors-counts"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureDiagnostics\n| where OperationName in ('ChatCompletions_Create','RequestResponse')\n| extend props = parse_json(properties_s)\n| extend Deployment = tostring(props.modelDeploymentName), StreamType = tostring(props.streamType), Status = toint(ResultSignature)\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| where '{StreamType}' == '*' or StreamType == '{StreamType}'\n| summarize TotalRequests = count(), HTTP429 = countif(Status == 429), HTTP400 = countif(Status == 400),\n    HTTP500 = countif(Status >= 500 and Status < 600), Successful = countif(Status == 200)\n    by TimeGenerated = bin(TimeGenerated, 5m)\n| extend BlockedCalls = HTTP429\n| extend TasaThrottling_Pct = iff(TotalRequests > 0, todouble(HTTP429) / TotalRequests * 100, 0.0)\n| extend TasaError_Pct = iff(TotalRequests > 0, todouble(TotalRequests - Successful) / TotalRequests * 100, 0.0)\n| project TimeGenerated, BlockedCalls, HTTP429, HTTP400, HTTP500, TasaThrottling_Pct, TasaError_Pct\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "Throttling rate and error rate (%)",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "timechart"
+            },
+            "name": "errors-rates"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AzureDiagnostics\n| where OperationName in ('ChatCompletions_Create','RequestResponse')\n| extend props = parse_json(properties_s)\n| extend Deployment = tostring(props.modelDeploymentName), StreamType = tostring(props.streamType), Status = toint(ResultSignature)\n| where '{Deployment}' == 'value::all' or Deployment == '{Deployment}'\n| where '{StreamType}' == '*' or StreamType == '{StreamType}'\n| summarize TotalRequests = count(), HTTP429 = countif(Status == 429), HTTP400 = countif(Status == 400),\n    HTTP500 = countif(Status >= 500 and Status < 600), Successful = countif(Status == 200)\n    by TimeGenerated = bin(TimeGenerated, 5m)\n| extend BlockedCalls = HTTP429\n| extend TasaThrottling_Pct = iff(TotalRequests > 0, todouble(HTTP429) / TotalRequests * 100, 0.0)\n| extend TasaError_Pct = iff(TotalRequests > 0, todouble(TotalRequests - Successful) / TotalRequests * 100, 0.0)\n| project TimeGenerated, BlockedCalls, HTTP429, HTTP400, HTTP500, TasaThrottling_Pct, TasaError_Pct\n| order by TimeGenerated asc",
+              "size": 0,
+              "title": "Errors and throttling (per bin)",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "visualization": "table"
+            },
+            "name": "errors-table"
+          }
+        ]
+      },
+      "name": "group-errors"
+    }
+  ],
+  "isLocked": false,
+  "fallbackResourceIds": [
+    "Azure Monitor"
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/src/agentops/templates/workbooks/queries/capacity_ptu_spillover.kql
+++ b/src/agentops/templates/workbooks/queries/capacity_ptu_spillover.kql
@@ -1,0 +1,52 @@
+// Capacity: PTU utilization, rate limit, and PAYG spillover
+// -----------------------------------------------------------------------------
+// Source: AzureMetrics (platform metrics emitted by the Azure OpenAI resource).
+// Derived metrics: PTU_Avg_Pct, PTU_Max_Pct, Ratelimit, Spillover volume,
+//                  Aggregated_PTU_With_Spillover, PTU_Normalizado.
+//
+// The foundry-ops workbook binds the following parameters into this query at
+// runtime. When running the query standalone in Log Analytics, edit the `let`
+// bindings below to match your environment.
+//   {TimeRange}  -> replaced by the workbook time-range picker (KQL timespan)
+//   {Resource}   -> Azure OpenAI resource id (used as the workbook scope)
+//   {Deployment} -> modelDeploymentName filter, or "*" for all deployments
+//   {StreamType} -> "Streaming", "NonStreaming", or "*" for both
+//
+// Note on PTU_Normalizado: this is a DISPLAY-ONLY series (PTU% * 100000). It
+// lets the 0-100 PTU utilization percentage share a Y axis with raw token
+// counts in a single timechart. Do not treat it as a real token volume.
+// -----------------------------------------------------------------------------
+let _bin = 1m;
+let _deployment = "*";      // workbook: {Deployment}
+AzureMetrics
+| where TimeGenerated {TimeRange}
+| where MetricName in (
+    "AzureOpenAIProvisionedManagedUtilizationV2",
+    "Ratelimit",
+    "TokenTransaction",
+    "ProcessedPromptTokens"
+  )
+| extend Deployment = tostring(split(Resource, "/")[-1])
+| where _deployment == "*" or Deployment == _deployment
+| summarize
+    PTU_Avg_Pct = avgif(Average, MetricName == "AzureOpenAIProvisionedManagedUtilizationV2"),
+    PTU_Max_Pct = maxif(Maximum, MetricName == "AzureOpenAIProvisionedManagedUtilizationV2"),
+    Ratelimit = avgif(Average, MetricName == "Ratelimit"),
+    ProcessedTokens = sumif(Total, MetricName in ("TokenTransaction", "ProcessedPromptTokens"))
+    by TimeGenerated = bin(TimeGenerated, _bin), Deployment
+// Tokens above the deployment rate limit spill over to pay-as-you-go capacity.
+| extend Spillover = max_of(0.0, ProcessedTokens - Ratelimit)
+| extend PTU_Tokens = ProcessedTokens - Spillover
+| extend Aggregated_PTU_With_Spillover = PTU_Tokens + Spillover
+// Display-only scaling series so PTU % can share a Y axis with token counts.
+| extend PTU_Normalizado = PTU_Avg_Pct * 100000
+| project
+    TimeGenerated,
+    Deployment,
+    PTU_Avg_Pct,
+    PTU_Max_Pct,
+    Ratelimit,
+    Spillover,
+    Aggregated_PTU_With_Spillover,
+    PTU_Normalizado
+| order by TimeGenerated asc

--- a/src/agentops/templates/workbooks/queries/errors_throttling.kql
+++ b/src/agentops/templates/workbooks/queries/errors_throttling.kql
@@ -1,0 +1,48 @@
+// Errors and throttling: HTTP status breakdown, throttling rate, error rate
+// -----------------------------------------------------------------------------
+// Source: AzureDiagnostics (ResultSignature holds the HTTP status) and
+// AzureMetrics (BlockedCalls / TotalCalls) for platform-side throttling counts.
+// Derived metrics: HTTP429, HTTP400, HTTP500, TasaThrottling_Pct, TasaError_Pct,
+//                  BlockedCalls.
+//
+// Workbook parameter bindings (edit the `let` lines to run standalone):
+//   {TimeRange}  -> workbook time-range picker (KQL timespan)
+//   {Deployment} -> modelDeploymentName filter, or "*" for all deployments
+//   {StreamType} -> "Streaming", "NonStreaming", or "*" for both
+// -----------------------------------------------------------------------------
+let _bin = 5m;
+let _deployment = "*";      // workbook: {Deployment}
+let _stream = "*";          // workbook: {StreamType}
+AzureDiagnostics
+| where TimeGenerated {TimeRange}
+| where OperationName in ("ChatCompletions_Create", "RequestResponse")
+| extend props = parse_json(properties_s)
+| extend
+    Deployment = tostring(props.modelDeploymentName),
+    StreamType = tostring(props.streamType),
+    Status = toint(ResultSignature)
+| where _deployment == "*" or Deployment == _deployment
+| where _stream == "*" or StreamType == _stream
+| summarize
+    TotalRequests = count(),
+    HTTP429 = countif(Status == 429),
+    HTTP400 = countif(Status == 400),
+    HTTP500 = countif(Status >= 500 and Status < 600),
+    Successful = countif(Status == 200)
+    by TimeGenerated = bin(TimeGenerated, _bin), Deployment
+| extend BlockedCalls = HTTP429
+// Throttling rate: share of requests rejected with HTTP 429.
+| extend TasaThrottling_Pct = iff(TotalRequests > 0, todouble(HTTP429) / TotalRequests * 100, 0.0)
+// Error rate: share of requests that did not return HTTP 200.
+| extend TasaError_Pct = iff(TotalRequests > 0, todouble(TotalRequests - Successful) / TotalRequests * 100, 0.0)
+| project
+    TimeGenerated,
+    Deployment,
+    TotalRequests,
+    BlockedCalls,
+    HTTP429,
+    HTTP400,
+    HTTP500,
+    TasaThrottling_Pct,
+    TasaError_Pct
+| order by TimeGenerated asc

--- a/src/agentops/templates/workbooks/queries/latency_percentiles.kql
+++ b/src/agentops/templates/workbooks/queries/latency_percentiles.kql
@@ -1,0 +1,74 @@
+// Latency: TTFT, TBT, TTLT, tokens/sec, and DurationMs percentiles
+// -----------------------------------------------------------------------------
+// Source: AzureMetrics for the normalized Azure OpenAI latency metrics, and
+// AzureDiagnostics (DurationMs) for per-request percentiles.
+// Derived metrics: P95LatencyMs, P99LatencyMs, AvgLatencyMs, MaxLatencyMs, plus
+//                  the platform latency metrics surfaced side by side.
+//
+// Workbook parameter bindings (edit the `let` lines to run standalone):
+//   {TimeRange}  -> workbook time-range picker (KQL timespan)
+//   {Deployment} -> modelDeploymentName filter, or "*" for all deployments
+//   {StreamType} -> "Streaming", "NonStreaming", or "*" for both
+// -----------------------------------------------------------------------------
+let _bin = 5m;
+let _deployment = "*";      // workbook: {Deployment}
+let _stream = "*";          // workbook: {StreamType}
+// Platform-normalized latency and throughput metrics.
+let platform =
+    AzureMetrics
+    | where TimeGenerated {TimeRange}
+    | where MetricName in (
+        "AzureOpenAINormalizedTTFTInMS",
+        "AzureOpenAINormalizedTBTInMS",
+        "AzureOpenAITTLTInMS",
+        "AzureOpenAITokenPerSecond",
+        "AzureOpenAITimeToResponse",
+        "Latency"
+      )
+    | extend Deployment = tostring(split(Resource, "/")[-1])
+    | where _deployment == "*" or Deployment == _deployment
+    | summarize
+        TTFT_Ms = avgif(Average, MetricName == "AzureOpenAINormalizedTTFTInMS"),
+        TBT_Ms = avgif(Average, MetricName == "AzureOpenAINormalizedTBTInMS"),
+        TTLT_Ms = avgif(Average, MetricName == "AzureOpenAITTLTInMS"),
+        TokensPerSecond = avgif(Average, MetricName == "AzureOpenAITokenPerSecond"),
+        TimeToResponse_Ms = avgif(Average, MetricName == "AzureOpenAITimeToResponse"),
+        Latency_Ms = avgif(Average, MetricName == "Latency")
+        by TimeGenerated = bin(TimeGenerated, _bin), Deployment;
+// Per-request duration percentiles from diagnostic records.
+let durations =
+    AzureDiagnostics
+    | where TimeGenerated {TimeRange}
+    | where OperationName in ("ChatCompletions_Create", "RequestResponse")
+    | extend props = parse_json(properties_s)
+    | extend
+        Deployment = tostring(props.modelDeploymentName),
+        StreamType = tostring(props.streamType)
+    | where _deployment == "*" or Deployment == _deployment
+    | where _stream == "*" or StreamType == _stream
+    | where isnotnull(DurationMs)
+    | summarize
+        P95LatencyMs = percentile(DurationMs, 95),
+        P99LatencyMs = percentile(DurationMs, 99),
+        AvgLatencyMs = avg(DurationMs),
+        MaxLatencyMs = max(DurationMs)
+        by TimeGenerated = bin(TimeGenerated, _bin), Deployment;
+platform
+| join kind=fullouter durations on TimeGenerated, Deployment
+| extend
+    TimeGenerated = coalesce(TimeGenerated, TimeGenerated1),
+    Deployment = coalesce(Deployment, Deployment1)
+| project
+    TimeGenerated,
+    Deployment,
+    TTFT_Ms,
+    TBT_Ms,
+    TTLT_Ms,
+    TokensPerSecond,
+    TimeToResponse_Ms,
+    Latency_Ms,
+    P95LatencyMs,
+    P99LatencyMs,
+    AvgLatencyMs,
+    MaxLatencyMs
+| order by TimeGenerated asc

--- a/src/agentops/templates/workbooks/queries/traffic_tokens.kql
+++ b/src/agentops/templates/workbooks/queries/traffic_tokens.kql
@@ -1,0 +1,61 @@
+// Traffic and tokens: call volume, token consumption, and PTU vs PAYG split
+// -----------------------------------------------------------------------------
+// Source: AzureDiagnostics (Category == "AzureOpenAIRequestUsage") for real
+// per-model token usage, joined with AzureMetrics for platform call volume.
+// Derived metrics: TokensPorRequest, InputTokens, OutputTokens, TotalTokens,
+//                  ProcessedPromptTokens, GeneratedTokens, and a PTU vs PAYG
+//                  spillover pivot.
+//
+// Workbook parameter bindings (edit the `let` lines to run standalone):
+//   {TimeRange}  -> workbook time-range picker (KQL timespan)
+//   {Deployment} -> modelDeploymentName filter, or "*" for all deployments
+//   {Model}      -> modelName filter, or "*" for all models
+//   {StreamType} -> "Streaming", "NonStreaming", or "*" for both
+// -----------------------------------------------------------------------------
+let _bin = 5m;
+let _deployment = "*";      // workbook: {Deployment}
+let _model = "*";           // workbook: {Model}
+let _stream = "*";          // workbook: {StreamType}
+AzureDiagnostics
+| where TimeGenerated {TimeRange}
+| where Category == "AzureOpenAIRequestUsage"
+| extend props = parse_json(properties_s)
+| extend
+    Deployment = tostring(props.modelDeploymentName),
+    Model = tostring(props.modelName),
+    ModelVersion = tostring(props.modelVersion),
+    StreamType = tostring(props.streamType),
+    PromptTokens = toreal(props.promptTokens[0]),
+    GeneratedTokens = toreal(props.generatedTokens[0])
+| where _deployment == "*" or Deployment == _deployment
+| where _model == "*" or Model == _model
+| where _stream == "*" or StreamType == _stream
+| summarize
+    AzureOpenAIRequests = count(),
+    InputTokens = sum(PromptTokens),
+    OutputTokens = sum(GeneratedTokens),
+    ProcessedPromptTokens = sum(PromptTokens)
+    by TimeGenerated = bin(TimeGenerated, _bin), Deployment, Model, StreamType
+| extend TotalTokens = InputTokens + OutputTokens
+| extend GeneratedTokens = OutputTokens
+| extend TotalCalls = AzureOpenAIRequests
+// Average tokens billed per request over the bin.
+| extend TokensPorRequest = iff(AzureOpenAIRequests > 0, ProcessedPromptTokens / AzureOpenAIRequests, 0.0)
+// PTU vs PAYG split: streaming and provisioned traffic run on PTU capacity;
+// non-streaming overflow is treated as the PAYG spillover pivot column.
+| extend CapacityType = iff(StreamType == "Streaming", "PTU", "PAYGO_SPILLOVER")
+| project
+    TimeGenerated,
+    Deployment,
+    Model,
+    StreamType,
+    CapacityType,
+    TotalCalls,
+    AzureOpenAIRequests,
+    InputTokens,
+    OutputTokens,
+    TotalTokens,
+    ProcessedPromptTokens,
+    GeneratedTokens,
+    TokensPorRequest
+| order by TimeGenerated asc

--- a/tests/unit/test_agent_posture_rules.py
+++ b/tests/unit/test_agent_posture_rules.py
@@ -10,6 +10,9 @@ from agentops.agent.checks.posture_rules.content_filter import (
 from agentops.agent.checks.posture_rules.diagnostics import (
     evaluate as diagnostics_rule,
 )
+from agentops.agent.checks.posture_rules.aoai_diagnostic_categories import (
+    evaluate as aoai_diag_rule,
+)
 from agentops.agent.checks.posture_rules.local_auth import (
     evaluate as local_auth_rule,
 )
@@ -265,6 +268,19 @@ def test_run_posture_check_aggregates_rules() -> None:
         disable_local_auth=False,
         public_network_access="Enabled",
         identity_type=None,
+        # Keep the AOAI usage-telemetry rule quiet so this test stays
+        # focused on the security rules it asserts on.
+        diagnostic_settings=[
+            DiagnosticSettingSnapshot(
+                name="default",
+                workspace_id="/subscriptions/s/workspaces/log",
+                enabled_log_categories=[
+                    "Audit",
+                    "RequestResponse",
+                    "AzureOpenAIRequestUsage",
+                ],
+            )
+        ],
     )
     findings = run_posture_check(payload, PostureCheckConfig(enabled=True))
     ids = {f.id for f in findings}
@@ -297,4 +313,71 @@ def test_rule_registry_only_contains_complementary_rules() -> None:
         "waf.security.local_auth_disabled",
         "waf.security.managed_identity",
         "waf.security.diagnostic_settings",
+        "waf.observability.aoai_diagnostic_categories",
     }
+
+
+# ---------------------------------------------------------------------------
+# aoai_diagnostic_categories (WAF-AI Operational Excellence)
+# ---------------------------------------------------------------------------
+
+
+def test_aoai_diag_rule_passes_when_both_categories_enabled() -> None:
+    payload = _payload(
+        diagnostic_settings=[
+            DiagnosticSettingSnapshot(
+                name="default",
+                workspace_id="/subscriptions/s/workspaces/log",
+                enabled_log_categories=[
+                    "RequestResponse",
+                    "AzureOpenAIRequestUsage",
+                ],
+            )
+        ]
+    )
+    assert aoai_diag_rule(payload, "azure_resources") == []
+
+
+def test_aoai_diag_rule_fires_when_usage_category_missing() -> None:
+    payload = _payload(
+        diagnostic_settings=[
+            DiagnosticSettingSnapshot(
+                name="default",
+                workspace_id="/subscriptions/s/workspaces/log",
+                enabled_log_categories=["RequestResponse"],
+            )
+        ]
+    )
+    findings = aoai_diag_rule(payload, "azure_resources")
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.id == "waf.observability.aoai_diagnostic_categories"
+    assert finding.severity is Severity.WARNING
+    assert finding.category is Category.OPERATIONAL_EXCELLENCE
+    assert finding.evidence["missing_categories"] == ["AzureOpenAIRequestUsage"]
+    # The recommendation must carry the exact az fix command.
+    assert "az monitor diagnostic-settings create" in finding.recommendation
+    assert "AzureOpenAIRequestUsage" in finding.recommendation
+
+
+def test_aoai_diag_rule_fires_when_no_categories() -> None:
+    payload = _payload(
+        diagnostic_settings=[
+            DiagnosticSettingSnapshot(
+                name="default",
+                workspace_id="/subscriptions/s/workspaces/log",
+                enabled_log_categories=[],
+            )
+        ]
+    )
+    findings = aoai_diag_rule(payload, "azure_resources")
+    assert len(findings) == 1
+    assert findings[0].evidence["missing_categories"] == [
+        "RequestResponse",
+        "AzureOpenAIRequestUsage",
+    ]
+
+
+def test_aoai_diag_rule_noop_without_account() -> None:
+    payload = AzureResourcesPayload(account=None)
+    assert aoai_diag_rule(payload, "azure_resources") == []

--- a/tests/unit/test_cli_dashboard.py
+++ b/tests/unit/test_cli_dashboard.py
@@ -1,0 +1,155 @@
+"""CLI tests for the ``agentops telemetry dashboard`` sub-app.
+
+The Azure logic lives in :mod:`agentops.services.dashboard`; these tests keep
+Azure out of the loop by exercising ``deploy --dry-run`` (which never touches
+Azure), ``open --print-url`` and ``export`` (both pure), plus the ``--help``
+and ``explain`` surfaces.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agentops.cli.app import app
+
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+# ---------------------------------------------------------------------------
+# help / discoverability
+# ---------------------------------------------------------------------------
+def test_dashboard_help_lists_commands() -> None:
+    result = runner.invoke(app, ["telemetry", "dashboard", "--help"])
+    assert result.exit_code == 0
+    stripped = _strip_ansi(result.stdout)
+    assert "deploy" in stripped
+    assert "open" in stripped
+    assert "export" in stripped
+
+
+def test_dashboard_deploy_help() -> None:
+    result = runner.invoke(app, ["telemetry", "dashboard", "deploy", "--help"])
+    assert result.exit_code == 0
+    stripped = _strip_ansi(result.stdout)
+    assert "--dry-run" in stripped
+    assert "--subscription" in stripped
+    assert "--resource-group" in stripped
+    assert "--workspace-id" in stripped
+    assert "--name" in stripped
+
+
+def test_dashboard_open_help() -> None:
+    result = runner.invoke(app, ["telemetry", "dashboard", "open", "--help"])
+    assert result.exit_code == 0
+    assert "--print-url" in _strip_ansi(result.stdout)
+
+
+def test_dashboard_export_help() -> None:
+    result = runner.invoke(app, ["telemetry", "dashboard", "export", "--help"])
+    assert result.exit_code == 0
+    assert "--out" in _strip_ansi(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# explain pages
+# ---------------------------------------------------------------------------
+def test_dashboard_explain_pages_exit_zero() -> None:
+    for path in (
+        ["telemetry", "dashboard", "explain"],
+        ["telemetry", "dashboard", "deploy", "explain"],
+        ["telemetry", "dashboard", "open", "explain"],
+        ["telemetry", "dashboard", "export", "explain"],
+    ):
+        result = runner.invoke(app, path)
+        assert result.exit_code == 0, f"{path} -> {result.stdout}"
+
+
+# ---------------------------------------------------------------------------
+# deploy --dry-run (no Azure)
+# ---------------------------------------------------------------------------
+def test_dashboard_deploy_dry_run_emits_arm_template(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "dashboard",
+            "deploy",
+            "--dry-run",
+            "--subscription",
+            "sub",
+            "--resource-group",
+            "rg",
+            "--dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    # The dry-run prints the ARM template to stdout and an advisory note to
+    # stderr (mixed into stdout by CliRunner); parse just the JSON object.
+    obj, _end = json.JSONDecoder().raw_decode(result.stdout[result.stdout.index("{") :])
+    template = obj
+    assert template["resources"][0]["type"] == "Microsoft.Insights/workbooks"
+    assert template["resources"][0]["properties"]["serializedData"]
+
+
+# ---------------------------------------------------------------------------
+# open --print-url (no browser, no Azure)
+# ---------------------------------------------------------------------------
+def test_dashboard_open_print_url(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "dashboard",
+            "open",
+            "--print-url",
+            "--subscription",
+            "sub",
+            "--resource-group",
+            "rg",
+            "--dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "https://portal.azure.com/" in result.stdout
+
+
+def test_dashboard_open_falls_back_to_gallery_without_target(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["telemetry", "dashboard", "open", "--print-url", "--dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.stdout
+    # No subscription/rg discoverable -> gallery deep link.
+    assert "WorkbookMenuBlade" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# export
+# ---------------------------------------------------------------------------
+def test_dashboard_export_writes_file(tmp_path: Path) -> None:
+    out = tmp_path / "foundry-ops.workbook.json"
+    result = runner.invoke(app, ["telemetry", "dashboard", "export", "--out", str(out)])
+    assert result.exit_code == 0, result.stdout
+    assert out.is_file()
+    # The exported file is valid JSON identical to the packaged template.
+    from agentops.services import dashboard as dash
+
+    assert json.loads(out.read_text(encoding="utf-8")) == dash.load_workbook_content()
+
+
+def test_dashboard_export_creates_parent_dirs(tmp_path: Path) -> None:
+    out = tmp_path / "nested" / "dir" / "wb.json"
+    result = runner.invoke(app, ["telemetry", "dashboard", "export", "--out", str(out)])
+    assert result.exit_code == 0, result.stdout
+    assert out.is_file()

--- a/tests/unit/test_cockpit.py
+++ b/tests/unit/test_cockpit.py
@@ -316,7 +316,12 @@ def test_html_includes_all_sections_when_data_present(tmp_path: Path, monkeypatc
     assert "Azure Monitor" in html
     assert "Observability readiness" in html
     assert "Next actions" in html
-    # Gate summary sections.
+    # Consolidated top status cards ("can I ship?").
+    assert 'id="section-status-cards"' in html
+    assert "Can I ship?" in html
+    # Gate summary sections: eval + quality gate are merged into one
+    # "Eval gates" section with two subgroups.
+    assert "Eval gates" in html
     assert "Eval gate summary" in html
     assert "AgentOps Doctor" in html
     assert "CI/CD" in html
@@ -331,41 +336,57 @@ def test_html_includes_all_sections_when_data_present(tmp_path: Path, monkeypatc
     assert "AgentOps gate history from local artifacts and CI runs" in html
     assert "<svg" in html
 
-    # Sections render in the strategic order: Foundry connection →
-    # Foundry launchpad → Observability readiness →
-    # AgentOps Doctor → Eval gate summary → Quality gate summary →
-    # Production signal → CI/CD → Next actions.
+    # Sections render in the redesigned "can I ship?" order: Foundry
+    # connection → consolidated status cards → Next actions →
+    # Observability readiness → AgentOps Doctor → Eval gates →
+    # Production signal → CI/CD → Foundry launchpad (footer).
     connection_pos = html.find('<span class="section-title-text">Foundry connection')
-    open_pos = html.find('<span class="section-title-text">Foundry launchpad')
+    status_cards_pos = html.find('id="section-status-cards"')
+    actions_pos = html.find('<span class="section-title-text">Next actions')
     readiness_pos = html.find('<span class="section-title-text">Observability readiness')
     doctor_pos = html.find('<span class="section-title-text">AgentOps Doctor')
-    eval_pos = html.find('<span class="section-title-text">Eval gate summary')
-    metrics_pos = html.find('<span class="section-title-text">Quality gate summary')
+    eval_gates_pos = html.find('<span class="section-title-text">Eval gates')
     prod_pos = html.find('<span class="section-title-text">Production signal')
     deploy_pos = html.find('<span class="section-title-text">CI/CD')
-    actions_pos = html.find('<span class="section-title-text">Next actions')
+    launchpad_pos = html.find('<span class="section-title-text">Foundry launchpad')
     for pos in (
-        connection_pos, open_pos, readiness_pos, doctor_pos,
-        eval_pos, metrics_pos, prod_pos, deploy_pos, actions_pos,
+        connection_pos, status_cards_pos, actions_pos, readiness_pos,
+        doctor_pos, eval_gates_pos, prod_pos, deploy_pos, launchpad_pos,
     ):
         assert pos != -1, "missing strategic section in cockpit HTML"
     assert (
-        connection_pos < open_pos < readiness_pos < doctor_pos
-        < eval_pos < metrics_pos < prod_pos < deploy_pos < actions_pos
+        connection_pos < status_cards_pos < actions_pos < readiness_pos
+        < doctor_pos < eval_gates_pos < prod_pos < deploy_pos < launchpad_pos
     )
-    assert '<details class="section-block" open' in html
+    # Both subgroup labels live inside the merged Eval gates section, eval
+    # before quality.
+    assert (
+        eval_gates_pos
+        < html.find("Eval gate summary")
+        < html.find("Quality gate summary")
+    )
+    # Detail sections collapse by default; the top status/next-actions
+    # sections stay open. At least one collapsed <details> is present.
+    assert '<details class="section-block" id="section-readiness"' in html
 
 
 
 def test_open_in_foundry_panel_separates_foundry_from_azure_monitor(tmp_path: Path):
-    """The launchpad separates configured-agent, project, and raw telemetry links."""
+    """The launchpad separates configured-agent and Foundry project links.
+
+    The former single-tile "Azure Monitor" group is folded into the
+    Foundry project subgroup (App Insights + the new Foundry operations
+    dashboard tile), so there is one place to look instead of a duplicated
+    one-tile group.
+    """
     payload = build_cockpit_payload(tmp_path, time_range=_WIDE)
 
     open_panel = payload["open_in_foundry"]
     groups = open_panel.get("groups") or []
     keys = [g.get("key") for g in groups]
-    assert keys == ["agent", "project", "azure_monitor"], (
-        "Agent links must precede project links, which must precede Azure Monitor"
+    assert keys == ["agent", "project"], (
+        "Agent links must precede project links; Azure Monitor is folded "
+        "into the project group"
     )
 
     agent_titles = {t["title"] for t in groups[0]["targets"]}
@@ -377,16 +398,23 @@ def test_open_in_foundry_panel_separates_foundry_from_azure_monitor(tmp_path: Pa
         "Datasets",
         "Red Teaming",
         "Operate overview",
+        "Foundry operations dashboard",
+        "App Insights",
     }.issubset(project_titles)
-    # The Azure Monitor subgroup carries only the App Insights tile.
-    azure_titles = {t["title"] for t in groups[2]["targets"]}
-    assert azure_titles == {"App Insights"}
+
+    # The new Foundry operations dashboard tile renders right after
+    # Operate overview, and the two descriptions must not read the same.
+    project_keys = [t["key"] for t in groups[1]["targets"]]
+    assert project_keys.index("foundry_ops_dashboard") == (
+        project_keys.index("operate") + 1
+    )
+    descriptions = {t["key"]: t.get("description", "") for t in groups[1]["targets"]}
+    assert descriptions["operate"] != descriptions["foundry_ops_dashboard"]
 
     html = render_cockpit_html(payload)
-    # Subheaders render.
+    # Subheaders render (only the two remaining groups).
     assert ">Configured agent<" in html
     assert ">Foundry project<" in html
-    assert ">Azure Monitor<" in html
     # The legacy flat ``targets`` key is kept for backwards-compat and
     # combines both groups in display order.
     flat_keys = [t["key"] for t in open_panel["targets"]]
@@ -893,7 +921,10 @@ def test_production_section_links_to_foundry_monitor_first(tmp_path: Path, monke
     html = render_cockpit_html(payload)
 
     assert "Full view in Foundry Monitor" in html
-    assert "Open App Insights KQL" in html
+    # The duplicated "Open App Insights KQL" CTA was removed from the
+    # Production signal section; the App Insights portal URL now lives only
+    # in the launchpad "App Insights" tile and the Doctor / Eval gate links.
+    assert "Open App Insights KQL" not in html
     # The Foundry Monitor link is styled as the primary section CTA.
     assert "section-link-primary" in html
 

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,0 +1,269 @@
+"""Unit tests for the Foundry operations dashboard service.
+
+These cover the pure, Azure-free surface of
+:mod:`agentops.services.dashboard`: template loading, the portal URL builder
+(deployed vs. gallery fallback), the diagnostic-settings helpers, the ARM
+template shape, and the RBAC preflight messaging with the authorization
+helpers mocked.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentops.services import dashboard as dash
+
+
+# ---------------------------------------------------------------------------
+# Template loading
+# ---------------------------------------------------------------------------
+def test_load_workbook_template_returns_valid_json() -> None:
+    raw = dash.load_workbook_template()
+    assert isinstance(raw, str) and raw.strip()
+    parsed = json.loads(raw)
+    # The packaged asset is a gallery-template workbook.
+    assert isinstance(parsed, dict)
+
+
+def test_load_workbook_content_matches_template() -> None:
+    assert dash.load_workbook_content() == json.loads(dash.load_workbook_template())
+
+
+# ---------------------------------------------------------------------------
+# Portal URL
+# ---------------------------------------------------------------------------
+def test_make_workbook_resource_id_is_deterministic() -> None:
+    a = dash.make_workbook_resource_id("sub", "rg", "AgentOps Foundry operations")
+    b = dash.make_workbook_resource_id("sub", "rg", "AgentOps Foundry operations")
+    assert a == b
+    assert a.startswith("/subscriptions/sub/resourceGroups/rg/providers/")
+    assert dash.WORKBOOK_RESOURCE_TYPE in a
+
+
+def test_portal_url_deployed_when_target_known() -> None:
+    url = dash.build_workbook_portal_url(
+        subscription_id="sub",
+        resource_group="rg",
+        name="AgentOps Foundry operations",
+        tenant_id="tenant-123",
+    )
+    assert url.startswith("https://portal.azure.com/#@tenant-123/resource")
+    assert url.endswith("/workbook")
+
+
+def test_portal_url_deployed_without_tenant() -> None:
+    url = dash.build_workbook_portal_url(
+        subscription_id="sub", resource_group="rg", name="wb"
+    )
+    assert url.startswith("https://portal.azure.com/#/resource")
+    assert "@" not in url.split("/resource", 1)[0]
+
+
+def test_portal_url_falls_back_to_gallery_when_target_unknown() -> None:
+    url = dash.build_workbook_portal_url()
+    assert "WorkbookMenuBlade" in url
+    assert url.endswith("/gallery")
+
+
+def test_portal_url_prefers_explicit_resource_id() -> None:
+    rid = "/subscriptions/s/resourceGroups/g/providers/x/y/z"
+    url = dash.build_workbook_portal_url(workbook_resource_id=rid, tenant_id="t")
+    assert url == f"https://portal.azure.com/#@t/resource{rid}/workbook"
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic settings
+# ---------------------------------------------------------------------------
+def test_missing_diagnostic_categories_none_when_all_present() -> None:
+    assert (
+        dash.missing_diagnostic_categories(
+            ["RequestResponse", "AzureOpenAIRequestUsage", "Audit"]
+        )
+        == []
+    )
+
+
+def test_missing_diagnostic_categories_reports_absent() -> None:
+    assert dash.missing_diagnostic_categories(["RequestResponse"]) == [
+        "AzureOpenAIRequestUsage"
+    ]
+    assert dash.missing_diagnostic_categories([]) == list(
+        dash.REQUIRED_DIAGNOSTIC_CATEGORIES
+    )
+
+
+def test_build_diagnostic_settings_command_shape() -> None:
+    cmd = dash.build_diagnostic_settings_command(
+        aoai_resource_id="/subscriptions/s/aoai",
+        workspace_id="/subscriptions/s/ws",
+    )
+    assert cmd.startswith("az monitor diagnostic-settings create ")
+    assert "--resource /subscriptions/s/aoai" in cmd
+    assert "--workspace /subscriptions/s/ws" in cmd
+    assert "RequestResponse" in cmd and "AzureOpenAIRequestUsage" in cmd
+
+
+def test_build_diagnostic_settings_command_uses_placeholders() -> None:
+    cmd = dash.build_diagnostic_settings_command(
+        aoai_resource_id=None, workspace_id=None
+    )
+    assert "<azure-openai-resource-id>" in cmd
+    assert "<log-analytics-workspace-id>" in cmd
+
+
+# ---------------------------------------------------------------------------
+# ARM template
+# ---------------------------------------------------------------------------
+def test_build_arm_template_shape() -> None:
+    target = dash.DashboardTarget(
+        name="AgentOps Foundry operations",
+        subscription_id="sub",
+        resource_group="rg",
+        workspace_id="/subscriptions/sub/ws",
+    )
+    template = dash.build_arm_template(target=target)
+    assert template["$schema"].startswith("https://schema.management.azure.com")
+    assert len(template["resources"]) == 1
+    resource = template["resources"][0]
+    assert resource["type"] == dash.WORKBOOK_RESOURCE_TYPE
+    assert resource["properties"]["displayName"] == "AgentOps Foundry operations"
+    # serializedData is the workbook content re-serialized as a string.
+    assert json.loads(resource["properties"]["serializedData"]) == (
+        dash.load_workbook_content()
+    )
+    assert resource["properties"]["sourceId"] == "/subscriptions/sub/ws"
+
+
+def test_build_arm_template_name_matches_resource_id() -> None:
+    target = dash.DashboardTarget(name="wb", subscription_id="sub", resource_group="rg")
+    template = dash.build_arm_template(target=target)
+    rid = dash.make_workbook_resource_id("sub", "rg", "wb")
+    assert template["resources"][0]["name"] == rid.rsplit("/", 1)[-1]
+
+
+# ---------------------------------------------------------------------------
+# RBAC preflight
+# ---------------------------------------------------------------------------
+def test_check_rbac_errors_without_subscription() -> None:
+    result = dash.check_rbac(
+        subscription_id=None, resource_group="rg", workspace_id=None
+    )
+    assert result.ok is False
+    assert result.level == "error"
+    assert any("subscription" in m.lower() for m in result.messages)
+
+
+def _patch_rbac(monkeypatch, *, rg_roles, ws_roles=None, raise_error=None):
+    """Install fakes for the lazy-imported authorization helpers."""
+    import agentops.agent.checks._rbac_authorization as rbac_mod
+
+    class _AuthErr(Exception):
+        pass
+
+    monkeypatch.setattr(rbac_mod, "AuthorizationCheckError", _AuthErr)
+    monkeypatch.setattr(
+        rbac_mod, "resolve_signed_in_principal_object_id", lambda: "principal-oid"
+    )
+
+    def _list(*, subscription_id, scope, principal_object_id):
+        if raise_error is not None:
+            raise _AuthErr(raise_error)
+        if scope.endswith("/resourceGroups/rg"):
+            return list(rg_roles)
+        return list(ws_roles or [])
+
+    monkeypatch.setattr(rbac_mod, "list_principal_role_definition_ids", _list)
+    return _AuthErr
+
+
+def test_check_rbac_passes_when_roles_present(monkeypatch) -> None:
+    _patch_rbac(
+        monkeypatch,
+        rg_roles=[dash._ROLE_WORKBOOK_CONTRIBUTOR],
+        ws_roles=[dash._ROLE_LOG_ANALYTICS_READER],
+    )
+    result = dash.check_rbac(
+        subscription_id="sub",
+        resource_group="rg",
+        workspace_id="/subscriptions/sub/ws",
+    )
+    assert result.ok is True
+    assert result.level == "ok"
+    assert any("passed" in m.lower() for m in result.messages)
+
+
+def test_check_rbac_fails_when_workbook_role_missing(monkeypatch) -> None:
+    _patch_rbac(monkeypatch, rg_roles=[dash._ROLE_READER], ws_roles=[])
+    result = dash.check_rbac(
+        subscription_id="sub", resource_group="rg", workspace_id=None
+    )
+    assert result.ok is False
+    assert result.level == "error"
+    joined = " ".join(result.messages)
+    assert "Workbook Contributor" in joined
+    assert "'rg'" in joined
+    assert "--dry-run" in joined
+
+
+def test_check_rbac_fails_when_workspace_role_missing(monkeypatch) -> None:
+    _patch_rbac(
+        monkeypatch,
+        rg_roles=[dash._ROLE_WORKBOOK_CONTRIBUTOR],
+        ws_roles=[dash._ROLE_READER.replace("a", "z")],  # unrelated role guid
+    )
+    result = dash.check_rbac(
+        subscription_id="sub",
+        resource_group="rg",
+        workspace_id="/subscriptions/sub/ws",
+    )
+    assert result.ok is False
+    assert any("Log Analytics Reader" in m for m in result.messages)
+
+
+def test_check_rbac_fails_open_on_authorization_error(monkeypatch) -> None:
+    _patch_rbac(monkeypatch, rg_roles=[], raise_error="listing denied")
+    result = dash.check_rbac(
+        subscription_id="sub", resource_group="rg", workspace_id=None
+    )
+    # Fails OPEN: warn but allow deploy to proceed.
+    assert result.ok is True
+    assert result.level == "warn"
+    assert any("listing denied" in m for m in result.messages)
+
+
+def test_check_rbac_fails_open_when_helpers_unavailable(monkeypatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked(name, *args, **kwargs):
+        if name == "agentops.agent.checks._rbac_authorization":
+            raise ImportError("no authorization helpers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked)
+    result = dash.check_rbac(
+        subscription_id="sub", resource_group="rg", workspace_id=None
+    )
+    assert result.ok is True
+    assert result.level == "warn"
+
+
+# ---------------------------------------------------------------------------
+# deploy_workbook guards (no live Azure)
+# ---------------------------------------------------------------------------
+def test_deploy_workbook_requires_subscription() -> None:
+    target = dash.DashboardTarget(name="wb")
+    with pytest.raises(dash.DashboardError) as exc:
+        dash.deploy_workbook(target=target)
+    assert "subscription" in str(exc.value).lower()
+
+
+def test_deploy_workbook_errors_when_az_missing(monkeypatch) -> None:
+    monkeypatch.setattr(dash, "_az_executable", lambda: None)
+    target = dash.DashboardTarget(name="wb", subscription_id="sub", resource_group="rg")
+    with pytest.raises(dash.DashboardError) as exc:
+        dash.deploy_workbook(target=target)
+    assert "az" in str(exc.value).lower()


### PR DESCRIPTION
## What and why

Implements #343: a Foundry / Azure OpenAI **operations dashboard** plus a cockpit redesign so operators can answer "can I ship?" and "how is it running?" without hand-building portal queries.

## Scope

### Part 1 — Foundry operations dashboard + CLI
- **Azure Monitor Workbook** (`src/agentops/templates/workbooks/foundry-ops.workbook.json`) with four sections: Capacity (PTU avg/max %, rate-limit, spillover), Traffic and tokens, Latency (TTFT/TBT/TTLT/tokens-per-sec, P95/P99/Avg/Max), Errors and throttling (429/400/500, throttling %, error %). Parameterized by subscription, Log Analytics workspace, Azure OpenAI resource, deployment, model, time range, and streaming filter. Includes the requested scope/`PTU_Normalizado` explainer text tile.
- **Per-metric KQL** under `queries/` (`capacity_ptu_spillover`, `traffic_tokens`, `latency_percentiles`, `errors_throttling`) drawn from `AzureMetrics` / `AzureDiagnostics` (parsing `properties_s`), plus a `README.md` index + authoring note.
- **New CLI sub-app** `agentops telemetry dashboard`:
  - `deploy` — discovers target from `agentops.yaml`, RBAC preflight (Workbook Contributor on RG, Log Analytics Reader on workspace) with a friendly, role-and-scope-named failure, diagnostic-settings preflight (warns + prints the exact `az monitor diagnostic-settings create`), then deploys the `Microsoft.Insights/workbooks` ARM resource and prints the portal URL. `--dry-run` emits the ARM template only. This is the CLI's first Azure-resource-creating command; it is intentionally narrow (single workbook).
  - `open` — builds the portal deep link and opens the browser, mirroring cockpit's flow with a `--print-url` / non-TTY fallback.
  - `export` — copies the packaged workbook JSON to `--out`.
  - Azure logic lives in a thin `src/agentops/services/dashboard.py`; the sub-app is wired into the existing explain-page pattern (`telemetry dashboard explain`).
- **Doctor rule** `waf.observability.aoai_diagnostic_categories` — warns when `RequestResponse` / `AzureOpenAIRequestUsage` categories aren't emitted to a workspace, prints the exact `az` fix. Doctor stays read-only.

### Part 2 — Cockpit redesign (`src/agentops/agent/cockpit.py`)
- Top: three consolidated clickable status cards (Readiness, Doctor, Eval gate) that expand their detail section on click.
- "Next actions" promoted to second position.
- Detail sections collapsed by default; the former "Eval gate summary" and "Quality gate summary" merged into one **Eval gates** section with two subgroups; duplicated App Insights CTA removed from Production signal.
- Footer launchpad: new **Foundry operations dashboard** tile (same portal URL as `telemetry dashboard open`) next to a reworded "Operate overview"; the single-tile "Azure Monitor" group folded into the Foundry project group. Flat `targets` back-compat list and tile-ordering tests updated. Cockpit remains a read-only deep-linker.

## Test evidence
- `pytest tests/unit` → **1083 passed, 1 skipped**.
- New/updated tests: `test_dashboard.py`, `test_cli_dashboard.py` (open/export/`deploy --dry-run` exit codes + `--help`), AOAI-rule tests in `test_agent_posture_rules.py`, doctor catalog invariant, and cockpit reorder/grouping assertions.
- `ruff check` clean on all changed files; new files `ruff format`-clean; `mypy` clean on the new source modules.
- `CHANGELOG.md` (Unreleased) and `AGENTS.md` command list updated.

## Known constraint (needs attention before production)
The workbook JSON was authored from the issue's KQL and the `Microsoft.Insights/workbooks` schema **without a live Azure environment**. It should be smoke-validated against a real Log Analytics workspace (confirm each tile renders and the parameters bind) before it is relied upon in production / GA. This caveat is also noted in the workbook README.

Closes #343
