### PR TITLE
Fix release mypy gate

### DIFF
--- a/src/agentops/core/agentops_config.py
+++ b/src/agentops/core/agentops_config.py
@@ -937,7 +937,6 @@ class AgentOpsConfig(BaseModel):
     protocol: Optional[Protocol] = None
     request_field: Optional[str] = None
     response_field: Optional[str] = None
-    response_fields: Dict[str, str] = Field(default_factory=dict)
     tool_calls_field: Optional[str] = None
     response_fields: Dict[str, str] = Field(
         default_factory=dict,

--- a/src/agentops/services/azd_eval_init.py
+++ b/src/agentops/services/azd_eval_init.py
@@ -831,6 +831,7 @@ def _azd_evaluator_selection_from_config(
     data = load_yaml(config_path)
     raw_evaluators = data.get("evaluators")
     names: list[str] = []
+    signals: list[str]
     if isinstance(raw_evaluators, list):
         for item in raw_evaluators:
             raw_name = item.get("name") if isinstance(item, dict) else item
@@ -841,7 +842,7 @@ def _azd_evaluator_selection_from_config(
             if mapped and mapped not in names:
                 names.append(mapped)
         selection_source = "explicit agentops.yaml evaluators"
-        signals = ("Using explicit evaluators from agentops.yaml.",)
+        signals = ["Using explicit evaluators from agentops.yaml."]
     else:
         selection_source = "AgentOps recommendation"
         signals = []
@@ -861,10 +862,10 @@ def _azd_evaluator_selection_from_config(
                     names.append(mapped)
         except (FileNotFoundError, OSError, ValueError) as exc:
             selection_source = "baseline fallback"
-            signals = (
+            signals = [
                 f"Could not inspect dataset for evaluator inference: {exc}",
                 "Using baseline evaluators only.",
-            )
+            ]
         if not names:
             names.extend(_DEFAULT_AZD_EVALUATORS)
     raw_rubrics = data.get("rubrics")


### PR DESCRIPTION
## Summary
- remove the duplicate `response_fields` Pydantic field declaration
- keep inferred evaluator signals mutable until conversion to the public tuple result
- preserve existing runtime behavior while restoring the release type-check gate

## Validation
- `uv run mypy src/agentops/ --ignore-missing-imports`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/unit/test_agentops_config.py tests/unit/test_azd_eval_init.py tests/unit/test_http_response_fields.py tests/unit/test_http_streaming.py tests/unit/test_runtime_response_fields.py -q` (99 passed)