### PR TITLE
fix(doctor): stop three readiness probes leaking non-fatal errors to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+- **`agentops doctor` no longer prints noisy non-fatal errors to the console.**
+  Three low-level probes that already degrade gracefully were leaking their
+  transport errors to the screen during readiness checks:
+  - The **LLM judge** called the Foundry project OpenAI client on the legacy
+    `/openai/` route, which returns HTTP 404 for chat completions, printing
+    `WARNING: llm_assist: judge call failed: Error code: 404`. The client is now
+    normalized to the stable `/openai/v1/` route (with the injected
+    `api-version` query parameter cleared) using the same reused credential and
+    token refresh, so the judge runs instead of 404ing. Non-Foundry endpoints
+    are left untouched.
+  - The **OpenAI data-plane RBAC check** built an ARM role-assignment filter
+    (`atScopeAndAbove() and assignedTo('<oid>')`) that ARM rejects with
+    `UnsupportedQuery`. It now sends the supported `assignedTo('<oid>')` filter,
+    which already returns assignments at the target scope and every ancestor
+    scope, so the check runs instead of skipping with a console error.
+  - The **Application Insights** REST probe caught only `urllib.error.URLError`,
+    so a read timeout (a `socket.timeout`, which is an `OSError` but not a
+    `URLError`) escaped and surfaced
+    `INFO: Rate-limit App Insights probe failed (non-fatal): The read operation
+    timed out`. It now catches `OSError` (covering both) and the request timeout
+    was raised from 10s to 30s, so a slow App Insights degrades quietly.
+
 ## [0.8.0] - 2026-07-14
 
 ### Added

--- a/src/agentops/agent/checks/_rbac_authorization.py
+++ b/src/agentops/agent/checks/_rbac_authorization.py
@@ -60,8 +60,13 @@ def list_principal_role_definition_ids(
     """List role definition GUIDs assigned to the principal at/above scope.
 
     Uses ``RoleAssignmentsOperations.list_for_scope`` with the
-    ``atScopeAndAbove() and assignedTo('<oid>')`` filter so management-plane
-    inheritance (subscription, resource group, account) is honoured.
+    ``assignedTo('<oid>')`` filter. That filter already returns assignments at
+    the given scope and every ancestor scope (subscription, resource group,
+    account), including those inherited through group membership, so
+    management-plane inheritance is honoured. The ARM RBAC API rejects the
+    combined ``atScopeAndAbove() and assignedTo(...)`` form
+    (``UnsupportedQuery``); ``assignedTo(...)`` on its own is the supported
+    equivalent.
     """
     try:
         from azure.mgmt.authorization import AuthorizationManagementClient
@@ -95,9 +100,7 @@ def list_principal_role_definition_ids(
         assignments = list(
             client.role_assignments.list_for_scope(
                 scope=scope,
-                filter=(
-                    f"atScopeAndAbove() and assignedTo('{principal_object_id}')"
-                ),
+                filter=f"assignedTo('{principal_object_id}')",
             )
         )
     except Exception as exc:  # noqa: BLE001

--- a/src/agentops/agent/llm_assist/_client.py
+++ b/src/agentops/agent/llm_assist/_client.py
@@ -39,6 +39,51 @@ class JudgementMeta:
     model_deployment: Optional[str] = None
 
 
+def _normalize_foundry_openai_client(client: Any) -> Any:
+    """Point a Foundry project OpenAI client at the ``/openai/v1/`` route.
+
+    ``AIProjectClient.get_openai_client()`` returns a client whose
+    ``base_url`` ends in ``/openai/`` and which injects an ``api-version``
+    query parameter. On that legacy route Foundry chat completions return
+    HTTP 404. The stable surface is the OpenAI v1 route (``/openai/v1/``)
+    served *without* an ``api-version`` parameter.
+
+    We rewrite the client in place with the public ``with_options`` API so
+    the reused credential and its token refresh keep working (no second
+    credential, no endpoint string-munging). The client is returned
+    unchanged when its ``base_url`` is not the recognised Foundry project
+    shape, so custom or already-normalised endpoints are left untouched.
+    """
+    try:
+        base_url = str(getattr(client, "base_url", "") or "")
+    except Exception:  # pragma: no cover - defensive
+        return client
+    if not base_url:
+        return client
+
+    normalized = base_url if base_url.endswith("/") else base_url + "/"
+    if normalized.endswith("/openai/v1/"):
+        # Already on the v1 surface; only ensure api-version is dropped.
+        pass
+    elif normalized.endswith("/openai/"):
+        normalized = normalized + "v1/"
+    else:
+        # Unknown shape (non-Foundry route). Leave routing untouched.
+        return client
+
+    with_options = getattr(client, "with_options", None)
+    if with_options is None:  # pragma: no cover - defensive
+        return client
+    try:
+        return with_options(
+            base_url=normalized,
+            default_query={"api-version": None},
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        log.info("llm_assist: could not normalize OpenAI route: %s", exc)
+        return client
+
+
 class LLMJudge:
     """Thin wrapper around the Foundry project's OpenAI client."""
 
@@ -230,6 +275,7 @@ class LLMJudge:
         if not endpoint:
             log.info("llm_assist: project endpoint not configured")
             return None
+
         try:
             from azure.ai.projects import AIProjectClient  # type: ignore
             from azure.identity import DefaultAzureCredential  # type: ignore
@@ -240,7 +286,9 @@ class LLMJudge:
         try:
             project_client = AIProjectClient(
                 endpoint=endpoint,
-                credential=DefaultAzureCredential(exclude_developer_cli_credential=True, process_timeout=30),
+                credential=DefaultAzureCredential(
+                    exclude_developer_cli_credential=True, process_timeout=30
+                ),
             )
             # Foundry exposes get_openai_client without an api_version arg;
             # never pass one (the SDK picks the right version).
@@ -251,7 +299,7 @@ class LLMJudge:
             if get_openai_client is None:
                 log.info("llm_assist: AIProjectClient has no OpenAI client helper")
                 return None
-            self._client = get_openai_client()
+            self._client = _normalize_foundry_openai_client(get_openai_client())
         except Exception as exc:  # pragma: no cover
             log.warning("llm_assist: openai client init failed: %s", exc)
             return None

--- a/src/agentops/agent/sources/azure_monitor.py
+++ b/src/agentops/agent/sources/azure_monitor.py
@@ -13,7 +13,7 @@ import os
 import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
-from urllib import error, request
+from urllib import request
 
 from agentops.agent.config import AzureMonitorSourceConfig
 
@@ -504,9 +504,13 @@ def _query_application_insights(
         method="POST",
     )
     try:
-        with request.urlopen(req, timeout=10) as resp:  # noqa: S310
+        with request.urlopen(req, timeout=30) as resp:  # noqa: S310
             parsed = json.loads(resp.read())
-    except (error.URLError, ValueError, KeyError) as exc:
+    except (OSError, ValueError, KeyError) as exc:
+        # OSError covers urllib.error.URLError *and* socket.timeout /
+        # TimeoutError. A read timeout is not a URLError, so catching only
+        # URLError here would let it propagate to the caller and surface a
+        # noisy non-fatal INFO line on the console. Degrade quietly instead.
         log.debug("App Insights REST query failed: %s", exc)
         return None
 

--- a/tests/unit/test_agent_checks_rbac_openai_data_plane.py
+++ b/tests/unit/test_agent_checks_rbac_openai_data_plane.py
@@ -310,8 +310,12 @@ def test_list_role_definition_ids_extracts_guid_suffix() -> None:
     role_assignments.list_for_scope.assert_called_once()
     kwargs = role_assignments.list_for_scope.call_args.kwargs
     assert kwargs["scope"] == _ACCOUNT_TARGET
-    assert _PRINCIPAL_OID in kwargs["filter"]
-    assert "atScopeAndAbove" in kwargs["filter"]
+    # The ARM RBAC API rejects the combined
+    # ``atScopeAndAbove() and assignedTo(...)`` filter with UnsupportedQuery.
+    # ``assignedTo(...)`` alone is the supported equivalent and already
+    # returns assignments at scope and every ancestor scope.
+    assert kwargs["filter"] == f"assignedTo('{_PRINCIPAL_OID}')"
+    assert "atScopeAndAbove" not in kwargs["filter"]
 
 
 def test_list_role_definition_ids_raises_when_sdk_missing() -> None:

--- a/tests/unit/test_llm_assist.py
+++ b/tests/unit/test_llm_assist.py
@@ -481,3 +481,85 @@ def test_judge_falls_back_to_inference_get_openai_client(
     judge = LLMJudge(config=_enabled_config(), workspace=tmp_path)
 
     assert judge._get_client() == "legacy-openai-client"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_foundry_openai_client -- Foundry /openai/v1/ route fix
+# ---------------------------------------------------------------------------
+
+
+class _FakeOpenAIClient:
+    """Minimal stand-in exposing ``base_url`` and ``with_options``."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url
+        self.with_options_kwargs: Optional[Dict[str, Any]] = None
+
+    def with_options(self, **kwargs: Any) -> "_FakeOpenAIClient":
+        self.with_options_kwargs = kwargs
+        new = _FakeOpenAIClient(kwargs.get("base_url", self.base_url))
+        new.with_options_kwargs = kwargs
+        return new
+
+
+def test_normalize_rewrites_openai_route_to_v1_and_drops_api_version() -> None:
+    from agentops.agent.llm_assist._client import (
+        _normalize_foundry_openai_client,
+    )
+
+    client = _FakeOpenAIClient(
+        "https://acct.services.ai.azure.com/api/projects/p/openai/"
+    )
+    normalized = _normalize_foundry_openai_client(client)
+
+    assert normalized.with_options_kwargs is not None
+    assert (
+        normalized.with_options_kwargs["base_url"]
+        == "https://acct.services.ai.azure.com/api/projects/p/openai/v1/"
+    )
+    # The injected ``api-version`` query param must be cleared, otherwise the
+    # Foundry v1 route returns HTTP 404.
+    assert normalized.with_options_kwargs["default_query"] == {
+        "api-version": None
+    }
+
+
+def test_normalize_leaves_v1_route_but_still_drops_api_version() -> None:
+    from agentops.agent.llm_assist._client import (
+        _normalize_foundry_openai_client,
+    )
+
+    client = _FakeOpenAIClient(
+        "https://acct.services.ai.azure.com/api/projects/p/openai/v1/"
+    )
+    normalized = _normalize_foundry_openai_client(client)
+
+    assert (
+        normalized.with_options_kwargs["base_url"]
+        == "https://acct.services.ai.azure.com/api/projects/p/openai/v1/"
+    )
+    assert normalized.with_options_kwargs["default_query"] == {
+        "api-version": None
+    }
+
+
+def test_normalize_leaves_unknown_route_untouched() -> None:
+    from agentops.agent.llm_assist._client import (
+        _normalize_foundry_openai_client,
+    )
+
+    client = _FakeOpenAIClient("https://custom.example.com/v1/")
+    normalized = _normalize_foundry_openai_client(client)
+
+    # Non-Foundry routes are returned as-is; with_options is never called.
+    assert normalized is client
+    assert client.with_options_kwargs is None
+
+
+def test_normalize_ignores_client_without_base_url() -> None:
+    from agentops.agent.llm_assist._client import (
+        _normalize_foundry_openai_client,
+    )
+
+    sentinel = object()
+    assert _normalize_foundry_openai_client(sentinel) is sentinel

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -708,6 +708,46 @@ def test_azure_monitor_skipped_when_connection_string_lacks_application_id(
     assert payload.diagnostics["discovery_reason"]
 
 
+def test_query_application_insights_returns_none_on_read_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A read timeout must degrade quietly, not raise.
+
+    ``socket.timeout`` (aka ``TimeoutError``) is an ``OSError`` but NOT a
+    ``urllib.error.URLError``, so the previous narrow ``except URLError``
+    let it escape and surface a noisy non-fatal INFO line on the console.
+    The fix catches ``OSError`` and returns ``None``.
+    """
+    import socket
+
+    def _raise_timeout(*_args, **_kwargs):
+        raise socket.timeout("The read operation timed out")
+
+    monkeypatch.setattr(azure_monitor.request, "urlopen", _raise_timeout)
+
+    assert (
+        azure_monitor._query_application_insights("app-id", "bearer", "kql")
+        is None
+    )
+
+
+def test_query_application_insights_returns_none_on_urlerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transport failures (URLError) also degrade quietly to None."""
+    from urllib.error import URLError
+
+    def _raise_urlerror(*_args, **_kwargs):
+        raise URLError("connection refused")
+
+    monkeypatch.setattr(azure_monitor.request, "urlopen", _raise_urlerror)
+
+    assert (
+        azure_monitor._query_application_insights("app-id", "bearer", "kql")
+        is None
+    )
+
+
 def _app_insights_result(row: dict[str, object]) -> dict[str, object]:
     return {
         "tables": [


### PR DESCRIPTION
## What

`agentops doctor` was leaking three low-level, non-fatal probe errors straight to the console during readiness checks. Each probe already degrades gracefully; only the *reporting* was noisy. This stops all three from printing.

### 1. LLM judge -> HTTP 404
`WARNING: llm_assist: judge call failed: Error code: 404`

The judge used the Foundry project OpenAI client on the legacy `/openai/` route, which returns 404 for chat completions. The client is now normalized to the stable `/openai/v1/` route (clearing the injected `api-version` query param) via `client.with_options(...)`, reusing the **same** credential and token refresh. Non-Foundry endpoints are returned unchanged. The judge now runs instead of 404ing.

### 2. OpenAI data-plane RBAC check -> UnsupportedQuery
`(UnsupportedQuery) The filter 'atScopeAndAbove() and assignedTo(...)' is not supported.`

The check built a combined ARM role-assignment filter that ARM rejects. It now sends the supported `assignedTo('<oid>')` filter, which already returns assignments at the target scope **and** every ancestor scope. The check runs instead of skipping with a console error.

### 3. App Insights probe -> read timeout
`INFO: Rate-limit App Insights probe failed (non-fatal): The read operation timed out`

`_query_application_insights` caught only `urllib.error.URLError`, so a read timeout (`socket.timeout`, an `OSError` but **not** a `URLError`) escaped and printed. It now catches `OSError` (covering both) and the request timeout was raised from 10s to 30s. Slow App Insights degrades quietly.

## Tests

- New coverage for the OpenAI client normalization (`_normalize_foundry_openai_client`), the corrected RBAC filter, and the App Insights timeout/URLError degrade-to-None path.
- Full suite: `1101 passed, 1 skipped`.

## Notes

- Bug fix, no linked issue required (per CONTRIBUTING).
- Targets `develop`.
- CHANGELOG updated under `## [Unreleased]`.
