### PR TITLE
fix(dashboard): deploy workbook to resource group region, not global

### DIFF
--- a/src/agentops/services/dashboard.py
+++ b/src/agentops/services/dashboard.py
@@ -85,7 +85,7 @@ class DashboardTarget:
     aoai_resource_id: Optional[str] = None
     aoai_account_name: Optional[str] = None
     tenant_id: Optional[str] = None
-    location: str = "global"
+    location: Optional[str] = None
     discovery: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -401,7 +401,10 @@ def build_arm_template(
         "type": WORKBOOK_RESOURCE_TYPE,
         "apiVersion": "2022-04-01",
         "name": guid,
-        "location": target.location,
+        # Workbooks reject "global"; resolve to the target region at deploy
+        # time. The RG-scoped deployment always has a valid location, and an
+        # explicit target.location (a real Azure region) still wins when set.
+        "location": target.location or "[resourceGroup().location]",
         "kind": "shared",
         "properties": {
             "displayName": target.name,

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -136,6 +136,21 @@ def test_build_arm_template_shape() -> None:
     assert resource["properties"]["sourceId"] == "/subscriptions/sub/ws"
 
 
+def test_build_arm_template_location_defaults_to_resource_group_expression() -> None:
+    # Workbooks reject "global"; the template must resolve to the RG region.
+    target = dash.DashboardTarget(name="wb", subscription_id="sub", resource_group="rg")
+    template = dash.build_arm_template(target=target)
+    assert template["resources"][0]["location"] == "[resourceGroup().location]"
+
+
+def test_build_arm_template_location_honors_explicit_region() -> None:
+    target = dash.DashboardTarget(
+        name="wb", subscription_id="sub", resource_group="rg", location="eastus2"
+    )
+    template = dash.build_arm_template(target=target)
+    assert template["resources"][0]["location"] == "eastus2"
+
+
 def test_build_arm_template_name_matches_resource_id() -> None:
     target = dash.DashboardTarget(name="wb", subscription_id="sub", resource_group="rg")
     template = dash.build_arm_template(target=target)


### PR DESCRIPTION
## Problem

`agentops telemetry dashboard deploy` (shipped in v0.7.0) fails for every user. The generated ARM template set the workbook `location` to `"global"`, but `Microsoft.Insights/workbooks` does not accept `global` and Azure returns `LocationNotAvailableForResourceType`. The workbook never deploys.

## Fix

Default the workbook `location` to the ARM expression `[resourceGroup().location]`. The deploy is resource-group scoped (`az deployment group create`), so this always resolves to a valid region. An explicit `--region`/`location` override is still honored.

## Live validation

Deployed against a real subscription and resource group:

- Before: deploy failed with `LocationNotAvailableForResourceType`.
- After: `Workbook deployed.` The `Microsoft.Insights/workbooks` resource is created and reports `location: eastus2` (the RG region).
- RBAC preflight still degrades gracefully when `azure-mgmt-authorization` is absent, and the diagnostic-settings hint still prints the exact `az` command.

## Tests

Added two regression tests in `tests/unit/test_dashboard.py`:
- location defaults to `[resourceGroup().location]` when not specified
- an explicit region is honored

All 23 dashboard tests pass.

Fixes the deploy bug found in live validation of the v0.7.0 dashboard feature.
